### PR TITLE
Explicitly set units in LAK package in the Prudic example 

### DIFF
--- a/notebooks/ex-gwt-prudic2004t2.ipynb
+++ b/notebooks/ex-gwt-prudic2004t2.ipynb
@@ -419,6 +419,7 @@
     "    flopy.mf6.ModflowGwflak(\n",
     "        gwf,\n",
     "        time_conversion=86400.000,\n",
+    "        length_conversion=3.28081,\n",
     "        print_stage=True,\n",
     "        print_flows=True,\n",
     "        stage_filerecord=name + \".lak.bin\",\n",

--- a/scripts/ex-gwt-prudic2004t2.py
+++ b/scripts/ex-gwt-prudic2004t2.py
@@ -256,6 +256,7 @@ def build_mf6gwf(sim_folder):
     flopy.mf6.ModflowGwflak(
         gwf,
         time_conversion=86400.000,
+        length_conversion=3.28081,
         print_stage=True,
         print_flows=True,
         stage_filerecord=name + ".lak.bin",


### PR DESCRIPTION
Fix accompanies [1058](https://github.com/MODFLOW-USGS/modflow6/pull/1058) in the [main MF6 repo](https://github.com/MODFLOW-USGS/modflow6), which was initiated by [1053](https://github.com/MODFLOW-USGS/modflow6/issues/1053).