### PR TITLE
fix(pandas): replace deprecated DataFrame.iteritems() with items

### DIFF
--- a/notebooks/ex-gwf-csub-p03.ipynb
+++ b/notebooks/ex-gwf-csub-p03.ipynb
@@ -1266,7 +1266,7 @@
     "    df_out = pd.DataFrame(index=new_index)\n",
     "    df_out.index.name = df_in.index.name\n",
     "\n",
-    "    for colname, col in df_in.iteritems():\n",
+    "    for colname, col in df_in.items():\n",
     "        df_out[colname] = np.interp(new_index, df_in.index, col)\n",
     "\n",
     "    return df_out"
@@ -2382,6 +2382,9 @@
    "cell_metadata_filter": "-all",
    "main_language": "python",
    "notebook_metadata_filter": "-all"
+  },
+  "language_info": {
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/scripts/ex-gwf-csub-p03.py
+++ b/scripts/ex-gwf-csub-p03.py
@@ -868,7 +868,7 @@ def dataframe_interp(df_in, new_index):
     df_out = pd.DataFrame(index=new_index)
     df_out.index.name = df_in.index.name
 
-    for colname, col in df_in.iteritems():
+    for colname, col in df_in.items():
         df_out[colname] = np.interp(new_index, df_in.index, col)
 
     return df_out


### PR DESCRIPTION
[Pandas 2.0 deprecated the `iteritems()` method](https://pandas.pydata.org/pandas-docs/version/2.0/whatsnew/v2.0.0.html) on `DataFrame` and `Series`. This caused [failures in the modflow6 nightly build](https://github.com/MODFLOW-USGS/modflow6-nightly-build/actions/runs/4614280087/jobs/8157087073#step:10:336). Replace usages with the equivalent `items()`.