### PR TITLE
refactor(config): require exes on path, don't hardcode locn

### DIFF
--- a/.doc/requirements.rtd.txt
+++ b/.doc/requirements.rtd.txt
@@ -2,6 +2,8 @@ nbsphinx
 nbsphinx_link
 ipython
 ipykernel
+recommonmark
 rtds_action
 sphinx_markdown_tables
+sphinx-rtd-theme
 pygments>=2.4.1

--- a/.github/workflows/ex-rtd.yml
+++ b/.github/workflows/ex-rtd.yml
@@ -4,12 +4,12 @@ on:
   schedule:
     - cron: '0 2 * * *' # run at 2 AM UTC
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
     paths-ignore:
       - 'README.md'
       - 'DEVELOPER.md'
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
 
 jobs:
   rtd_build:
@@ -23,9 +23,8 @@ jobs:
     defaults:
       run:
         shell: bash
-
-    if: github.repository_owner == 'MODFLOW-USGS'
     steps:
+
       - name: Checkout MODFLOW6 examples repo
         uses: actions/checkout@v3
 
@@ -76,36 +75,29 @@ jobs:
           repo: modflow6-nightly-build
 
       - name: Run scripts without model runs
-        run: |
-          pytest -v -n=auto --durations=0 ci_build_files.py
+        run: pytest -v -n=auto --durations=0 ci_build_files.py
         working-directory: ${{env.etc-directory}}
 
       - name: Run processing script
-        run: |
-          python process-scripts.py
+        run: python process-scripts.py
         working-directory: ${{env.script-directory}}
 
       - name: Run notebooks with jupytext for ReadtheDocs
-        run: |
-          pytest -v -n=auto --durations=0 ci_run_notebooks.py
+        run: pytest -v -n=auto --durations=0 ci_run_notebooks.py
         working-directory: ${{env.etc-directory}}
 
       - name: Create package tables and examples.rst for ReadtheDocs
-        run: |
-          python ci_create_examples_rst.py
+        run: python ci_create_examples_rst.py
         working-directory: ${{env.etc-directory}}
 
       - name: List example rst files for ReadtheDocs
-        run: |
-          ls -R .doc/_examples/
+        run: ls -R .doc/_examples/
 
       - name: List example image files for ReadtheDocs
-        run: |
-          ls -R .doc/_images/
+        run: ls -R .doc/_images/
 
       - name: List example notebook files for ReadtheDocs
-        run: |
-          ls -R .doc/_notebooks/
+        run: ls -R .doc/_notebooks/
 
       - name: Upload completed jupyter notebooks as an artifact for ReadtheDocs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ex-workflow.yml
+++ b/.github/workflows/ex-workflow.yml
@@ -4,12 +4,12 @@ on:
   schedule:
     - cron: '0 2 * * *' # run at 2 AM UTC
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
     paths-ignore:
       - 'README.md'
       - 'DEVELOPER.md'
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
     paths-ignore:
       - 'README.md'
       - 'DEVELOPER.md'

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,49 +1,93 @@
-# Creating New MODFLOW 6 Examples
+# Developing MODFLOW 6 examples
 
-Adding a new example requires adding a new example script in the `scripts` folder and adding a new latex problem description in the `doc/sections` folder.  The following steps describe the process for running all the scripts, converting them to jupyter notebooks and latex tables, and then building the pdf document.
+This document describes how to set up an environment to use or develop the MODFLOW 6 example models.
 
-## Installation of Modeling Programs
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-Install modeling programs using the get-modflow utility that is available when the flopy Python package is installed. From any directory, issue the following commands:
+
+- [Overview](#overview)
+- [Setup](#setup)
+  - [Install MODFLOW 6 and related programs](#install-modflow-6-and-related-programs)
+  - [Install Python dependencies](#install-python-dependencies)
+  - [Update FloPy](#update-flopy)
+- [Running the examples](#running-the-examples)
+  - [Using `jupyter`](#using-jupyter)
+  - [Using `pytest`](#using-pytest)
+- [Contributing examples](#contributing-examples)
+- [Releasing the examples](#releasing-the-examples)
+  - [Extract notebooks and tables from scripts](#extract-notebooks-and-tables-from-scripts)
+  - [Build the documentation](#build-the-documentation)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Overview
+
+The examples are Python scripts managed with [`jupytext`](https://github.com/mwouts/jupytext). The Python files in `scripts/` are the ultimate source of truth. Data and notebooks are generated from the scripts. There are more examples than scripts: some of the scripts produce multiple examples.
+
+## Setup
+
+This section lists steps to set up a development environment, build the examples from scripts, and finally build the examples documentation.
+
+- install MODFLOW 6 and related programs
+- Install Python dependencies
+- make sure FloPy is up to date
+
+### Install MODFLOW 6 and related programs
+
+Install modeling programs using the `get-modflow` utility that is available from FloPy. From any directory, issue the following commands:
 
 ```commandline
-get-modflow :flopy
-get-modflow --repo modflow6-nightly-build :flopy
+get-modflow :
+get-modflow --repo modflow6-nightly-build :
 ```
 
-This will install the executables in the `python/bin` directory associated with your flopy installation. Other installation location options can be found by issuing the following command:
+The command will show a prompt to select the install location. Any location can be selected, as `get-modflow` will put the executables on your path (the notebooks expect binaries to be available on the path).
 
-```commandline
-get-modflow -h
-```
+### Install Python dependencies
 
+Several Python packages are required to create the MODFLOW 6 examples. These are listed in `etc/requirements.pip.txt` and `etc/requirements.usgs.txt`.
 
-There are quite a few Python packages that are required in order to create MODFLOW 6 examples.  They are listed in `etc/requirements.pip.txt` and `etc/requirements.usgs.txt`.
+### Update FloPy
 
-## Update FloPy
+It's important that FloPy is up-to-date with the latest changes to MODFLOW 6. The latest release of FloPy is always up to date with the latest release of MODFLOW 6.
 
-It's important that FloPy is up-to-date with the latest changes to MODFLOW 6.  This can be achieved by running the following Python commands:
+To manually update FloPy from some branch of the [official MODFLOW 6 repository](https://github.com/MODFLOW-USGS/modflow6):
 
 ```commandline
 import flopy
-flopy.mf6.utils.generate_classes(branch="develop", backup=False)
+flopy.mf6.utils.generate_classes(owner="MODFLOW-USGS", branch="master", backup=True)
 ```
 
-## Running the Example Scripts
+The above is equivalent to calling the function with no arguments. Arguments may be substituted to select an alternative repository (e.g. your fork) or branch.
 
-Pytest can be used to run all of the examples.  From the `scripts` directory, issue the following command:
+## Running the examples
+
+The examples can be run with Jupyter or with Pytest.
+
+### Using `jupyter`
+
+To start a Jupyter browser interface, run `jupyter notebook` from the `notebooks/` directory.
+
+### Using `pytest`
+
+Pytest can be used to run all of the examples from the `scripts` directory. For instance, to run the examples on as many cores as your machine can spare, issue the following command:
 
 ```commandline
-pytest -v -n=auto ex-*.py 
+pytest -v -n auto
 ```
 
-or use the following command, which runs in serial instead of running in parallel:
+Remove `-n auto` to run in serial instead of parallel.
 
-```commandline
-pytest -v ex-*.py 
-```
+## Contributing examples
 
-## Extract Notebooks and Tables from Scripts
+Adding a new example requires adding a new example script in the `scripts/` folder and adding a new LaTeX problem description in the `doc/sections/` folder. After a new example is added, a new release should be made (see below).
+
+## Releasing the examples
+
+A new release is automatically created whenever code is merged into the trunk branch of this repository. Steps to manually prepare for a release are listed below.
+
+### Extract notebooks and tables from scripts
 
 The example scripts are converted into jupyter notebooks, and latex tables are created from the scripts using jupytext.  To convert all of the scripts, run the following command in the scripts directory:
 
@@ -51,6 +95,6 @@ The example scripts are converted into jupyter notebooks, and latex tables are c
 python process-scripts.py
 ```
 
-## Build the Latex Document
+### Build the documentation
 
-If the figures and tables were generated correctly, then it should be possible to build the pdf document for the examples.  The pdf is created by converting the `doc/mf6examples.tex` document into a pdf.
+If the figures and tables were generated correctly, then it should be possible to build the pdf document for the examples. The pdf is created by converting the `doc/mf6examples.tex` document into a pdf with `pdftex` or a similar tool.

--- a/common/config.py
+++ b/common/config.py
@@ -102,12 +102,3 @@ if sys.platform.lower() == "win32":
     soext = ".dll"
 if sys.platform.lower() == "darwin":
     soext = ".dylib"
-
-# set executables names
-mf6_exe = f"mf6{eext}"
-libmf6_exe = f"libmf6{soext}"
-mf2005_exe = f"mf2005{eext}"
-mf2005dbl_exe = f"mf2005dbl{eext}"
-mfnwt_exe = f"mfnwt{eext}"
-mt3dms_exe = f"mt3dms{eext}"
-mt3dusgs_exe = f"mt3dusgs{eext}"

--- a/notebooks/ex-gwf-advtidal.ipynb
+++ b/notebooks/ex-gwf-advtidal.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9ab63620",
+   "id": "4411da57",
    "metadata": {},
    "source": [
     "## Advgwtidal example\n",
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70e1c96f",
+   "id": "1a75e9d1",
    "metadata": {},
    "source": [
     "### Advgwtidal Problem Setup\n",
@@ -28,13 +28,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81f7e0a1",
+   "id": "e6881cac",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c7ab014",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
@@ -44,7 +52,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0600065",
+   "id": "a443a794",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -53,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "04e7ac8f",
+   "id": "06c49239",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +70,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "432e1c6e",
+   "id": "5d847cd8",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -71,7 +79,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c674ef0",
+   "id": "21c78f8e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +89,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2301dbf9",
+   "id": "4fbff411",
    "metadata": {},
    "source": [
     "Set default figure properties"
@@ -90,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "663a6808",
+   "id": "2c89d5f1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +107,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53c07998",
+   "id": "a32c3afa",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -108,7 +116,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0bca8dde",
+   "id": "7af70771",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +125,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b50863b9",
+   "id": "d2061249",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -126,7 +134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b381c7a7",
+   "id": "17c514d1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,7 +143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a23ee663",
+   "id": "18ce5ace",
    "metadata": {},
    "source": [
     "Model units"
@@ -144,7 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fa13ce28",
+   "id": "e034b9e3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e88a8c0",
+   "id": "8c8bf07b",
    "metadata": {},
    "source": [
     "Table Advgwtidal Model Parameters"
@@ -163,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1e94cc8",
+   "id": "d1372a50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +193,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8099152d",
+   "id": "35f88aba",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file\n",
@@ -197,7 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9857293e",
+   "id": "c404006b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,7 +217,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed371aaf",
+   "id": "094ead5b",
    "metadata": {},
    "source": [
     "parse parameter strings into tuples"
@@ -218,7 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59d808bb",
+   "id": "ad82358e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,7 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2b8b2f56",
+   "id": "a1e1a771",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -270,7 +278,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f535167c",
+   "id": "af624fc7",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -279,7 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8bd07695",
+   "id": "feed9675",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dee2956d",
+   "id": "59226c48",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -304,7 +312,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29b1cadc",
+   "id": "1e02f151",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,7 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84f0bf63",
+   "id": "78ca96c2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -337,7 +345,7 @@
     "        sim = flopy.mf6.MFSimulation(\n",
     "            sim_name=sim_name,\n",
     "            sim_ws=sim_ws,\n",
-    "            exe_name=config.mf6_exe,\n",
+    "            exe_name=\"mf6\",\n",
     "            verbosity_level=0,\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
@@ -534,7 +542,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3eea803f",
+   "id": "e9c75206",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -545,7 +553,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52aa6ff8",
+   "id": "59288d78",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -558,7 +566,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc4fa0d2",
+   "id": "cc09941f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -570,7 +578,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c7a92a74",
+   "id": "9d48385e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -587,14 +595,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f057cc9a",
+   "id": "afb9af4c",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Function to plot the Advgwtidal model results.\n",
     "#\n",
-    "\n",
-    "\n",
     "def plot_grid(sim):\n",
     "    fs = USGSFigure(figure_type=\"map\", verbose=False)\n",
     "    sim_ws = os.path.join(ws, sim_name)\n",
@@ -670,7 +676,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a7802878",
+   "id": "d2b5a249",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -708,7 +714,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "790f77ee",
+   "id": "4b9b8eda",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -723,7 +729,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9fa53e6",
+   "id": "0c180319",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -739,7 +745,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20229bab",
+   "id": "a93b3d79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -754,29 +760,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d05a6dd2",
+   "id": "b16910d4",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "e50b35ba",
+   "id": "b4d6a23a",
    "metadata": {},
    "source": [
-    "### Advgwtidal Simulation\n",
-    "\n",
-    "Model grid and simulation results"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0fe1f3d",
+   "id": "a9ad4a31",
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation()"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Advgwtidal Simulation\n",
+    "    #\n",
+    "    # Model grid and simulation results\n",
+    "\n",
+    "    simulation()"
    ]
   }
  ],

--- a/notebooks/ex-gwf-bcf2ss.ipynb
+++ b/notebooks/ex-gwf-bcf2ss.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f4af7588",
+   "id": "16fb7e43",
    "metadata": {},
    "source": [
     "## Original BCF2SS MODFLOW example\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb639836",
+   "id": "13f5171f",
    "metadata": {},
    "source": [
     "### BCF2SS Problem Setup\n",
@@ -25,13 +25,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "795c1652",
+   "id": "eca817d7",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59e9cd82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
@@ -40,7 +48,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "02c54420",
+   "id": "08c451a4",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -49,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb622c3c",
+   "id": "c5f2b91c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +66,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4981f6d5",
+   "id": "5bada09d",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -67,7 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "908b2b0f",
+   "id": "a4884517",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93f280bc",
+   "id": "7dd34921",
    "metadata": {},
    "source": [
     "Set figure properties specific to the"
@@ -86,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56f1d29f",
+   "id": "296dbbe6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1568f82",
+   "id": "78ed30d4",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -104,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f3639a19",
+   "id": "4c01ab99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16cf606d",
+   "id": "9a228b59",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -122,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "776251e8",
+   "id": "130e3fe2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a65e7d84",
+   "id": "dd17d973",
    "metadata": {},
    "source": [
     "Model units"
@@ -140,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fd185a0f",
+   "id": "b9087412",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0df314be",
+   "id": "d3d1b07a",
    "metadata": {},
    "source": [
     "Load the wetdry array for layer 1"
@@ -159,7 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "441cb8e5",
+   "id": "124bc0b4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -173,7 +181,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "137ba31d",
+   "id": "ffce6367",
    "metadata": {},
    "source": [
     "Scenario parameters"
@@ -182,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0ca3e4e1",
+   "id": "8190b0d6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +216,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71801e94",
+   "id": "e7ab2455",
    "metadata": {},
    "source": [
     "Table BCF2SS Model Parameters"
@@ -217,7 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c59602e",
+   "id": "d6535a33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +246,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9d3f78f",
+   "id": "de16a04f",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -247,7 +255,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c19ff93",
+   "id": "92b69dfe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -259,7 +267,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a9bb8cb",
+   "id": "6c5bafa8",
    "metadata": {},
    "source": [
     "parse parameter strings into tuples"
@@ -268,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47169228",
+   "id": "9f8dc33e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -281,7 +289,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01d2acc4",
+   "id": "87110471",
    "metadata": {},
    "source": [
     "### Create BCF2SS Model Boundary Conditions"
@@ -289,7 +297,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "960b7784",
+   "id": "407d28cd",
    "metadata": {},
    "source": [
     "Well boundary conditions"
@@ -298,7 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f1c4315",
+   "id": "bafc19a3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +320,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8ebb4598",
+   "id": "13efa4f8",
    "metadata": {},
    "source": [
     "River boundary conditions"
@@ -321,7 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "667d84de",
+   "id": "4806255c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -330,7 +338,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a733db4",
+   "id": "25900d04",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -339,7 +347,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4f078f06",
+   "id": "181fd2d5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,7 +360,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b7a67cf5",
+   "id": "45bc77dd",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -365,7 +373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25b9765b",
+   "id": "0cf0f84a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -375,7 +383,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -443,7 +451,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e26f5400",
+   "id": "f40bc69e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -454,7 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "005828d5",
+   "id": "7a2410cc",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -467,7 +475,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "243ed049",
+   "id": "e655d823",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -479,7 +487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb447883",
+   "id": "211d0411",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -498,7 +506,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6192f58",
+   "id": "6d777a84",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -509,7 +517,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "584940e9",
+   "id": "f8aae8e7",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -666,7 +674,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51cf96be",
+   "id": "b94d9e4a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -677,7 +685,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a946f2b",
+   "id": "84d5f148",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -833,7 +841,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2e67d12d",
+   "id": "f1828662",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -849,7 +857,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d610cb3a",
+   "id": "afcfa71b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -869,71 +877,52 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "313a92f3",
+   "id": "cc732bc6",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_and_plot():\n",
+    "    simulation(0, silent=False)\n",
+    "    simulation(1, silent=False)\n",
+    "    plot_results(silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "711cac2d",
+   "id": "09a8a325",
    "metadata": {},
    "source": [
-    "### BCF2SS Simulation\n",
+    "nosetest end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d52c2346",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    # ### BCF2SS Simulation\n",
+    "    #\n",
+    "    #  Node Property Flow Package with rewetting option\n",
     "\n",
-    " Node Property Flow Package with rewetting option"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7301c1ff",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ff43d93a",
-   "metadata": {},
-   "source": [
-    "Newton-Raphson formulation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "00d9957d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5817a434",
-   "metadata": {},
-   "source": [
-    "Simulated water levels and normalized specific discharge vectors in the\n",
-    "upper and lower aquifers under natural and pumping conditions using (1) the\n",
-    "rewetting option in the Node Property Flow (NPF) Package with the\n",
-    "Standard Conductance Formulation and (2) the Newton-Raphson formulation.\n",
-    "A. Upper aquifer results under natural conditions. B. Lower aquifer results\n",
-    "under natural conditions C. Upper aquifer results under pumping conditions.\n",
-    "D. Lower aquifer results under pumping conditions"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e6146879",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_results()"
+    "    simulation(0)\n",
+    "\n",
+    "    # Newton-Raphson formulation\n",
+    "\n",
+    "    simulation(1)\n",
+    "\n",
+    "    # Simulated water levels and normalized specific discharge vectors in the\n",
+    "    # upper and lower aquifers under natural and pumping conditions using (1) the\n",
+    "    # rewetting option in the Node Property Flow (NPF) Package with the\n",
+    "    # Standard Conductance Formulation and (2) the Newton-Raphson formulation.\n",
+    "    # A. Upper aquifer results under natural conditions. B. Lower aquifer results\n",
+    "    # under natural conditions C. Upper aquifer results under pumping conditions.\n",
+    "    # D. Lower aquifer results under pumping conditions\n",
+    "\n",
+    "    plot_results()"
    ]
   }
  ],

--- a/notebooks/ex-gwf-bump.ipynb
+++ b/notebooks/ex-gwf-bump.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8a750225",
+   "id": "9509d5d4",
    "metadata": {},
    "source": [
     "## Flow diversion example\n",
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8dea516e",
+   "id": "6ba0aa01",
    "metadata": {},
    "source": [
     "### Flow diversion Problem Setup\n",
@@ -22,13 +22,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fdb9cabf",
+   "id": "5a1ed334",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef6bbb56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
@@ -37,7 +45,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "166b6ea3",
+   "id": "2e48d2de",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -46,7 +54,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7005a1ae",
+   "id": "5d19658f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +63,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac87f9e3",
+   "id": "69f3cdc9",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -64,7 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e6b99b9",
+   "id": "77de87bb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd74c134",
+   "id": "4a3439a5",
    "metadata": {},
    "source": [
     "Set figure properties"
@@ -83,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e4f69fd8",
+   "id": "fac8bf03",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2514a0b",
+   "id": "7f3b8218",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -102,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80cc096b",
+   "id": "4993a5f1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35381a0d",
+   "id": "34127847",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -120,7 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "da7c9ff3",
+   "id": "c12565e9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32a701da",
+   "id": "a2563cd4",
    "metadata": {},
    "source": [
     "Model units"
@@ -138,7 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6dbc983b",
+   "id": "cfc65f93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,7 +156,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8796075",
+   "id": "805939a5",
    "metadata": {},
    "source": [
     "Scenario parameters"
@@ -157,7 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02dc1179",
+   "id": "dc5d4c48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,7 +189,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f3318ca",
+   "id": "2debb9e0",
    "metadata": {},
    "source": [
     "Table"
@@ -190,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9df7e1c0",
+   "id": "0b1c8509",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +216,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad572e4f",
+   "id": "b3fe0d86",
    "metadata": {},
    "source": [
     "plotting ranges and contour levels"
@@ -217,7 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1d25de54",
+   "id": "9707b71c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -233,7 +241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b3984973",
+   "id": "74281365",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -242,7 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a2bd1e1",
+   "id": "c353dc76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -251,7 +259,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "613d8256",
+   "id": "1b954fdb",
    "metadata": {},
    "source": [
     "Calculate delr, delc, extents, and shape3d"
@@ -260,7 +268,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3aaf6cfe",
+   "id": "a51781c9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,7 +280,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65757ad4",
+   "id": "32c433dd",
    "metadata": {},
    "source": [
     "Load the bottom"
@@ -281,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59b629f4",
+   "id": "33ed1f58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b9b91d2f",
+   "id": "1a13d1a3",
    "metadata": {},
    "source": [
     "create a cylinder"
@@ -300,7 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8bbf80e7",
+   "id": "33dd9760",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +320,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7390ab52",
+   "id": "9158f94e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,7 +331,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c88d477f",
+   "id": "f2850c08",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -332,7 +340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "041715c0",
+   "id": "f7ab402c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +352,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3cf0731",
+   "id": "6bc0c25e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -357,7 +365,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76ca2161",
+   "id": "75385c76",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -376,7 +384,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        if newton:\n",
@@ -453,7 +461,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b03dba8e",
+   "id": "0b7abce6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -464,7 +472,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3dd3c61a",
+   "id": "3a43abd6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -477,7 +485,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eacfec77",
+   "id": "9f661aef",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -488,7 +496,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2e78ced6",
+   "id": "0e5c817b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -507,7 +515,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c09424e6",
+   "id": "19a5da66",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -518,7 +526,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b3e6f989",
+   "id": "c77f6a38",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -559,7 +567,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd918499",
+   "id": "92f8ae41",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -570,7 +578,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46b91bca",
+   "id": "83999854",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -645,7 +653,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "610a1d21",
+   "id": "ff7d83d4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -656,7 +664,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "840721ec",
+   "id": "20c822d2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -782,7 +790,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1944d4db",
+   "id": "e56c6da5",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -798,7 +806,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d30e3b15",
+   "id": "b04f5a11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -819,66 +827,67 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30723773",
+   "id": "1a5d9a84",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(0, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88b9fe01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_02():\n",
+    "    simulation(1, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e21176bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_03():\n",
+    "    simulation(2, silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "a1ade3db",
+   "id": "54aa892d",
    "metadata": {},
    "source": [
-    "### Zaidel Simulation\n",
+    "nosetest end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d430a26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    # ### Zaidel Simulation\n",
+    "    #\n",
+    "    # Simulated heads in the flow diversion model with Newton-Raphson.\n",
     "\n",
-    "Simulated heads in the flow diversion model with Newton-Raphson."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2a345783",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "91448e72",
-   "metadata": {},
-   "source": [
-    "Simulated heads in the flow diversion model with rewetting."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cd37339e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "167d2775",
-   "metadata": {},
-   "source": [
-    "Simulated heads in the flow diversion model with Newton-Raphson and\n",
-    "cylinderical topography."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "344789bd",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(2)"
+    "    simulation(0)\n",
+    "\n",
+    "    # Simulated heads in the flow diversion model with rewetting.\n",
+    "\n",
+    "    simulation(1)\n",
+    "\n",
+    "    # Simulated heads in the flow diversion model with Newton-Raphson and\n",
+    "    # cylinderical topography.\n",
+    "\n",
+    "    simulation(2)"
    ]
   }
  ],

--- a/notebooks/ex-gwf-capture.ipynb
+++ b/notebooks/ex-gwf-capture.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "1290b050",
+   "id": "419a0d78",
    "metadata": {},
    "source": [
     "## Capture fraction analysis\n",
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c6c58f38",
+   "id": "f54ae1fb",
    "metadata": {},
    "source": [
     "### Capture Fraction Problem Setup\n",
@@ -28,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d6c47597",
+   "id": "880123dc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +41,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad980ca0",
+   "id": "370eab01",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0c3ff8a",
+   "id": "69cfcfde",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -63,7 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "409cf72d",
+   "id": "f7b3248e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f487dd21",
+   "id": "d8b91748",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -81,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3951adea",
+   "id": "536fdd8d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1a97a187",
+   "id": "93ede7a8",
    "metadata": {},
    "source": [
     "Set figure properties specific to the"
@@ -100,7 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e99a94a",
+   "id": "f1855ac0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9ec3734",
+   "id": "cbe4c555",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -118,7 +118,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5b4ca89e",
+   "id": "7be67cc9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42724174",
+   "id": "12e8921d",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -136,7 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23eab9d6",
+   "id": "e2bce434",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cc22d4f5",
+   "id": "42c43375",
    "metadata": {},
    "source": [
     "Model units"
@@ -154,7 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "155e227b",
+   "id": "20d9c2a6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +164,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ecb90272",
+   "id": "8b040b32",
    "metadata": {},
    "source": [
     "Load the bottom, hydraulic conductivity, and idomain arrays"
@@ -173,7 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30372e6a",
+   "id": "838bd833",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -193,7 +193,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d2c0d1b",
+   "id": "1b239e12",
    "metadata": {},
    "source": [
     "Table Capture Fraction Model Parameters"
@@ -202,7 +202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a2548515",
+   "id": "4cfcf54c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f283651",
+   "id": "553bb5ba",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -230,7 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31619e0c",
+   "id": "34c1135e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -241,7 +241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f0b76336",
+   "id": "98b939a5",
    "metadata": {},
    "source": [
     "### Create Capture Fraction Model Boundary Conditions"
@@ -249,7 +249,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4da2963a",
+   "id": "17da7d55",
    "metadata": {},
    "source": [
     "Well boundary conditions"
@@ -258,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8d9cff1a",
+   "id": "fed722b5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,7 +276,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6847c8c",
+   "id": "f00eaf84",
    "metadata": {},
    "source": [
     "Constant head boundary conditions"
@@ -285,7 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1129b231",
+   "id": "fec85bb8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -307,7 +307,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "656ee010",
+   "id": "791b2578",
    "metadata": {},
    "source": [
     "River boundary conditions"
@@ -316,7 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "362d03d0",
+   "id": "f4221b5a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -330,7 +330,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f48e7ffb",
+   "id": "097eed06",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -339,7 +339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4f9583c6",
+   "id": "4dc81f27",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -354,7 +354,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b7b73d2",
+   "id": "25d1d076",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -368,7 +368,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ee100ee",
+   "id": "3979af47",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -381,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46e4983b",
+   "id": "578daa1d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -393,7 +393,7 @@
     "        sim = flopy.mf6.MFSimulation(\n",
     "            sim_name=sim_name,\n",
     "            sim_ws=sim_ws,\n",
-    "            exe_name=config.mf6_exe,\n",
+    "            exe_name=\"mf6\",\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -452,7 +452,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b68374f2",
+   "id": "69f2225d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -463,7 +463,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bde08615",
+   "id": "d01c239b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -476,7 +476,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2a2046f6",
+   "id": "ce339c69",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -487,7 +487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6e5da604",
+   "id": "66df034b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -510,7 +510,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82e9373b",
+   "id": "cb7eee56",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -521,7 +521,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "affe4ad3",
+   "id": "017cfe4e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -547,7 +547,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc93b62a",
+   "id": "0129157c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -558,7 +558,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa57a3d5",
+   "id": "bb3436ab",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -571,7 +571,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5459f03",
+   "id": "8eef2f92",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -583,7 +583,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb468a94",
+   "id": "d1e2b6f7",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -593,7 +593,9 @@
     "def run_model():\n",
     "    success = True\n",
     "    if config.runModel:\n",
-    "        libmf6_path = pl.Path(shutil.which(config.mf6_exe)).parent / config.libmf6_exe\n",
+    "        libmf6_path = (\n",
+    "            pl.Path(shutil.which(\"mf6\")).parent / f\"libmf6{config.soext}\"\n",
+    "        )\n",
     "        sim_ws = os.path.join(ws, sim_name)\n",
     "        mf6 = modflowapi.ModflowApi(libmf6_path, working_directory=sim_ws)\n",
     "        qbase = capture_fraction_iteration(mf6, cf_q)\n",
@@ -627,7 +629,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b49f5d02",
+   "id": "dbec3ec5",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -638,7 +640,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "050a98ec",
+   "id": "7708f454",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -752,7 +754,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee5f97fb",
+   "id": "082b2905",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -768,7 +770,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1a58ee4a",
+   "id": "63a0e945",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -785,48 +787,42 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32479be8",
+   "id": "183e81dd",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(silent=False)\n",
+    "    plot_results(silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "67a61028",
+   "id": "7b4b6a0e",
    "metadata": {},
    "source": [
-    "### Capture Zone Simulation\n",
+    "nosetest end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60451192",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    # ### Capture Zone Simulation\n",
+    "    #\n",
+    "    #  Capture zone examples using the MODFLOW API with the Freyberg (1988) model\n",
     "\n",
-    " Capture zone examples using the MODFLOW API with the Freyberg (1988) model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "12bff460",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4b531004",
-   "metadata": {},
-   "source": [
-    "Simulated streamflow capture fraction map for the Freyberg (1988) groundwater\n",
-    "flow model."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a29f41f7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_results()"
+    "    simulation()\n",
+    "\n",
+    "    # Simulated streamflow capture fraction map for the Freyberg (1988) groundwater\n",
+    "    # flow model.\n",
+    "\n",
+    "    plot_results()"
    ]
   }
  ],

--- a/notebooks/ex-gwf-csub-p01.ipynb
+++ b/notebooks/ex-gwf-csub-p01.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b1a4e088",
+   "id": "6eec192f",
    "metadata": {},
    "source": [
     "## Jacob (1939) Elastic Aquifer Loading\n",
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1273f5ea",
+   "id": "d6725bdc",
    "metadata": {},
    "source": [
     "### Problem Setup\n",
@@ -26,14 +26,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3d08b3d8",
+   "id": "e1679fd8",
    "metadata": {},
    "outputs": [],
    "source": [
     "import datetime\n",
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "227ccc18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
@@ -42,7 +50,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "daeef97c",
+   "id": "8df9c0ff",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -51,7 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce0b69fe",
+   "id": "9f1f2134",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +68,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4bdd1423",
+   "id": "fc0be912",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -69,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "765632e3",
+   "id": "757afb2f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +87,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51c9a160",
+   "id": "32ac5d2f",
    "metadata": {},
    "source": [
     "Set figure properties specific to the"
@@ -88,7 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99ad2426",
+   "id": "9ee9a4df",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,7 +105,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57459a71",
+   "id": "6343dfa8",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -106,7 +114,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ed72617a",
+   "id": "94bdca7f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,7 +123,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb4693e0",
+   "id": "b6542ce5",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -124,7 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7fcd9d3",
+   "id": "7a800ade",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2fb9c3af",
+   "id": "b5418fad",
    "metadata": {},
    "source": [
     "Model units"
@@ -142,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1579de0f",
+   "id": "f8c58e46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1bd38296",
+   "id": "6ec033c5",
    "metadata": {},
    "source": [
     "Simulation starting date and time"
@@ -161,7 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15eb72bc",
+   "id": "50ef2669",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +178,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33f40625",
+   "id": "0009362b",
    "metadata": {},
    "source": [
     "Table"
@@ -179,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6be1042d",
+   "id": "93db262a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +212,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a31c82ee",
+   "id": "09b466fd",
    "metadata": {},
    "source": [
     "Create delr from delr0 and delrmac"
@@ -213,7 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec3f4baa",
+   "id": "315588e1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,7 +235,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b8b8e97",
+   "id": "36bc6684",
    "metadata": {},
    "source": [
     "Location of the observation well"
@@ -236,7 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7372fe78",
+   "id": "28d1e5cd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +253,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8fef3d3",
+   "id": "4800de50",
    "metadata": {},
    "source": [
     "Load the aquifer load time series"
@@ -254,7 +262,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af62063c",
+   "id": "1cd1e9e7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,7 +272,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7972ad11",
+   "id": "c4b794da",
    "metadata": {},
    "source": [
     "Reformat csv data into format for MODFLOW 6 timeseries file"
@@ -273,7 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d97f3214",
+   "id": "73924090",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +292,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6e5dd0e",
+   "id": "16672b0f",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -293,7 +301,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17117b3f",
+   "id": "925ac697",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -307,7 +315,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af4d9bde",
+   "id": "3959ca2e",
    "metadata": {},
    "source": [
     "Simulation starting date and time"
@@ -316,7 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2635618c",
+   "id": "73c8c420",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,7 +333,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba84c4fb",
+   "id": "97bb49ab",
    "metadata": {},
    "source": [
     "Create a datetime list"
@@ -334,7 +342,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5d32fe18",
+   "id": "b6b852bc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,7 +351,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89178597",
+   "id": "884a219c",
    "metadata": {},
    "source": [
     "parse parameter strings into tuples"
@@ -352,7 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b60bc8d2",
+   "id": "86f4fd8d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -366,7 +374,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e44d6fc4",
+   "id": "d2717955",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -375,7 +383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f72a856f",
+   "id": "39dd823d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -391,7 +399,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eac330ff",
+   "id": "0a74a2b1",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -404,7 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c19dc34",
+   "id": "ecbfdf6d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -414,7 +422,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, sim_name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -496,7 +504,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d889a66",
+   "id": "ad70f5b2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -507,7 +515,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "366ee48b",
+   "id": "f7528098",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -520,7 +528,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20e236e9",
+   "id": "e8c9feb3",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -532,7 +540,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a11d63c3",
+   "id": "9e775f73",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -551,7 +559,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a0e1a242",
+   "id": "aedc2187",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -562,8 +570,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96ff69cf",
-   "metadata": {},
+   "id": "17bdc05f",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "outputs": [],
    "source": [
     "def plot_results(sim, silent=True):\n",
@@ -705,8 +715,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "655af1f9",
-   "metadata": {},
+   "id": "fccff0ca",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "Function that wraps all of the steps for the model\n",
     "\n",
@@ -719,7 +731,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5fc60d49",
+   "id": "61fad8cd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -737,27 +749,35 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bd41b8ec",
+   "id": "73088204",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "d08531cd",
+   "id": "e2d0897e",
    "metadata": {},
    "source": [
-    "### Jacob (1939) Elastic Aquifer Loading\n"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e2cded86",
+   "id": "363ae389",
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation()"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Jacob (1939) Elastic Aquifer Loading\n",
+    "    #\n",
+    "\n",
+    "    simulation()"
    ]
   }
  ],

--- a/notebooks/ex-gwf-csub-p02.ipynb
+++ b/notebooks/ex-gwf-csub-p02.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "2c9c033e",
+   "id": "a066f648",
    "metadata": {},
    "source": [
     "## Delay interbed drainage\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eb3356ab",
+   "id": "3a0b8995",
    "metadata": {},
    "source": [
     "### Problem Setup\n",
@@ -25,13 +25,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ea3be4bc",
+   "id": "72c98530",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acf78154",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
@@ -40,7 +48,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d42339d5",
+   "id": "4dea619e",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -49,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05862d9a",
+   "id": "f5c87f00",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +66,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b93864b0",
+   "id": "db54745d",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -67,7 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dcdad35d",
+   "id": "73bad8ab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d206b82",
+   "id": "5e3ce07c",
    "metadata": {},
    "source": [
     "Set figure properties specific to the problem"
@@ -86,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6fa9342e",
+   "id": "5b914889",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1a966c8a",
+   "id": "c7ec24da",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -105,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a19dacb4",
+   "id": "79329afe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "458a2ab8",
+   "id": "6644a8a6",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -123,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eb77c568",
+   "id": "775fb742",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +140,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4664cb43",
+   "id": "b4164215",
    "metadata": {},
    "source": [
     "Scenario parameters"
@@ -141,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b544d80f",
+   "id": "478fb767",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +177,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "afa7b5ee",
+   "id": "72764ed4",
    "metadata": {},
    "source": [
     "Model units"
@@ -178,7 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3cd33127",
+   "id": "e1ae3401",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,7 +196,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34102506",
+   "id": "08d31de6",
    "metadata": {},
    "source": [
     "Table"
@@ -197,7 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4662a3f8",
+   "id": "1313b1ec",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +233,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9dc091fe",
+   "id": "84247b03",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -234,7 +242,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f4613ad5",
+   "id": "e9e73165",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +251,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c722dbe",
+   "id": "25f83a4a",
    "metadata": {},
    "source": [
     "Constant head cells"
@@ -252,7 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "286ac8cd",
+   "id": "a8fec733",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +271,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9357e516",
+   "id": "3dcb2624",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -272,7 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f222d34b",
+   "id": "6b3d7e41",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -288,7 +296,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a82f28f9",
+   "id": "032e85d6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -301,7 +309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dc5effb0",
+   "id": "8e5e2904",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -320,7 +328,7 @@
     "        if subdir_name is not None:\n",
     "            sim_ws = os.path.join(sim_ws, subdir_name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -446,7 +454,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6504cee3",
+   "id": "f2e5cd46",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -457,7 +465,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bfa8f038",
+   "id": "bfbb1480",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -470,7 +478,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea8e421f",
+   "id": "044b9359",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -482,7 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "688d05f3",
+   "id": "b3b76627",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -501,7 +509,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a0c952e0",
+   "id": "0bc7b731",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -512,7 +520,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8811b2d3",
+   "id": "bafaa2fd",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -537,7 +545,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "987210ed",
+   "id": "cb2fb732",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -548,7 +556,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0a6de34b",
+   "id": "0f4b2959",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -622,7 +630,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "113a6f73",
+   "id": "6f0c9dde",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -633,7 +641,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "902b869e",
+   "id": "c6e25a07",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -730,7 +738,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b4d81fec",
+   "id": "15f92764",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -818,7 +826,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4bf93ec3",
+   "id": "f381685e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -829,7 +837,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17e2e5d6",
+   "id": "cdc2988f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -854,7 +862,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "114154a5",
+   "id": "afb7b668",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -865,7 +873,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cb17164c",
+   "id": "b38ffdb4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -882,7 +890,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fb3c107f",
+   "id": "cb42d54c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -893,7 +901,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71b3d9e4",
+   "id": "24719296",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -984,7 +992,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0b5a264a",
+   "id": "19a50278",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -995,7 +1003,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d8f5f000",
+   "id": "4e532551",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1139,7 +1147,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a4799cb1",
+   "id": "5bdaf5a8",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1150,7 +1158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7891e3d9",
+   "id": "9c739a75",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1172,7 +1180,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ebe6f34f",
+   "id": "6bc8f5ba",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1188,7 +1196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ba0dbcca",
+   "id": "a54efe3c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1239,65 +1247,66 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52ef851e",
+   "id": "97051ea0",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(0, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7daf246",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_02():\n",
+    "    simulation(1, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6fa7a023",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_03():\n",
+    "    simulation(2, silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "368034d6",
+   "id": "6acdb353",
    "metadata": {},
    "source": [
-    "### Delay interbed drainage\n",
+    "nosetest end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3eed6ae9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    # ### Delay interbed drainage\n",
+    "    #\n",
+    "    # #### Head based solution\n",
     "\n",
-    "#### Head based solution"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "885536d6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "12cb33bd",
-   "metadata": {},
-   "source": [
-    "#### Effective stress solution"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7d187263",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2c432eea",
-   "metadata": {},
-   "source": [
-    "#### Head based for multiple interbed thicknesses"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a9ddcad2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(2)"
+    "    simulation(0)\n",
+    "\n",
+    "    # #### Effective stress solution\n",
+    "\n",
+    "    simulation(1)\n",
+    "\n",
+    "    # #### Head based for multiple interbed thicknesses\n",
+    "\n",
+    "    simulation(2)"
    ]
   }
  ],

--- a/notebooks/ex-gwf-csub-p03.ipynb
+++ b/notebooks/ex-gwf-csub-p03.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "2632ad74",
+   "id": "d1b7c605",
    "metadata": {},
    "source": [
     "## One-dimensional compaction\n",
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f8ec9e1b",
+   "id": "dc1b6895",
    "metadata": {},
    "source": [
     "### Problem Setup\n",
@@ -26,14 +26,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b2f3bdb3",
+   "id": "2612af1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "import datetime\n",
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09fc5690",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
@@ -43,7 +51,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d7b1cbde",
+   "id": "3162a57b",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -52,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4274e9ce",
+   "id": "161a587c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53d538c6",
+   "id": "c1ba9ea2",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -70,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78221edf",
+   "id": "b0b4191c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +89,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2ee0f9c5",
+   "id": "b6893ecc",
    "metadata": {},
    "source": [
     "Set figure properties specific to the problem"
@@ -90,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c44604d8",
+   "id": "7f76326a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +108,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db980466",
+   "id": "193aa9b6",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -109,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c3c4f20",
+   "id": "9223f72f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ae6e0630",
+   "id": "12d52e84",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -127,7 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c58c68cd",
+   "id": "11c05f2f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +144,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eaf77077",
+   "id": "a00e52b8",
    "metadata": {},
    "source": [
     "Load the constant time series"
@@ -145,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "888c1017",
+   "id": "e841a85b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,7 +163,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2c5a8225",
+   "id": "ff6ed67b",
    "metadata": {},
    "source": [
     "Reformat csv data into format for MODFLOW 6 timeseries file"
@@ -164,7 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1788fd23",
+   "id": "526a71d5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +190,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be9e0ec9",
+   "id": "eca16e4f",
    "metadata": {},
    "source": [
     "Simulation starting date and time"
@@ -191,7 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bb71937b",
+   "id": "2d9c0f45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "779e96bd",
+   "id": "c8e3a446",
    "metadata": {},
    "source": [
     "Create a datetime list for the simulation"
@@ -209,7 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61360b60",
+   "id": "78412a4f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -220,7 +228,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7031f030",
+   "id": "c1e371f5",
    "metadata": {},
    "source": [
     "Scenario parameters"
@@ -229,7 +237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4310917c",
+   "id": "d8252a01",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -367,7 +375,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d07d756e",
+   "id": "61c8ba0a",
    "metadata": {},
    "source": [
     "Model units"
@@ -376,7 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01eeacd2",
+   "id": "c7514804",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -386,7 +394,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eb8bc842",
+   "id": "2ef2c940",
    "metadata": {},
    "source": [
     "Model parameters"
@@ -395,7 +403,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "969c4b62",
+   "id": "e107e203",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -584,7 +592,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a7eff6d",
+   "id": "81b647ac",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -593,7 +601,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63b41cb9",
+   "id": "fd05bf63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -606,7 +614,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c8ef3fc5",
+   "id": "f496b02c",
    "metadata": {},
    "source": [
     "Constant head cells"
@@ -615,7 +623,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2daa9e2c",
+   "id": "5cf5cc1d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -634,7 +642,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aa2b3005",
+   "id": "de7f2a9e",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -643,7 +651,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f0fdb1f4",
+   "id": "eb97080c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -657,7 +665,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fbdc5f59",
+   "id": "5513c55e",
    "metadata": {},
    "source": [
     "Create data for plotting"
@@ -666,7 +674,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "863c78f1",
+   "id": "5454d5c7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -689,7 +697,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "464c981d",
+   "id": "b6592d35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -703,7 +711,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f08bcf5e",
+   "id": "a1a6d39a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -729,7 +737,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88a8df5a",
+   "id": "0eddd672",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -744,7 +752,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19736f6d",
+   "id": "b7438019",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -757,7 +765,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "256d1305",
+   "id": "556c6cab",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -777,7 +785,7 @@
     "        if subdir_name is not None:\n",
     "            sim_ws = os.path.join(sim_ws, subdir_name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -947,7 +955,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "563ed50f",
+   "id": "d925a8c6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -958,7 +966,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce00155d",
+   "id": "e3893e9d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -971,7 +979,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a0d97381",
+   "id": "66844fa9",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -983,7 +991,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e847b8e",
+   "id": "b1948672",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1002,7 +1010,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c92a41b3",
+   "id": "b7041b82",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1013,7 +1021,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82fa8463",
+   "id": "2aa2b05c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1128,7 +1136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef607349",
+   "id": "8bb4a767",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1139,7 +1147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e3f58d0e",
+   "id": "1c8cec88",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1155,7 +1163,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5041ed21",
+   "id": "4746d9e2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1166,7 +1174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e775e8a",
+   "id": "631903c6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1188,7 +1196,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d8bd22a8",
+   "id": "4526d38a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1199,7 +1207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f0c42104",
+   "id": "172ec177",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1231,7 +1239,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08cf80d5",
+   "id": "1c68e211",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1242,7 +1250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d2e08fc9",
+   "id": "93943212",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1260,7 +1268,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "701e4e84",
+   "id": "09c4b098",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1271,7 +1279,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a0182cda",
+   "id": "6f3d59b2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1315,7 +1323,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "04964aaa",
+   "id": "bd42ee47",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1326,7 +1334,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53af4e68",
+   "id": "dd098fee",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1341,7 +1349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7352179a",
+   "id": "3fecbffb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1389,7 +1397,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20b89f3d",
+   "id": "187db938",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1448,7 +1456,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47be0b09",
+   "id": "210b6f7c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1459,7 +1467,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f0f426c",
+   "id": "b87f6971",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1593,7 +1601,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bfb2751b",
+   "id": "47aa34ec",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1604,7 +1612,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc0c2031",
+   "id": "b2c6e243",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1665,7 +1673,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8347721f",
+   "id": "93de9134",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1676,7 +1684,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d2f0106a",
+   "id": "ddc1233c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1768,7 +1776,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a7999d3",
+   "id": "d887947c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -2050,7 +2058,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "910813ce",
+   "id": "964a770d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -2061,7 +2069,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef76ae5a",
+   "id": "68e57fd7",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -2203,7 +2211,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af767b23",
+   "id": "79e4b9bd",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -2214,7 +2222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c299e47",
+   "id": "34f805eb",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -2231,7 +2239,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1426c86f",
+   "id": "4cd4f2b4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -2247,7 +2255,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98a6cf12",
+   "id": "1e8ec17c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2265,83 +2273,51 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1bf5283c",
+   "id": "73af9dcb",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_and_plot():\n",
+    "    simulation(0, silent=False)\n",
+    "    simulation(1, silent=False)\n",
+    "    plot_results(silent=False)\n",
+    "    export_tables(silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "08a464d7",
+   "id": "a2558099",
    "metadata": {},
    "source": [
-    "### One-dimensional compaction\n",
+    "nosetest end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d31cdf5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    # ### One-dimensional compaction\n",
+    "    #\n",
+    "    # #### Head based solution\n",
     "\n",
-    "#### Head based solution"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0d816ea7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b658348c",
-   "metadata": {},
-   "source": [
-    "#### Effective stress solution"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0e0a041b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fdaf0621",
-   "metadata": {},
-   "source": [
-    "#### Plot results"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "05854f0d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_results()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bc430315",
-   "metadata": {},
-   "source": [
-    "#### Export tables"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6a2c83ae",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "export_tables()"
+    "    simulation(0)\n",
+    "\n",
+    "    # #### Effective stress solution\n",
+    "\n",
+    "    simulation(1)\n",
+    "\n",
+    "    # #### Plot results\n",
+    "\n",
+    "    plot_results()\n",
+    "\n",
+    "    # #### Export tables\n",
+    "\n",
+    "    export_tables()"
    ]
   }
  ],

--- a/notebooks/ex-gwf-csub-p04.ipynb
+++ b/notebooks/ex-gwf-csub-p04.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d78e2fe9",
+   "id": "51432426",
    "metadata": {},
    "source": [
     "## One-dimensional compaction in a three-dimensional flow field\n",
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65b31d7c",
+   "id": "f6804d79",
    "metadata": {},
    "source": [
     "### Problem Setup\n",
@@ -26,13 +26,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0f0ead5",
+   "id": "495b31e8",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b36a2ecf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
@@ -41,7 +49,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e92f0910",
+   "id": "2c98f073",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -50,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bf1299f6",
+   "id": "bc153e87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "069b19fb",
+   "id": "4910e54c",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -68,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c53ebc7e",
+   "id": "c4535c39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f8dcd6d",
+   "id": "d26ece75",
    "metadata": {},
    "source": [
     "Set figure properties specific to the problem"
@@ -87,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "829e26ef",
+   "id": "400b24b0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,7 +114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08dbaa1b",
+   "id": "72a807fd",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -115,7 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec6e44e6",
+   "id": "e2a354e5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,7 +132,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de3bef69",
+   "id": "859df4dd",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -133,7 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96f55121",
+   "id": "d2fa9eb9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +150,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7d17894",
+   "id": "173731b3",
    "metadata": {},
    "source": [
     "Model units"
@@ -151,7 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f4a1beb4",
+   "id": "87208381",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -161,7 +169,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "227979e0",
+   "id": "5155fa3c",
    "metadata": {},
    "source": [
     "Table"
@@ -170,7 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f008529d",
+   "id": "32a5c1da",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +210,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a759504e",
+   "id": "1bdab070",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -211,7 +219,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "788f86dc",
+   "id": "4efc34b7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,7 +232,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93023863",
+   "id": "df8a2cb7",
    "metadata": {},
    "source": [
     "parse parameter strings into tuples"
@@ -233,7 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b26cfa45",
+   "id": "d87dc7c5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -251,7 +259,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c99f80c",
+   "id": "53ab1e3a",
    "metadata": {},
    "source": [
     "Load active domain and create idomain array"
@@ -260,7 +268,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ceb9227c",
+   "id": "0a1e3cde",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,7 +279,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df50a2cf",
+   "id": "ffc5546e",
    "metadata": {},
    "source": [
     "Constant head boundary cells"
@@ -280,7 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d33fc8da",
+   "id": "f010a795",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -293,7 +301,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a3d3169",
+   "id": "1f8b6cce",
    "metadata": {},
    "source": [
     "Recharge boundary cells"
@@ -302,7 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5738a068",
+   "id": "9460a30a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -317,7 +325,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4c00edf7",
+   "id": "6f196c09",
    "metadata": {},
    "source": [
     "Well boundary cells"
@@ -326,7 +334,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3ee28cf7",
+   "id": "dff88020",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,7 +356,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2dbee575",
+   "id": "d3b553bf",
    "metadata": {},
    "source": [
     "Create interbed package data"
@@ -357,7 +365,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1491fe43",
+   "id": "9d55cdf0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -389,7 +397,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b8735531",
+   "id": "9d4eae47",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -398,7 +406,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "be996260",
+   "id": "e90fabcf",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -414,7 +422,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0555b483",
+   "id": "75ae1918",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -427,7 +435,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3cad119a",
+   "id": "c22fd715",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -437,7 +445,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, sim_name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -593,7 +601,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54e5048d",
+   "id": "85191e01",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -604,7 +612,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78bd0a41",
+   "id": "feeeabfa",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -617,7 +625,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e95a18af",
+   "id": "0411aa2b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -629,8 +637,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f622c6e5",
-   "metadata": {},
+   "id": "90df95eb",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "outputs": [],
    "source": [
     "@config.timeit\n",
@@ -646,8 +656,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8b5305fc",
-   "metadata": {},
+   "id": "514b6765",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "Function to get csub observations"
    ]
@@ -655,7 +667,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e45051d7",
+   "id": "46a1555b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -686,7 +698,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5ec3aa1",
+   "id": "36a0f78a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -697,7 +709,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02c27271",
+   "id": "b626c4de",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -719,7 +731,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3986a02d",
+   "id": "94aba15f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -730,7 +742,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97552372",
+   "id": "de18df5b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -748,7 +760,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74647a30",
+   "id": "5b98c893",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -759,7 +771,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b33488d4",
+   "id": "e7c7f1e0",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1027,7 +1039,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f3880d6",
+   "id": "b263f12f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1038,7 +1050,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "735cae0a",
+   "id": "7b5dc986",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1120,7 +1132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c396715",
+   "id": "e60e7517",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1208,7 +1220,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2c4e555",
+   "id": "35ae4d0f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1219,7 +1231,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62cf8f39",
+   "id": "bbfbf685",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1234,7 +1246,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81f7a0cc",
+   "id": "673b0471",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1250,7 +1262,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0a25fdc8",
+   "id": "07d7b636",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1268,27 +1280,34 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99ee1982",
+   "id": "2302dc62",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation()"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "576711b0",
+   "id": "19ef4d65",
    "metadata": {},
    "source": [
-    "### One-dimensional compaction in a three-dimensional flow field"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "06a13dae",
+   "id": "bdaef32b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation()"
+    "if __name__ == \"__main__\":\n",
+    "    # ### One-dimensional compaction in a three-dimensional flow field\n",
+    "\n",
+    "    simulation()"
    ]
   }
  ],

--- a/notebooks/ex-gwf-disvmesh.ipynb
+++ b/notebooks/ex-gwf-disvmesh.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "5078b819",
+   "id": "d9d8b1aa",
    "metadata": {},
    "source": [
     "## USG1DISV example\n",
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "995844f2",
+   "id": "87096657",
    "metadata": {},
    "source": [
     "### USG1DISV Problem Setup\n",
@@ -27,13 +27,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f9f12254",
+   "id": "c4e5df81",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c4c813e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import flopy.utils.cvfdutil\n",
     "import matplotlib.pyplot as plt\n",
@@ -45,7 +53,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92867f7d",
+   "id": "53440d1f",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -54,7 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a70feef9",
+   "id": "a044fbbe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +71,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2b0f3cb",
+   "id": "27cbaceb",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -72,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93c1239e",
+   "id": "16d550b7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +90,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0cb454db",
+   "id": "f0cdeb33",
    "metadata": {},
    "source": [
     "Set default figure properties"
@@ -91,7 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "514d2d13",
+   "id": "a77aee85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +108,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "68cfdcf6",
+   "id": "189920c6",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -109,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c5e2b711",
+   "id": "3fa0ad4c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8dffc343",
+   "id": "91a70389",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d2c013ca",
+   "id": "cdb8c36a",
    "metadata": {},
    "source": [
     "Model units"
@@ -138,7 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "276e2bd4",
+   "id": "10525bac",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,7 +156,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da99c9ea",
+   "id": "b589ddd0",
    "metadata": {},
    "source": [
     "Table USG1DISV Model Parameters"
@@ -157,7 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1a820046",
+   "id": "2c87c64c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +182,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f256095a",
+   "id": "0398599e",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file\n",
@@ -184,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fd5c47a6",
+   "id": "a5dbba54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +204,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be8a36fc",
+   "id": "03bc15b9",
    "metadata": {},
    "source": [
     "Parse strings into lists"
@@ -205,10 +213,8 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8bca26f9",
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "id": "b7e55a37",
+   "metadata": {},
    "outputs": [],
    "source": [
     "botm = [float(value) for value in botm_str.split(\",\")]"
@@ -216,8 +222,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73cc8f89",
-   "metadata": {},
+   "id": "6ad8b42b",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "create the disv grid"
    ]
@@ -225,7 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b1a77293",
+   "id": "ecec4132",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +275,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ece664d1",
+   "id": "0380fe5c",
    "metadata": {},
    "source": [
     "Load argus mesh and get disv grid properties"
@@ -276,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e5f30ba7",
+   "id": "54a46473",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -293,7 +301,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f36dccd1",
+   "id": "992ab9d4",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -302,7 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94743511",
+   "id": "92afb645",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,7 +322,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "faa86567",
+   "id": "ee7cec6c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -327,7 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b68350c6",
+   "id": "8c201740",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -337,7 +345,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, sim_name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -413,7 +421,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cfe83470",
+   "id": "e8aaf0ee",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -424,7 +432,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27b53dc4",
+   "id": "eff7720d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -437,7 +445,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d2a8e459",
+   "id": "7360bfdc",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -449,7 +457,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "551d6080",
+   "id": "e9b5bfca",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,14 +474,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "abb84720",
+   "id": "4c13abe5",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Function to plot the DISVMESH model results.\n",
     "#\n",
-    "\n",
-    "\n",
     "def plot_grid(idx, sim):\n",
     "    fs = USGSFigure(figure_type=\"map\", verbose=False)\n",
     "    sim_ws = os.path.join(ws, sim_name)\n",
@@ -499,7 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aacd4eca",
+   "id": "a8c7c375",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -559,7 +565,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f2c17175",
+   "id": "68b1eb06",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -575,7 +581,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b1dcf2c",
+   "id": "a796b5cd",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -591,7 +597,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aedc2a83",
+   "id": "8b72e068",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -606,29 +612,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a49069f3",
+   "id": "4c9a5484",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(0, silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "d98286bd",
+   "id": "adcb66de",
    "metadata": {},
    "source": [
-    "### DISVMESH Simulation\n",
-    "\n",
-    "Model grid and simulated heads in the DISVMESH model"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a816e7ef",
+   "id": "54930513",
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation(0)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### DISVMESH Simulation\n",
+    "    #\n",
+    "    # Model grid and simulated heads in the DISVMESH model\n",
+    "\n",
+    "    simulation(0)"
    ]
   }
  ],

--- a/notebooks/ex-gwf-drn-p01.ipynb
+++ b/notebooks/ex-gwf-drn-p01.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "4c4d65f6",
+   "id": "d6081b32",
    "metadata": {},
    "source": [
     "## Unsaturated Zone Flow (UZF) Package problem 2\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c3f111bc",
+   "id": "5e668e0a",
    "metadata": {},
    "source": [
     "### UZF Package Problem 2 Setup\n",
@@ -25,13 +25,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05c90ef8",
+   "id": "872b797c",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e779d7ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"
@@ -39,7 +47,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "09cfe005",
+   "id": "39f21084",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -48,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8df7ac8c",
+   "id": "19dc9ef8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +65,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11882dde",
+   "id": "b99b87ad",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -66,7 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "def29be9",
+   "id": "fe535f1d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b890fff5",
+   "id": "cca6828c",
    "metadata": {},
    "source": [
     "Set figure properties specific to the"
@@ -86,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76b02f5f",
+   "id": "9401ecee",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26944aea",
+   "id": "998c4eeb",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -105,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "afab12a5",
+   "id": "ab855d8c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d1534d6d",
+   "id": "741fa1fc",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -123,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83d48379",
+   "id": "c792a6fd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +140,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e7f9601",
+   "id": "ba57f296",
    "metadata": {},
    "source": [
     "Model units"
@@ -141,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "899147d4",
+   "id": "f2d530f8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -151,7 +159,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b11e39f7",
+   "id": "248f561c",
    "metadata": {},
    "source": [
     "Model parameters"
@@ -160,7 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50f34909",
+   "id": "1feefd9c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -178,7 +186,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fda61248",
+   "id": "da450a2e",
    "metadata": {},
    "source": [
     "Table UZF Package Problem 2 Model Parameters"
@@ -187,7 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6ab29cf5",
+   "id": "b2804fbb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +224,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9f727ef",
+   "id": "cedebbed",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -225,7 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b8cb5db2",
+   "id": "528137f5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,7 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "015d0d0a",
+   "id": "e9a614e9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +257,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "065b5af4",
+   "id": "7b0434bc",
    "metadata": {},
    "source": [
     "Load the idomain, top, bottom, and uzf/mvr arrays"
@@ -258,7 +266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f96ada45",
+   "id": "87d8b5b8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,7 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15f1b5a9",
+   "id": "1a1c0b24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +297,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4fa3a0f4",
+   "id": "ffe345ae",
    "metadata": {},
    "source": [
     "convert routing map to zero-based reach numbers"
@@ -298,7 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "687d91ba",
+   "id": "1a6cc357",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -307,7 +315,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "84052ad8",
+   "id": "f8b06893",
    "metadata": {},
    "source": [
     "Create hydraulic conductivity and specific yield"
@@ -316,7 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c3022049",
+   "id": "468bfacf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -330,7 +338,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc767f25",
+   "id": "0acf794d",
    "metadata": {},
    "source": [
     "Infiltration rates"
@@ -339,7 +347,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24738934",
+   "id": "0b1663f6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -361,7 +369,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93be2076",
+   "id": "7741fa16",
    "metadata": {},
    "source": [
     "Pumping rates"
@@ -370,7 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "06dfd42a",
+   "id": "3964a3fd",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -394,7 +402,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f01ea8c1",
+   "id": "d755dd34",
    "metadata": {},
    "source": [
     "### Create UZF Package Problem 2 Model Boundary Conditions\n",
@@ -405,7 +413,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e9530a5c",
+   "id": "a739b468",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -417,7 +425,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dccb1ff3",
+   "id": "48544fbf",
    "metadata": {},
    "source": [
     "Well boundary conditions"
@@ -426,7 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6a784d81",
+   "id": "655c9c3a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,7 +460,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4d606d1",
+   "id": "f3403807",
    "metadata": {},
    "source": [
     "Drain boundary"
@@ -461,7 +469,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f2a195c",
+   "id": "b7b98988",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -484,7 +492,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a16774ef",
+   "id": "d9266c2a",
    "metadata": {},
    "source": [
     "UZF package"
@@ -493,7 +501,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8fefcb5b",
+   "id": "7db8e95c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -525,7 +533,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "065fb4a8",
+   "id": "6beeb677",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -554,7 +562,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0afb2fee",
+   "id": "91465e7e",
    "metadata": {},
    "source": [
     "SFR Package"
@@ -563,7 +571,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a92a986",
+   "id": "ce194d9a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1150,7 +1158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78383558",
+   "id": "16ad37e9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1197,7 +1205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "935630a3",
+   "id": "d2a92a0e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1207,7 +1215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "03708594",
+   "id": "6f236978",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1235,7 +1243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c5ec3d3",
+   "id": "3476fcb1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1248,7 +1256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5d5637bb",
+   "id": "d5ad3ef8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1274,7 +1282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f5549945",
+   "id": "a142d0a1",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1301,7 +1309,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e1ba4fa9",
+   "id": "1e1ea441",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -1310,7 +1318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce716a4b",
+   "id": "9a280cbb",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1324,7 +1332,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bd8fc341",
+   "id": "a4f11347",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1337,7 +1345,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45e9e8c5",
+   "id": "4b406b79",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1347,7 +1355,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -1474,7 +1482,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a67d13ba",
+   "id": "23142eae",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1485,7 +1493,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fcc64a81",
+   "id": "e6f81d5d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1498,7 +1506,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d83aff2",
+   "id": "41d01f77",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1510,7 +1518,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ed815200",
+   "id": "8e288d80",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1528,7 +1536,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be82cc24",
+   "id": "2755ac3f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1539,7 +1547,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e5335b26",
+   "id": "d3947751",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1571,7 +1579,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b37d3c55",
+   "id": "16fdeacd",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1582,7 +1590,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d61cbc77",
+   "id": "a9d2372e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1701,7 +1709,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8f912cf3",
+   "id": "6ee1577c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1734,7 +1742,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "94c72f50",
+   "id": "e6bc3ad7",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1745,7 +1753,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5b3ccdb6",
+   "id": "50e2ef95",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1759,7 +1767,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60f8bf88",
+   "id": "2884d6d2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1775,7 +1783,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "afe49718",
+   "id": "483a7c6a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1794,50 +1802,43 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3341059b",
+   "id": "29333b74",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_and_plot():\n",
+    "    simulation(0, silent=False)\n",
+    "    simulation(1, silent=False)\n",
+    "    plot_results(silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "79dfa72c",
+   "id": "b9bdfe37",
    "metadata": {},
    "source": [
-    "### UZF Package Problem 2 Simulation"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f2b775f",
+   "id": "d55ee73e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# drain used to simulate discharge to the land surface\n",
-    "simulation(0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0bb8b8f6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# uzf used to simulate discharge to the land surface\n",
-    "simulation(1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bdd1028c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# plot the results\n",
-    "plot_results()"
+    "if __name__ == \"__main__\":\n",
+    "    # ### UZF Package Problem 2 Simulation\n",
+    "\n",
+    "    # drain used to simulate discharge to the land surface\n",
+    "    simulation(0)\n",
+    "\n",
+    "    # uzf used to simulate discharge to the land surface\n",
+    "    simulation(1)\n",
+    "\n",
+    "    # plot the results\n",
+    "    plot_results()"
    ]
   }
  ],

--- a/notebooks/ex-gwf-fhb.ipynb
+++ b/notebooks/ex-gwf-fhb.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "757a1f48",
+   "id": "4006c165",
    "metadata": {},
    "source": [
     "## FHB example\n",
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1a67c39",
+   "id": "8024c07e",
    "metadata": {},
    "source": [
     "### FHB Problem Setup\n",
@@ -26,13 +26,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f6a1175",
+   "id": "c7c9c601",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c52a3f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"
@@ -40,7 +48,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f72c8116",
+   "id": "b7b72001",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -49,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9867409a",
+   "id": "83fdd51a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +66,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a93e1738",
+   "id": "25584133",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -67,7 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f0d1147e",
+   "id": "c12ace9f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a883a468",
+   "id": "ae24c8a5",
    "metadata": {},
    "source": [
     "Set default figure properties"
@@ -86,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66ea4bd4",
+   "id": "4fca210e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10a2d49d",
+   "id": "9a7d8916",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -104,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7ddc761",
+   "id": "103a7828",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d900f6fe",
+   "id": "2cbd8139",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -122,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3d527a83",
+   "id": "d45105ea",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fb017314",
+   "id": "2025ea2c",
    "metadata": {},
    "source": [
     "Model units"
@@ -140,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39cf0f10",
+   "id": "6b65c37d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9467711",
+   "id": "11178810",
    "metadata": {},
    "source": [
     "Table FHB Model Parameters"
@@ -159,7 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "791834de",
+   "id": "754d1938",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a8b5064",
+   "id": "93539610",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file\n",
@@ -191,7 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ba9a2e30",
+   "id": "6aefb475",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +211,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "09abaab7",
+   "id": "8dc8b47c",
    "metadata": {},
    "source": [
     "parse parameter strings into tuples"
@@ -212,7 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bb342ca8",
+   "id": "8c75b896",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -223,7 +231,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53678a66",
+   "id": "a79802a5",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -232,7 +240,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b5ec2fe6",
+   "id": "1b2feaf2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "824f1ae3",
+   "id": "124b8a94",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -257,7 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5639a522",
+   "id": "0ab64a55",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -267,7 +275,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, sim_name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -368,7 +376,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1436a72",
+   "id": "83a6dd37",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -379,7 +387,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f448cdf9",
+   "id": "6a327761",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -392,7 +400,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1599ac19",
+   "id": "0ce01620",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -404,7 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b2afc86",
+   "id": "b9c0c0e3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,14 +429,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0560faea",
+   "id": "397d5325",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Function to plot the FHB model results.\n",
     "#\n",
-    "\n",
-    "\n",
     "def plot_grid(sim):\n",
     "    fs = USGSFigure(figure_type=\"map\", verbose=False)\n",
     "    sim_ws = os.path.join(ws, sim_name)\n",
@@ -455,7 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7cb0c0f3",
+   "id": "291df36b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -492,7 +498,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0edd34a8",
+   "id": "9a2c6707",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -507,7 +513,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79a4884c",
+   "id": "924622ce",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -523,7 +529,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05a87546",
+   "id": "90831f24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,29 +544,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11c88af6",
+   "id": "d921ce23",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "f5cc378a",
+   "id": "15a2626e",
    "metadata": {},
    "source": [
-    "### FHB Simulation\n",
-    "\n",
-    "Model grid and simulation results"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "08c04039",
+   "id": "bd4379ec",
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation()"
+    "if __name__ == \"__main__\":\n",
+    "    # ### FHB Simulation\n",
+    "    #\n",
+    "    # Model grid and simulation results\n",
+    "\n",
+    "    simulation()"
    ]
   }
  ],

--- a/notebooks/ex-gwf-hani.ipynb
+++ b/notebooks/ex-gwf-hani.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "daa93e6f",
+   "id": "f7a20e7b",
    "metadata": {},
    "source": [
     "## Hani example\n",
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4390472c",
+   "id": "0bffbb43",
    "metadata": {},
    "source": [
     "### Hani Problem Setup\n",
@@ -26,13 +26,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7b5b84a",
+   "id": "ed33f2a8",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ae74d1e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import flopy.utils.cvfdutil\n",
     "import matplotlib.pyplot as plt\n",
@@ -41,7 +49,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "320f84a0",
+   "id": "b0dad088",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -50,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fbcf1827",
+   "id": "3cb5b62d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5042cbf",
+   "id": "acd6008e",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -68,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d814e389",
+   "id": "b20f4a44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83f5ded2",
+   "id": "c07f4827",
    "metadata": {},
    "source": [
     "Set default figure properties"
@@ -87,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d9bc92d6",
+   "id": "5cfea9a3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db775907",
+   "id": "c1561d48",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -105,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1b22c322",
+   "id": "61351ab0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fbcf9583",
+   "id": "6ed83db4",
    "metadata": {},
    "source": [
     "Model units"
@@ -123,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84c5dec8",
+   "id": "19765999",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d718189",
+   "id": "1680a954",
    "metadata": {},
    "source": [
     "Scenario parameters"
@@ -142,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48e73594",
+   "id": "c7309870",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,7 +163,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c280f0dc",
+   "id": "cf058d78",
    "metadata": {},
    "source": [
     "Table Hani Model Parameters"
@@ -164,7 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "813a7831",
+   "id": "df35c2c1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +193,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25cb8823",
+   "id": "5d1031d4",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file\n",
@@ -195,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "533bbcd0",
+   "id": "1cf4e94a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6efbe397",
+   "id": "fe49c36b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -220,7 +228,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c1756bfb",
+   "id": "859259fd",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -233,7 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a33a160",
+   "id": "45fe562a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -243,7 +251,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, sim_name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -305,7 +313,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83d31b92",
+   "id": "8b1dacd4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -316,7 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e6f3263c",
+   "id": "671bfc40",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -329,7 +337,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4d19fd43",
+   "id": "d5eacd57",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -341,7 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5ee71f16",
+   "id": "e580bc97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -358,14 +366,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c86ed723",
+   "id": "4c83fda4",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Function to plot the Hani model results.\n",
     "#\n",
-    "\n",
-    "\n",
     "def plot_grid(idx, sim):\n",
     "    fs = USGSFigure(figure_type=\"map\", verbose=False)\n",
     "    sim_name = list(parameters.keys())[idx]\n",
@@ -393,7 +399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "728dc838",
+   "id": "1219ee7c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -427,7 +433,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8add2bf9",
+   "id": "d26cc2e3",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -443,7 +449,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c450fa4c",
+   "id": "a19eb77e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -459,7 +465,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eb0bdf3d",
+   "id": "06678f21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -476,65 +482,66 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3cfad468",
+   "id": "f7f06079",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(0, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68c2d46b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_02():\n",
+    "    simulation(1, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8950eb57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_03():\n",
+    "    simulation(2, silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "664ae6a1",
+   "id": "056c39bb",
    "metadata": {},
    "source": [
-    "### Hani Simulation\n",
+    "nosetest end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8137d96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    # ### Hani Simulation\n",
+    "    #\n",
+    "    # Simulated heads in the Hani model with anisotropy in x direction.\n",
     "\n",
-    "Simulated heads in the Hani model with anisotropy in x direction."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cf26b939",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "16d930b0",
-   "metadata": {},
-   "source": [
-    "Simulated heads in the Hani model with anisotropy in y direction."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1940674e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "673909df",
-   "metadata": {},
-   "source": [
-    "Simulated heads in the Hani model with anisotropy rotated 15 degrees."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2535f680",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(2)"
+    "    simulation(0)\n",
+    "\n",
+    "    # Simulated heads in the Hani model with anisotropy in y direction.\n",
+    "\n",
+    "    simulation(1)\n",
+    "\n",
+    "    # Simulated heads in the Hani model with anisotropy rotated 15 degrees.\n",
+    "\n",
+    "    simulation(2)"
    ]
   }
  ],

--- a/notebooks/ex-gwf-lak-p01.ipynb
+++ b/notebooks/ex-gwf-lak-p01.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a5330612",
+   "id": "4310e083",
    "metadata": {},
    "source": [
     "## Lake package (LAK) Package problem 1\n",
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "144befc7",
+   "id": "889bbb3f",
    "metadata": {},
    "source": [
     "### LAK Package Problem 1 Setup\n",
@@ -24,13 +24,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2eb4f120",
+   "id": "ca73e242",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af205d26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
@@ -39,7 +47,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a7c9e7db",
+   "id": "b044a0ff",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -48,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "538edf57",
+   "id": "0255d529",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +65,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e967b34c",
+   "id": "a50acc7a",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -66,7 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f378053",
+   "id": "bc140e56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "593d9991",
+   "id": "e9c423a5",
    "metadata": {},
    "source": [
     "Set figure properties specific to the"
@@ -85,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e8569aa2",
+   "id": "32858787",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8766199a",
+   "id": "ebbd4d10",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -104,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd93ce08",
+   "id": "93287e58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9bbb61cc",
+   "id": "151b5d60",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -122,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a7c5a625",
+   "id": "c2afd686",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20927fab",
+   "id": "14594c9d",
    "metadata": {},
    "source": [
     "Model units"
@@ -140,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d652ed6",
+   "id": "ef86822f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85239f9b",
+   "id": "8c20c3e9",
    "metadata": {},
    "source": [
     "Table LAK Package Problem 1 Model Parameters"
@@ -159,7 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5e215bcc",
+   "id": "7f039b0e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +194,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28ac1a2a",
+   "id": "c47e0dbe",
    "metadata": {},
    "source": [
     "parse parameter strings into tuples"
@@ -195,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d3fef644",
+   "id": "60a0f63b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +213,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4f31d47",
+   "id": "9eacf280",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -214,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6451c8da",
+   "id": "bb23b2de",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,7 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a259e88a",
+   "id": "7b40807e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a153d9c3",
+   "id": "f0e6e954",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +296,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67733066",
+   "id": "3603a0e1",
    "metadata": {},
    "source": [
     "Create the array defining the lake location"
@@ -297,7 +305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3bd25f55",
+   "id": "5c12df3d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +317,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73528480",
+   "id": "56e2fd7e",
    "metadata": {},
    "source": [
     "create linearly varying evapotranspiration surface"
@@ -318,7 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c677c945",
+   "id": "f49fc975",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -336,7 +344,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b29de41a",
+   "id": "1b01f1b6",
    "metadata": {},
    "source": [
     "### Create LAK Package Problem 1 Model Boundary Conditions\n",
@@ -347,7 +355,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca81d5cb",
+   "id": "c8e25312",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +367,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a5e71b5c",
+   "id": "53cc94b4",
    "metadata": {},
    "source": [
     "LAK Package"
@@ -368,7 +376,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9c27d8b4",
+   "id": "846842f9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -380,7 +388,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d24e4603",
+   "id": "73795e74",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -389,7 +397,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49ad1fe8",
+   "id": "778f5cd1",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -403,7 +411,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40ceee15",
+   "id": "c03d68c5",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -416,7 +424,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37716409",
+   "id": "4e69aea8",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -426,7 +434,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, sim_name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -527,7 +535,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2970271f",
+   "id": "f54f46cd",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -538,7 +546,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e1e90f33",
+   "id": "8617bcc4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -551,7 +559,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "77373eb9",
+   "id": "c129e339",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -563,7 +571,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b8c592c9",
+   "id": "bf4f157c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -581,7 +589,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d03e24e",
+   "id": "6d5b8c40",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -592,7 +600,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66b5dace",
+   "id": "fac9cfe3",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -797,7 +805,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2927aa1",
+   "id": "68168956",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -808,7 +816,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bb09dc2d",
+   "id": "2b0cff21",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -890,7 +898,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12e67d9e",
+   "id": "76bcaeb5",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -901,7 +909,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dc19afa1",
+   "id": "a9f69b72",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -918,7 +926,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70961781",
+   "id": "87ba84a6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -934,7 +942,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d4dc08a5",
+   "id": "d0b5c020",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -953,27 +961,35 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "751537aa",
+   "id": "4254cf0b",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "1713af3a",
+   "id": "f00a6de7",
    "metadata": {},
    "source": [
-    "### LAK Package Problem 1 Simulation\n"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b6e5828",
+   "id": "3c98c979",
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation()"
+    "if __name__ == \"__main__\":\n",
+    "    # ### LAK Package Problem 1 Simulation\n",
+    "    #\n",
+    "\n",
+    "    simulation()"
    ]
   }
  ],

--- a/notebooks/ex-gwf-lak-p02.ipynb
+++ b/notebooks/ex-gwf-lak-p02.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "2ff0376a",
+   "id": "34d35df7",
    "metadata": {},
    "source": [
     "## Lake package (LAK) Package problem 2\n",
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd488ef5",
+   "id": "7e28bc0a",
    "metadata": {},
    "source": [
     "### LAK Package problem 2 Setup\n",
@@ -24,13 +24,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7bf57834",
+   "id": "24697ca5",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a2142b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
@@ -39,7 +47,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f0d1ac1",
+   "id": "06caeacd",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -48,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49e4c151",
+   "id": "fa0e09b5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +65,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87ac5f7f",
+   "id": "338f09a1",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -66,7 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c55c553",
+   "id": "ca5169b8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52d298a6",
+   "id": "eb2976d1",
    "metadata": {},
    "source": [
     "Set figure properties specific to the"
@@ -85,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e3d6b7e0",
+   "id": "4d93e182",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19012774",
+   "id": "3fe76d1a",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -104,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01b40e4e",
+   "id": "4c686d98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28ec3672",
+   "id": "205c44ea",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -122,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7e0477c8",
+   "id": "c7897d62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9843bac0",
+   "id": "0484c8ff",
    "metadata": {},
    "source": [
     "Model units"
@@ -140,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a152d87",
+   "id": "155cebc0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08be3262",
+   "id": "9379c4a3",
    "metadata": {},
    "source": [
     "Table LAK Package problem 2 Model Parameters"
@@ -159,7 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "803f6c71",
+   "id": "7404468b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +194,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3e7fa29e",
+   "id": "92858668",
    "metadata": {},
    "source": [
     "parse parameter strings into tuples"
@@ -195,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "828cbb84",
+   "id": "b4383d2d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +212,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3e83baf7",
+   "id": "7bb01150",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -213,7 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf534817",
+   "id": "f39a0220",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -223,7 +231,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7da80526",
+   "id": "b493ce34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -285,7 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d9608b53",
+   "id": "047f79a3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,7 +305,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58101f5f",
+   "id": "7c7f81d5",
    "metadata": {},
    "source": [
     "Load the idomain arrays"
@@ -306,7 +314,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b5c281f",
+   "id": "7e6aaeea",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,7 +328,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59725620",
+   "id": "073d28bc",
    "metadata": {},
    "source": [
     "create linearly varying evapotranspiration surface"
@@ -329,7 +337,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50234c38",
+   "id": "65a48879",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -347,7 +355,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ada1af6c",
+   "id": "6d5c99a4",
    "metadata": {},
    "source": [
     "### Create LAK Package problem 2 Model Boundary Conditions\n",
@@ -358,7 +366,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "444e28e4",
+   "id": "ca850f01",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,7 +378,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5acf138d",
+   "id": "c7cfdf3a",
    "metadata": {},
    "source": [
     "LAK Package"
@@ -379,7 +387,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e07b0220",
+   "id": "fbce3703",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -390,7 +398,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c6edcf2",
+   "id": "4d6ab1e3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,7 +411,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "03df33a0",
+   "id": "0c07c5e4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -417,7 +425,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86587b0a",
+   "id": "1d2ac86a",
    "metadata": {},
    "source": [
     "SFR package"
@@ -426,7 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d31bed5",
+   "id": "366e01e4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -789,7 +797,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b98db44f",
+   "id": "2b9ec779",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -822,7 +830,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e12e9dda",
+   "id": "9e8e2a18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -831,7 +839,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5e40022b",
+   "id": "fb2b57bb",
    "metadata": {},
    "source": [
     "MVR package"
@@ -840,7 +848,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b799486",
+   "id": "232008d4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -853,7 +861,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9c2d19c0",
+   "id": "5a1d690a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -867,7 +875,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53fe4fb0",
+   "id": "449e072a",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -876,7 +884,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f2967504",
+   "id": "58ac37f2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -890,7 +898,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d103f454",
+   "id": "719ceabc",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -903,7 +911,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bff236c0",
+   "id": "00523042",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -913,7 +921,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, sim_name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -1043,7 +1051,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38c04024",
+   "id": "f3c7cb82",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1054,7 +1062,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c2290261",
+   "id": "d2af9b87",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1067,7 +1075,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9852b2f7",
+   "id": "98b1d959",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1079,7 +1087,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca732ceb",
+   "id": "7aea9875",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1097,7 +1105,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c510d110",
+   "id": "4381acda",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1108,7 +1116,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "be2058db",
+   "id": "777c59f7",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1383,7 +1391,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eb68e72f",
+   "id": "f750542d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1394,7 +1402,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b212e17f",
+   "id": "93510f20",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1511,7 +1519,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8016c9db",
+   "id": "d055ac6f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1522,7 +1530,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e33633c",
+   "id": "ba0fb3cd",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1539,7 +1547,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e390f09c",
+   "id": "e064e69f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1555,7 +1563,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8ae54ac2",
+   "id": "8029aef4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1574,27 +1582,35 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d9043717",
+   "id": "870eea97",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "a0dba99e",
+   "id": "baafe468",
    "metadata": {},
    "source": [
-    "### LAK Package problem 2 Simulation\n"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "454cdea9",
+   "id": "324101dd",
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation()"
+    "if __name__ == \"__main__\":\n",
+    "    # ### LAK Package problem 2 Simulation\n",
+    "    #\n",
+    "\n",
+    "    simulation()"
    ]
   }
  ],

--- a/notebooks/ex-gwf-lgr.ipynb
+++ b/notebooks/ex-gwf-lgr.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "26174e82",
+   "id": "9c101d64",
    "metadata": {},
    "source": [
     "## LGR example with MVR for SFR between two models\n",
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96a785cf",
+   "id": "c3b4a533",
    "metadata": {},
    "source": [
     "### MODFLOW 6 LGR Problem Setup"
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8bf8fe65",
+   "id": "3ba1d415",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -29,7 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e8e7ee9a",
+   "id": "4861f20a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "107824d6",
+   "id": "e5b7f9aa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71e9ea89",
+   "id": "cee66f58",
    "metadata": {},
    "source": [
     "Imports"
@@ -58,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d11dcb00",
+   "id": "01a3e9cf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,18 +74,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9fa42a3a",
+   "id": "58883c7b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mf2005_exe\n",
-    "exe_name_mt = config.mt3dms_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mf2005\"\n",
+    "exe_name_mt = \"mt3dms\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3983d57d",
+   "id": "9a4cfda8",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -94,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95dab4c5",
+   "id": "3708aa79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2740d9b9",
+   "id": "d3193557",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -112,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2b7940d0",
+   "id": "4ecc52fe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2f6ba16",
+   "id": "a6d63df6",
    "metadata": {},
    "source": [
     "Model units"
@@ -131,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "730733f6",
+   "id": "40338482",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "746bcea4",
+   "id": "eebb0440",
    "metadata": {},
    "source": [
     "Table"
@@ -150,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c2dec5a2",
+   "id": "10d19aa9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +169,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80cd785b",
+   "id": "bd9dbc6a",
    "metadata": {},
    "source": [
     "Additional model input preparation\n",
@@ -179,7 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2dae3047",
+   "id": "5e6e869c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,7 +194,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6858d045",
+   "id": "1eaa68c5",
    "metadata": {},
    "source": [
     "Further parent model grid discretization"
@@ -203,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ecfbc80e",
+   "id": "687f2f70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "237bbae8",
+   "id": "10d5e511",
    "metadata": {},
    "source": [
     "Solver settings"
@@ -227,7 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f47e1551",
+   "id": "a753378e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,7 +237,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95730981",
+   "id": "d87e7386",
    "metadata": {},
    "source": [
     "Prepping input for SFR package for parent model\n",
@@ -247,7 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a22617cf",
+   "id": "012aa22d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -275,7 +275,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4197c2ad",
+   "id": "1a11a4d3",
    "metadata": {},
    "source": [
     "Package_data information"
@@ -284,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30774684",
+   "id": "d2bce22d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -384,7 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dda4be84",
+   "id": "6395ae68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -393,7 +393,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86804c63",
+   "id": "59583324",
    "metadata": {},
    "source": [
     "Next, set up SFR input for the child model\n",
@@ -406,7 +406,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "08f8a5db",
+   "id": "856daede",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,7 +422,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "555539b1",
+   "id": "728b248a",
    "metadata": {},
    "source": [
     "Package_data information"
@@ -431,7 +431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61bfd8d8",
+   "id": "20f0c2ff",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -531,7 +531,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e8c16a9e",
+   "id": "21eb8640",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -748,7 +748,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7bc7d427",
+   "id": "bd2e6798",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -759,7 +759,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "03adc39b",
+   "id": "af982128",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -772,7 +772,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "947f8203",
+   "id": "effa93eb",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1091,7 +1091,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "861a9927",
+   "id": "e4ea0f23",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1102,7 +1102,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29bc443e",
+   "id": "fefd6f61",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1115,7 +1115,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0da950f3",
+   "id": "583e40eb",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1126,7 +1126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6cf07da3",
+   "id": "3d030f30",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1145,7 +1145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9e47da12",
+   "id": "7a6e5265",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1156,7 +1156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0a1673b5",
+   "id": "cfdde59c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1390,7 +1390,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4c539cc4",
+   "id": "0f7107e1",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1406,7 +1406,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ffadc7b1",
+   "id": "cafcadbd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1422,29 +1422,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27078fdf",
+   "id": "cb127350",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "f79b2497",
+   "id": "185fefb8",
    "metadata": {},
    "source": [
-    "### Mehl and Hill (2013) results\n",
-    "\n",
-    "Two-dimensional transport in a uniform flow field"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c9718eab",
+   "id": "9114755d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(0)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Mehl and Hill (2013) results\n",
+    "    #\n",
+    "    # Two-dimensional transport in a uniform flow field\n",
+    "\n",
+    "    scenario(0)"
    ]
   }
  ],

--- a/notebooks/ex-gwf-lgrv.ipynb
+++ b/notebooks/ex-gwf-lgrv.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "defda0c4",
+   "id": "7a4b6eee",
    "metadata": {},
    "source": [
     "## LGRV example\n",
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b3dfa297",
+   "id": "3c549c65",
    "metadata": {},
    "source": [
     "### LGRV Problem Setup\n",
@@ -24,13 +24,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "296a2c16",
+   "id": "7b5334d5",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2e2817c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import flopy.utils.lgrutil\n",
     "import matplotlib.pyplot as plt\n",
@@ -39,7 +47,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1a6dcf7a",
+   "id": "b0280214",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -48,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6640e7d3",
+   "id": "2a3ac180",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +65,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42380375",
+   "id": "254a76f3",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -66,7 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ba8ef62",
+   "id": "d6234892",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fd35e45a",
+   "id": "aa72cedd",
    "metadata": {},
    "source": [
     "Set default figure properties"
@@ -85,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76f61630",
+   "id": "883c1f98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +102,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5e467d5",
+   "id": "8af6ddcc",
    "metadata": {},
    "source": [
     "Base simulation and data workspace"
@@ -103,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f18f800b",
+   "id": "b277c7a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36074efb",
+   "id": "b7eeed50",
    "metadata": {},
    "source": [
     "Model units"
@@ -122,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "085d4cf3",
+   "id": "89188094",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +140,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c3ebd20",
+   "id": "f942d6aa",
    "metadata": {},
    "source": [
     "Scenario parameters"
@@ -141,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c5972e75",
+   "id": "38abd1d2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aa5b0e36",
+   "id": "9c416bb5",
    "metadata": {},
    "source": [
     "Table LGRV Model Parameters"
@@ -163,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b1e71eda",
+   "id": "d16fc146",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "00b15d08",
+   "id": "94d361f9",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file\n",
@@ -199,7 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b464145",
+   "id": "dfee3c32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,7 +219,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "890ab6ef",
+   "id": "760ed847",
    "metadata": {},
    "source": [
     "load data files and process into arrays"
@@ -220,7 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7b8a2880",
+   "id": "7f397431",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7cc36781",
+   "id": "fbb653a4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +271,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95965c5f",
+   "id": "edbca64c",
    "metadata": {},
    "source": [
     "Define model extent and child model extent"
@@ -272,7 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cbde6ec1",
+   "id": "c4779ace",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e75f9b7",
+   "id": "af79df3f",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -300,7 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01706a18",
+   "id": "c45c4011",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +320,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37dccb14",
+   "id": "eff4568f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -325,7 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4bcd57b7",
+   "id": "3a4362e1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -338,7 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48ba4cab",
+   "id": "7c66da6b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -356,7 +364,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f8153711",
+   "id": "286e8dcd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -382,7 +390,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17603392",
+   "id": "4e437123",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -427,14 +435,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87e76dcb",
+   "id": "d245f899",
    "metadata": {},
    "outputs": [],
    "source": [
     "def build_lgr_model(sim_name):\n",
     "    sim_ws = os.path.join(ws, sim_name)\n",
     "    sim = flopy.mf6.MFSimulation(\n",
-    "        sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "        sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "    )\n",
     "    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "    flopy.mf6.ModflowIms(\n",
@@ -500,7 +508,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5754c1d3",
+   "id": "0f49f0ef",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -531,7 +539,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1353f52b",
+   "id": "235b23f6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -560,7 +568,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "668043c3",
+   "id": "c75c4c90",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -581,7 +589,7 @@
     "        if sim is None:\n",
     "            sim_ws = os.path.join(ws, sim_name)\n",
     "            sim = flopy.mf6.MFSimulation(\n",
-    "                sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "                sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "            )\n",
     "            flopy.mf6.ModflowTdis(\n",
     "                sim, nper=nper, perioddata=tdis_ds, time_units=time_units\n",
@@ -676,7 +684,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a44d2a90",
+   "id": "d0454c30",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -687,7 +695,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a75031a2",
+   "id": "e518bc81",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -701,7 +709,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32ac2202",
+   "id": "879c9687",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -713,7 +721,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57914ee0",
+   "id": "7edc174c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -731,14 +739,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74b6dc2c",
+   "id": "b5623cf0",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Function to plot the LGRV model results.\n",
     "#\n",
-    "\n",
-    "\n",
     "def plot_grid(sim):\n",
     "    print(f\"Plotting grid for {sim.name}...\")\n",
     "    fs = USGSFigure(figure_type=\"map\", verbose=False)\n",
@@ -802,7 +808,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43172301",
+   "id": "3b664bbe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -837,7 +843,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce021833",
+   "id": "6ec08b7b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -899,7 +905,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4f22dbb2",
+   "id": "e541e782",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -915,7 +921,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f31b9e8",
+   "id": "fe14db5f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -931,7 +937,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bfc09adb",
+   "id": "e0903fe6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -954,65 +960,66 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7f6a348",
+   "id": "8622883e",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(0, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a85a500",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_02():\n",
+    "    simulation(1, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10950541",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_03():\n",
+    "    simulation(2, silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "99aef0fb",
+   "id": "d289c9d9",
    "metadata": {},
    "source": [
-    "### LGRV Simulation\n",
+    "nosetest end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bdbe628e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    # ### LGRV Simulation\n",
+    "    #\n",
+    "    # Global Refined Model\n",
     "\n",
-    "Global Refined Model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e9f37d23",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "910a994a",
-   "metadata": {},
-   "source": [
-    "Global Coarse Model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e4040d57",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4d8c4845",
-   "metadata": {},
-   "source": [
-    "Locally Refined Grid Model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b4d35627",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(2)"
+    "    simulation(0)\n",
+    "\n",
+    "    # Global Coarse Model\n",
+    "\n",
+    "    simulation(1)\n",
+    "\n",
+    "    # Locally Refined Grid Model\n",
+    "\n",
+    "    simulation(2)"
    ]
   }
  ],

--- a/notebooks/ex-gwf-maw-p01.ipynb
+++ b/notebooks/ex-gwf-maw-p01.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "14663fd0",
+   "id": "e4e3202f",
    "metadata": {},
    "source": [
     "## Neville-Tonkin Multi-Aquifer Well Problem,\n",
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fffda107",
+   "id": "25048471",
    "metadata": {},
    "source": [
     "### Neville-Tonkin MAW Problem Setup\n",
@@ -24,13 +24,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e4ed667d",
+   "id": "8d25a200",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5869cc08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
@@ -39,7 +47,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "882b7bd6",
+   "id": "3be27d44",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -48,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "faf31ef1",
+   "id": "2d46993f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +65,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff59f1ae",
+   "id": "331b7b6f",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -66,7 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0daa8e2e",
+   "id": "56635740",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d143c39a",
+   "id": "a579efcc",
    "metadata": {},
    "source": [
     "Set figure properties specific to the"
@@ -85,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "08e4e684",
+   "id": "82eea462",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f106a4bf",
+   "id": "67e4c11c",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -104,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73e82d38",
+   "id": "3c30fc94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2bb83bd3",
+   "id": "d492f475",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -122,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cfaec0ff",
+   "id": "f5d407b3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f52f7b98",
+   "id": "5de5d48c",
    "metadata": {},
    "source": [
     "Model units"
@@ -140,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2634d011",
+   "id": "45da9335",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fc25843b",
+   "id": "01374fda",
    "metadata": {},
    "source": [
     "Scenario parameters"
@@ -159,7 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ad73168",
+   "id": "2b3802f1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +183,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d6700e9",
+   "id": "daf2a10d",
    "metadata": {},
    "source": [
     "Table Neville-Tonkin MAW Problem Model Parameters"
@@ -184,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca3a7b22",
+   "id": "2c7fc312",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +213,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed661844",
+   "id": "30104721",
    "metadata": {},
    "source": [
     "parse parameter strings into tuples"
@@ -214,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a181681a",
+   "id": "a10ff733",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,7 +232,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee2abc42",
+   "id": "e53e4e74",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -233,7 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2926ddd3",
+   "id": "15030f61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +250,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7847a24",
+   "id": "f32e419e",
    "metadata": {},
    "source": [
     "Define dimensions"
@@ -251,7 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a81eb056",
+   "id": "2924446e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,7 +270,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eae35923",
+   "id": "752ac9b5",
    "metadata": {},
    "source": [
     "create idomain"
@@ -271,7 +279,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19629de4",
+   "id": "35f087bd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -290,7 +298,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa8f3354",
+   "id": "88897c15",
    "metadata": {},
    "source": [
     "### Create Neville-Tonkin MAW Problem Model Boundary Conditions"
@@ -298,7 +306,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c5bd75f",
+   "id": "cd5f1483",
    "metadata": {},
    "source": [
     "MAW Package"
@@ -307,7 +315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b6a90f4a",
+   "id": "ef37bba3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3d4ecaa2",
+   "id": "fa9ca8d6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,7 +336,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0173bb1",
+   "id": "e7443798",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -342,7 +350,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "294ed4d1",
+   "id": "dbb5d8fa",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -351,7 +359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67dbb144",
+   "id": "50139015",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -365,7 +373,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "484a5042",
+   "id": "bce8c253",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -378,7 +386,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18fcf7d6",
+   "id": "123cc330",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -388,7 +396,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -459,7 +467,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87d2a777",
+   "id": "04197969",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -470,7 +478,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4fe013a6",
+   "id": "f8dbfe2c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -483,7 +491,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ebf36ce9",
+   "id": "66e4a732",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -495,7 +503,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "04c4e15a",
+   "id": "15c9ef05",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -513,7 +521,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fbdd5b47",
+   "id": "e27bb3b1",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -524,7 +532,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36ef7b30",
+   "id": "84311774",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -637,7 +645,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4833fe8a",
+   "id": "316fd405",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -648,7 +656,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e4ea802",
+   "id": "e95af62b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -742,7 +750,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c5acc9d4",
+   "id": "afa19765",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -753,7 +761,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f9a0f73",
+   "id": "62fe8d79",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -767,7 +775,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca76f5c3",
+   "id": "9d1115a0",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -783,7 +791,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e6b6132",
+   "id": "4a9fbb82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -802,65 +810,66 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aba2feea",
+   "id": "ae49ce30",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(idx=0, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b489ec22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_02():\n",
+    "    simulation(idx=1, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c43b71a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_plot():\n",
+    "    plot_results()"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "57f603d4",
+   "id": "068049d6",
    "metadata": {},
    "source": [
-    "### Neville-Tonkin MAW Problem Simulation\n",
+    "nosetest end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09db4111",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    # ### Neville-Tonkin MAW Problem Simulation\n",
+    "    #\n",
+    "    # No pumping case\n",
     "\n",
-    "No pumping case"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8d0af1eb",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3253571e",
-   "metadata": {},
-   "source": [
-    "Pumping case"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "989845c7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "13f1137f",
-   "metadata": {},
-   "source": [
-    "Plot the results"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "298c05ef",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_results()"
+    "    simulation(0)\n",
+    "\n",
+    "    # Pumping case\n",
+    "\n",
+    "    simulation(1)\n",
+    "\n",
+    "    # Plot the results\n",
+    "\n",
+    "    plot_results()"
    ]
   }
  ],

--- a/notebooks/ex-gwf-maw-p02.ipynb
+++ b/notebooks/ex-gwf-maw-p02.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a00ec03b",
+   "id": "acf112de",
    "metadata": {},
    "source": [
     "## Flowing well Multi-Aquifer Well Problem,\n",
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "096c7f68",
+   "id": "10411fed",
    "metadata": {},
    "source": [
     "### Flowing Well Problem Setup\n",
@@ -24,13 +24,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c6e51984",
+   "id": "2d0b35db",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea1f7427",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
@@ -39,7 +47,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "085db9f8",
+   "id": "c07ec82d",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -48,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52911f91",
+   "id": "4c9ab12d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +65,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f3f4e2cc",
+   "id": "83f1c5d1",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -66,7 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "185d89b8",
+   "id": "b203d161",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "522993e1",
+   "id": "30f357a0",
    "metadata": {},
    "source": [
     "Set figure properties specific to the"
@@ -85,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e96bf21",
+   "id": "235ca699",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bda5017f",
+   "id": "dc77924e",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -104,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13e11ef6",
+   "id": "82c1d11d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4bd196ef",
+   "id": "817ba99c",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -122,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5674d128",
+   "id": "06472525",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c1679b5",
+   "id": "52c992d7",
    "metadata": {},
    "source": [
     "Model units"
@@ -140,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4c73b8a5",
+   "id": "823ef2a1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d6b9019",
+   "id": "38cd2d12",
    "metadata": {},
    "source": [
     "Table Flowing Well Problem Model Parameters"
@@ -159,7 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "381b90b0",
+   "id": "404c8115",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,7 +189,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3423d597",
+   "id": "56bc0bcc",
    "metadata": {},
    "source": [
     "parse parameter strings into tuples"
@@ -190,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89640e4e",
+   "id": "12dcbd6b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e6a9bdf0",
+   "id": "4fcbb08e",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -209,7 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2fc830f5",
+   "id": "c2799ccd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +226,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83eb3e14",
+   "id": "f3730059",
    "metadata": {},
    "source": [
     "Define dimensions"
@@ -227,7 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8f4613d3",
+   "id": "6a20e78a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +246,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9fe3a3dc",
+   "id": "6b44ce71",
    "metadata": {},
    "source": [
     "create idomain"
@@ -247,7 +255,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e0a6d841",
+   "id": "f3ee8c75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +274,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4e746906",
+   "id": "c48d33a9",
    "metadata": {},
    "source": [
     "### Create Flowing Well Problem Model Boundary Conditions"
@@ -274,7 +282,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e5222dd",
+   "id": "e55fa989",
    "metadata": {},
    "source": [
     "MAW Package"
@@ -283,7 +291,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef016bd7",
+   "id": "2b8a6821",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,7 +302,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bd45398a",
+   "id": "3a5277c4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -304,7 +312,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "807d6410",
+   "id": "58458650",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -317,7 +325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c60bcb07",
+   "id": "5a35a92b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,7 +334,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e3c2929d",
+   "id": "eb1480c1",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -335,7 +343,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc7ac6e5",
+   "id": "cc69f357",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -349,7 +357,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c5d68279",
+   "id": "75fd83d9",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -362,7 +370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9867e4a2",
+   "id": "ae99235f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -372,7 +380,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, sim_name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -443,7 +451,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eae32da9",
+   "id": "1cd1c30a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -454,7 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9fa68b8a",
+   "id": "153ef461",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -467,7 +475,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a0c79d4",
+   "id": "1083a011",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -479,7 +487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e7e423e6",
+   "id": "8e9b3b1f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -497,7 +505,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "498f9a0b",
+   "id": "eb795335",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -508,7 +516,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "280b39d2",
+   "id": "34583646",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -623,7 +631,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9e3f0da5",
+   "id": "c8802cf0",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -634,7 +642,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "940983df",
+   "id": "820a8435",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -719,7 +727,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0010a229",
+   "id": "25b72139",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -730,7 +738,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bf895091",
+   "id": "5a3b8116",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -744,7 +752,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eedbfe01",
+   "id": "821523d0",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -760,7 +768,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55fefe88",
+   "id": "253c5701",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -779,27 +787,34 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73859a11",
+   "id": "d52acb8f",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "bb233f7a",
+   "id": "46c7ceb3",
    "metadata": {},
    "source": [
-    "### Flowing Well Problem Simulation"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc4cdffe",
+   "id": "371aadf8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation()"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Flowing Well Problem Simulation\n",
+    "\n",
+    "    simulation()"
    ]
   }
  ],

--- a/notebooks/ex-gwf-maw-p03.ipynb
+++ b/notebooks/ex-gwf-maw-p03.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "37f2f009",
+   "id": "46c0fb12",
    "metadata": {},
    "source": [
     "## Reilly Multi-Aquifer Well Problem,\n",
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "994277cc",
+   "id": "ed52c932",
    "metadata": {},
    "source": [
     "### Reilly MAW Problem Setup\n",
@@ -23,13 +23,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2d3601b3",
+   "id": "8e2a1c55",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6210efb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"
@@ -37,7 +45,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f51b822",
+   "id": "a0489812",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -46,7 +54,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10499d3c",
+   "id": "0e68aec8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +63,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4659dc03",
+   "id": "bd9d0565",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -64,7 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82c67936",
+   "id": "3fe48da1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a2884dab",
+   "id": "0522eb38",
    "metadata": {},
    "source": [
     "Set figure properties specific to the"
@@ -83,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fdc8f7eb",
+   "id": "92e48231",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +102,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63c8db66",
+   "id": "d11e6f19",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -103,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24c3846c",
+   "id": "00e34bd2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b3fc940",
+   "id": "9a0af7a9",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -121,7 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "293c50e3",
+   "id": "30a5bfae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +138,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0000c7d3",
+   "id": "d7987805",
    "metadata": {},
    "source": [
     "Model units"
@@ -139,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "477bc7d1",
+   "id": "ae431e83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +157,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0795ff4",
+   "id": "63be37b4",
    "metadata": {},
    "source": [
     "Scenario parameters"
@@ -158,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc1c6271",
+   "id": "1ca02fb6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -179,7 +187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93277210",
+   "id": "7db5de89",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -190,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f74339d7",
+   "id": "d2655be0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +210,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76dff24d",
+   "id": "756dbd7f",
    "metadata": {},
    "source": [
     "Table Reilly MAW Problem Model Parameters"
@@ -211,7 +219,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a0a85e03",
+   "id": "dd5b73d8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +248,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c11a79b3",
+   "id": "8b76f1aa",
    "metadata": {},
    "source": [
     "set delr and delc for the local model"
@@ -249,7 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b7cb8ff",
+   "id": "0649eb77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -287,7 +295,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9481aa4e",
+   "id": "a791fc05",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,7 +321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d1161a7",
+   "id": "fa36b0ee",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -322,7 +330,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fdf849ee",
+   "id": "d3916a12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,7 +339,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "205c262e",
+   "id": "47789186",
    "metadata": {},
    "source": [
     "Define dimensions"
@@ -340,7 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7ef4b77c",
+   "id": "00386635",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -351,7 +359,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43fde4a5",
+   "id": "f01e2b71",
    "metadata": {},
    "source": [
     "### Create Reilly MAW Problem Model Boundary Conditions"
@@ -359,7 +367,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "506f28b6",
+   "id": "c85e7593",
    "metadata": {},
    "source": [
     "MAW Package"
@@ -368,7 +376,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61070893",
+   "id": "5fc56dc6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -378,7 +386,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71ec282a",
+   "id": "a262a05e",
    "metadata": {},
    "source": [
     "Build the MAW connection data"
@@ -387,7 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec2bb298",
+   "id": "be31c46e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -471,7 +479,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d8c45b5",
+   "id": "c6686020",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -480,7 +488,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "745ec1f6",
+   "id": "119350ee",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -494,7 +502,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5eb1cb97",
+   "id": "7c8e9d40",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -507,7 +515,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b07f164",
+   "id": "e66139cd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -524,14 +532,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13c14601",
+   "id": "f47215ec",
    "metadata": {},
    "outputs": [],
    "source": [
     "def build_regional(name):\n",
     "    sim_ws = os.path.join(ws, name)\n",
     "    sim = flopy.mf6.MFSimulation(\n",
-    "        sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "        sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "    )\n",
     "    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "    flopy.mf6.ModflowIms(\n",
@@ -581,7 +589,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fba2e55f",
+   "id": "3e331eff",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -618,7 +626,7 @@
     "\n",
     "    sim_ws = os.path.join(ws, name)\n",
     "    sim = flopy.mf6.MFSimulation(\n",
-    "        sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "        sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "    )\n",
     "    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "    flopy.mf6.ModflowIms(\n",
@@ -709,7 +717,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe74648d",
+   "id": "2c3e4da9",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -720,7 +728,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c8019848",
+   "id": "97e21891",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -733,7 +741,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddf3f4f7",
+   "id": "92b211d4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -745,7 +753,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66abf10f",
+   "id": "cbfbedde",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -763,7 +771,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5d425bb",
+   "id": "3a9516a2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -774,7 +782,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bc18d5de",
+   "id": "da1d22f4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -906,7 +914,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71c9a9fe",
+   "id": "f74c39da",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -917,7 +925,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79e1917c",
+   "id": "0baee18c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1048,7 +1056,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "afe8ae69",
+   "id": "ce665b53",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1059,7 +1067,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e4ebce83",
+   "id": "045ba081",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1200,7 +1208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a67070e6",
+   "id": "1bc0dd5e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1211,7 +1219,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e5bbcbd",
+   "id": "f84b2fb6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1227,7 +1235,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "135ceca9",
+   "id": "36802e07",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1243,7 +1251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c1ce7855",
+   "id": "912bcdee",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1262,83 +1270,81 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e95691d8",
+   "id": "34412d00",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(idx=0, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd4c1683",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_02():\n",
+    "    simulation(idx=1, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "581d20fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_03():\n",
+    "    simulation(idx=2, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb322ed1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_plot():\n",
+    "    plot_results()"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "cf44d4c2",
+   "id": "667b77c1",
    "metadata": {},
    "source": [
-    "### Reilly MAW Problem Simulation\n",
+    "nosetest end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2451418f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    # ### Reilly MAW Problem Simulation\n",
+    "    #\n",
+    "    # Regional model\n",
     "\n",
-    "Regional model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "99543364",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b1c958ce",
-   "metadata": {},
-   "source": [
-    "Local model with MAW well"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8683150b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "937d30e8",
-   "metadata": {},
-   "source": [
-    "Local model with high K well"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c3227e84",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(2)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3015db99",
-   "metadata": {},
-   "source": [
-    "Plot the results"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "be3dc286",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_results()"
+    "    simulation(0)\n",
+    "\n",
+    "    # Local model with MAW well\n",
+    "\n",
+    "    simulation(1)\n",
+    "\n",
+    "    # Local model with high K well\n",
+    "\n",
+    "    simulation(2)\n",
+    "\n",
+    "    # Plot the results\n",
+    "\n",
+    "    plot_results()"
    ]
   }
  ],

--- a/notebooks/ex-gwf-nwt-p02.ipynb
+++ b/notebooks/ex-gwf-nwt-p02.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "77a2cae3",
+   "id": "911b5ddc",
    "metadata": {},
    "source": [
     "## Flow diversion example\n",
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "467f34f3",
+   "id": "6953f530",
    "metadata": {},
    "source": [
     "### Flow diversion Problem Setup\n",
@@ -22,13 +22,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "993e71ac",
+   "id": "117970f1",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd4a77c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
@@ -37,7 +45,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f9c94de",
+   "id": "ee949a7c",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -46,7 +54,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0628f2c0",
+   "id": "436c6941",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +63,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64dfd3a2",
+   "id": "2473e71d",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -64,7 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "efbea2a4",
+   "id": "35a8a541",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de984596",
+   "id": "0bdf5bfa",
    "metadata": {},
    "source": [
     "Set figure properties"
@@ -83,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a1f03fdf",
+   "id": "1dd981a2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f501898",
+   "id": "0c659702",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -102,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "09671ee5",
+   "id": "2e11d72a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a572dd5b",
+   "id": "543a25f2",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -120,7 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e36a010",
+   "id": "f64ddf5e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e98af82f",
+   "id": "881c0810",
    "metadata": {},
    "source": [
     "Model units"
@@ -138,7 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "03a5ddbc",
+   "id": "dbba2e26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,7 +156,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3e10c0ee",
+   "id": "a4c949b0",
    "metadata": {},
    "source": [
     "Scenario parameters"
@@ -157,7 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a1c86051",
+   "id": "cdfde781",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +185,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3478fb80",
+   "id": "5abc863b",
    "metadata": {},
    "source": [
     "Table"
@@ -186,7 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2bea3bf1",
+   "id": "e3c1cf6e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -209,7 +217,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3459074d",
+   "id": "14697537",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -218,7 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7749d43d",
+   "id": "c3f78410",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,7 +240,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "502405af",
+   "id": "ed053ced",
    "metadata": {},
    "source": [
     "Calculate extents, and shape3d"
@@ -241,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70ab694a",
+   "id": "a913d35a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -251,7 +259,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d255383d",
+   "id": "293a8d25",
    "metadata": {},
    "source": [
     "Create the bottom"
@@ -260,7 +268,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d5d6a1b5",
+   "id": "08e72d6a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +277,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6d6198c",
+   "id": "600a1eee",
    "metadata": {},
    "source": [
     "Create icelltype (which is the same as iconvert)"
@@ -278,7 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "363d3797",
+   "id": "00fb8738",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -287,7 +295,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d9c572de",
+   "id": "e080c065",
    "metadata": {},
    "source": [
     "Constant head boundary conditions"
@@ -296,7 +304,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b768820d",
+   "id": "773f32eb",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -310,7 +318,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad5e7854",
+   "id": "3e260721",
    "metadata": {},
    "source": [
     "Recharge boundary conditions"
@@ -319,7 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae67b782",
+   "id": "5441d184",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,7 +339,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4db48f61",
+   "id": "73e82073",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -340,7 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ba1d1ed5",
+   "id": "828764c3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,7 +360,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2ca767e7",
+   "id": "f100ff92",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -365,7 +373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bcb7aef9",
+   "id": "f6ed443a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -383,7 +391,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        if newton:\n",
@@ -465,7 +473,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80a00a4d",
+   "id": "8621d548",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -476,7 +484,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4f59b072",
+   "id": "45018a6f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -489,7 +497,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51eef4e8",
+   "id": "937c0b74",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -500,7 +508,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc67429c",
+   "id": "d0ef8666",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -519,7 +527,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1137b26",
+   "id": "cd97cc1f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -530,7 +538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "054ab9e1",
+   "id": "5df80472",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -544,7 +552,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ded28c61",
+   "id": "3595449c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -555,7 +563,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bfe849b3",
+   "id": "8ff7a4bf",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -711,7 +719,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "774f29a1",
+   "id": "afc26f6a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -727,7 +735,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1ead3786",
+   "id": "03c2b9fa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -746,65 +754,46 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6e5bc898",
+   "id": "078a22b3",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_and_plot():\n",
+    "    simulation(0, silent=False)\n",
+    "    simulation(1, silent=False)\n",
+    "    plot_results(silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "589e94b5",
+   "id": "0c38c0f1",
    "metadata": {},
    "source": [
-    "### MODFLOW-NWT Problem 2 Simulation\n",
+    "nosetest end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c9b7a2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    # ### MODFLOW-NWT Problem 2 Simulation\n",
+    "    #\n",
+    "    # Newton-Raphson.\n",
     "\n",
-    "Newton-Raphson."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "42ccbf27",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fbf8d44d",
-   "metadata": {},
-   "source": [
-    "Rewetting."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fe099ff2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b6db28bd",
-   "metadata": {},
-   "source": [
-    "Plot results"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "655b4016",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_results()"
+    "    simulation(0)\n",
+    "\n",
+    "    # Rewetting.\n",
+    "\n",
+    "    simulation(1)\n",
+    "\n",
+    "    # Plot results\n",
+    "\n",
+    "    plot_results()"
    ]
   }
  ],

--- a/notebooks/ex-gwf-nwt-p03.ipynb
+++ b/notebooks/ex-gwf-nwt-p03.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "1b009fed",
+   "id": "72aa557f",
    "metadata": {},
    "source": [
     "## MODFLOW-NWT Problem 3 example\n",
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9456c849",
+   "id": "4150ad75",
    "metadata": {},
    "source": [
     "### MODFLOW-NWT Problem 3 Setup\n",
@@ -22,13 +22,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1fe902b",
+   "id": "f01ab3fb",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6e81de5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
@@ -37,7 +45,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c28d18c8",
+   "id": "e25f02c3",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -46,7 +54,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ee508f03",
+   "id": "01fd6cc3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +63,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7a686e0",
+   "id": "8a1b788e",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -64,7 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "961c975f",
+   "id": "996f8c99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08ce93b5",
+   "id": "0a13fcc9",
    "metadata": {},
    "source": [
     "Set figure properties"
@@ -83,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15f3b87b",
+   "id": "c7be7faa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e03ce1a6",
+   "id": "5e291741",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -102,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "411697ec",
+   "id": "5dc46a01",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad496a74",
+   "id": "947d0adb",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -120,7 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "228a8293",
+   "id": "8ce90883",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "211654c2",
+   "id": "f1dff8d4",
    "metadata": {},
    "source": [
     "Model units"
@@ -138,7 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6d6ffe23",
+   "id": "a0a21133",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,7 +156,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "debf9b8a",
+   "id": "25b7b137",
    "metadata": {},
    "source": [
     "Scenario parameters"
@@ -157,7 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f92ca9d8",
+   "id": "3eedb3f9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +181,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fcebf66f",
+   "id": "47acc454",
    "metadata": {},
    "source": [
     "Table"
@@ -182,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fcf298ea",
+   "id": "3ce93050",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,7 +207,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "435b3109",
+   "id": "9656fc0e",
    "metadata": {},
    "source": [
     "plotting ranges and contour levels"
@@ -208,7 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "306a4c7a",
+   "id": "57034ed5",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -227,7 +235,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "febb84e3",
+   "id": "d06e0a6c",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -236,7 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c4e8bcef",
+   "id": "b43a87cf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +253,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8ccc619e",
+   "id": "f760955f",
    "metadata": {},
    "source": [
     "Calculate extents, and shape3d"
@@ -254,7 +262,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f43a4ea5",
+   "id": "7f3e7791",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +273,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b349b98f",
+   "id": "c8845d2e",
    "metadata": {},
    "source": [
     "Load the bottom"
@@ -274,7 +282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "224e3fe7",
+   "id": "75ad8278",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +292,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e5e34324",
+   "id": "eb6d7af9",
    "metadata": {},
    "source": [
     "Set the starting heads"
@@ -293,7 +301,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "473cdd82",
+   "id": "68a0d1be",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +310,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e01bfa01",
+   "id": "8a302a8b",
    "metadata": {},
    "source": [
     "Load the high recharge rate"
@@ -311,7 +319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "210d2946",
+   "id": "ebba19a7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -321,7 +329,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f2b0de3c",
+   "id": "813481f9",
    "metadata": {},
    "source": [
     "Generate the low recharge rate from the high recharge rate"
@@ -330,7 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8a3e68b7",
+   "id": "ffb19a10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -340,7 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2e183740",
+   "id": "4f769154",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -357,7 +365,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d4b8718c",
+   "id": "6fabaf15",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -366,7 +374,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a4960780",
+   "id": "19abb81b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -378,7 +386,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cfdabb6f",
+   "id": "b42302c5",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -391,7 +399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c9784217",
+   "id": "eccad508",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -404,7 +412,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -460,7 +468,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cb4bfe54",
+   "id": "09375a7d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -471,7 +479,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d863645",
+   "id": "6e651412",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -484,7 +492,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a982ea3",
+   "id": "bd71fab2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -495,7 +503,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15e60f9f",
+   "id": "60793b8c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -514,7 +522,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55010eff",
+   "id": "39de0da6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -525,7 +533,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c98bb92a",
+   "id": "8fea6baa",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -573,7 +581,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc725106",
+   "id": "d0e821ee",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -584,7 +592,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05453568",
+   "id": "7aa12756",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -658,7 +666,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4cc85ba9",
+   "id": "3c0dd7cb",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -756,7 +764,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c864074d",
+   "id": "6335d872",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -767,7 +775,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74f8f822",
+   "id": "4a202b1b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -909,7 +917,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2483250",
+   "id": "bed0c60d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -925,7 +933,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50a982cb",
+   "id": "b2cd183d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -946,47 +954,51 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7e65d01b",
+   "id": "3abf6cce",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(0, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd2096cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_02():\n",
+    "    simulation(1, silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "1051d78a",
+   "id": "e516cb1a",
    "metadata": {},
    "source": [
-    "### MODFLOW-NWT Problem 3 Simulation\n",
+    "nosetest end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "773164f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    # ### MODFLOW-NWT Problem 3 Simulation\n",
+    "    #\n",
+    "    # Simulated heads in the MODFLOW-NWT Problem 3 model with high recharge.\n",
     "\n",
-    "Simulated heads in the MODFLOW-NWT Problem 3 model with high recharge."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "98328327",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a06a0fe1",
-   "metadata": {},
-   "source": [
-    "Simulated heads in the MODFLOW-NWT Problem 3 model with low recharge."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bbd66e8f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(1)"
+    "    simulation(0)\n",
+    "\n",
+    "    # Simulated heads in the MODFLOW-NWT Problem 3 model with low recharge.\n",
+    "\n",
+    "    simulation(1)"
    ]
   }
  ],

--- a/notebooks/ex-gwf-radial.ipynb
+++ b/notebooks/ex-gwf-radial.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0d721b3b",
+   "id": "3a5fe181",
    "metadata": {},
    "source": [
     "## USG1DISU example\n",
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e07234be",
+   "id": "4b473d40",
    "metadata": {},
    "source": [
     "Imports"
@@ -32,7 +32,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d8740226",
+   "id": "93a07f3f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc10072a",
+   "id": "c1182d14",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -55,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7055052",
+   "id": "70f532d5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b3edf9b8",
+   "id": "c1dddeb8",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -73,7 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce391545",
+   "id": "500e2427",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +84,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6af1737a",
+   "id": "ce90787e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74ceccef",
+   "id": "f1e51401",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -105,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4bb25e8f",
+   "id": "dac8c8a1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32b3bc5c",
+   "id": "31b27727",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,7 +167,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c95cd542",
+   "id": "ba1efc91",
    "metadata": {},
    "source": [
     "Run Analytical Model - Very slow\n",
@@ -178,7 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4dcf966e",
+   "id": "ebab85e0",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -189,7 +189,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5fe160a7",
+   "id": "136c7541",
    "metadata": {},
    "source": [
     "Set default figure properties"
@@ -198,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d93ff217",
+   "id": "82e6dee4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,7 +207,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aec17036",
+   "id": "2f5124e1",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -216,7 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05a6b161",
+   "id": "1e93bfff",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +225,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2ae1c023",
+   "id": "c4e910a1",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -234,7 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15702cb1",
+   "id": "0c4c571a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e23bb609",
+   "id": "d12dd423",
    "metadata": {},
    "source": [
     "Model units"
@@ -252,7 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33244658",
+   "id": "c2c1c6e4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,7 +262,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5b31a0d",
+   "id": "bb38d6b3",
    "metadata": {},
    "source": [
     "Table Model Parameters"
@@ -271,7 +271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0e7fcbe",
+   "id": "2b54bf1e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bd45d54e",
+   "id": "cc423fe1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,7 +294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "241c63ad",
+   "id": "c812cdf4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -304,7 +304,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0aba39c",
+   "id": "f461cbb1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -317,7 +317,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fbcfdc71",
+   "id": "3de3bc36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,7 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27c80dd0",
+   "id": "480ae446",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -339,7 +339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7e55692",
+   "id": "26d38689",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -351,7 +351,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7939a83",
+   "id": "fcbf14ab",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -365,7 +365,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e739085a",
+   "id": "a7ae350d",
    "metadata": {},
    "source": [
     "Outer Radius for each radial band"
@@ -374,7 +374,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f8e2f4e",
+   "id": "3e747a11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -407,7 +407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec81d3e2",
+   "id": "859036c1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -426,7 +426,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "069c7bd5",
+   "id": "fa5f376d",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file\n",
@@ -437,7 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e1cec833",
+   "id": "f992f794",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -446,7 +446,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb1369f2",
+   "id": "5e82dd93",
    "metadata": {},
    "source": [
     "Setup observation location and times"
@@ -455,7 +455,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5979947e",
+   "id": "4408634e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -469,7 +469,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0aa92949",
+   "id": "172709e9",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -478,7 +478,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42d3365e",
+   "id": "87906f9b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -492,7 +492,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f51b5cad",
+   "id": "70f74e12",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -505,7 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec592ca4",
+   "id": "6e497f53",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -515,7 +515,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(\n",
     "            sim, nper=nper, perioddata=tdis_ds, time_units=time_units\n",
@@ -586,7 +586,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8695d889",
+   "id": "1ed26d4e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -597,7 +597,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32be7c8f",
+   "id": "d092cc66",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -610,7 +610,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d215aa4",
+   "id": "8cdcc69e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -622,7 +622,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d6690892",
+   "id": "7548ec85",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -641,7 +641,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f45d4ef1",
+   "id": "06624685",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -652,7 +652,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bbc33601",
+   "id": "b59a07cf",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -763,7 +763,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0d9aa49",
+   "id": "c26e5bb4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -774,7 +774,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a2b2454e",
+   "id": "9393c8f1",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1315,7 +1315,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62702fa2",
+   "id": "8c8db5db",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1326,7 +1326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61721aa7",
+   "id": "e8ee9706",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1408,7 +1408,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4b9fd575",
+   "id": "f05046a7",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1419,7 +1419,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4f690e43",
+   "id": "93ee4c39",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1451,7 +1451,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c7e9d3d0",
+   "id": "02ba73b0",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1467,7 +1467,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2d34eeb0",
+   "id": "0fbd0e8a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1486,41 +1486,44 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5957e106",
+   "id": "b4d826f8",
    "metadata": {
     "lines_to_next_cell": 2
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_and_plot():\n",
+    "    simulation(silent=False)\n",
+    "    plot_results(silent=False)\n",
+    "    return"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "f3df19f1",
-   "metadata": {},
+   "id": "6046fac3",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
-    "### Axisymmetric Example"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9dd3dd88",
+   "id": "9c7cdb27",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# MF6 Axisymmetric Model\n",
-    "simulation()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3db77a1b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Solve analytical and plot results with MF6 results\n",
-    "plot_results()"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Axisymmetric Example\n",
+    "\n",
+    "    # MF6 Axisymmetric Model\n",
+    "    simulation()\n",
+    "\n",
+    "    # Solve analytical and plot results with MF6 results\n",
+    "    plot_results()"
    ]
   }
  ],

--- a/notebooks/ex-gwf-sagehen.ipynb
+++ b/notebooks/ex-gwf-sagehen.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "fca986d0",
+   "id": "6d9b3615",
    "metadata": {},
    "source": [
     "## Sagehen example with UZF, SFR, and MVR advanced packages activated\n",
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "baeca1c8",
+   "id": "eb2bafd3",
    "metadata": {},
    "source": [
     "### MODFLOW 6 Sagehen Problem Setup"
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5595ede6",
+   "id": "e2de4fe7",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02c47de5",
+   "id": "a51cf3e7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,18 +41,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c203f8e",
+   "id": "536b636c",
    "metadata": {},
    "outputs": [],
    "source": [
     "sys.path.append(os.path.join(\"..\", \"common\"))\n",
-    "import sfr_uzf_mvr_support_funcs as sageBld"
+    "import config\n",
+    "import flopy\n",
+    "import flopy.utils.binaryfile as bf\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import sfr_uzf_mvr_support_funcs as sageBld\n",
+    "from figspecs import USGSFigure"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ab16776a",
-   "metadata": {},
+   "id": "9152d058",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "Imports"
    ]
@@ -60,23 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2cdd1328",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import config\n",
-    "import flopy\n",
-    "import flopy.utils.binaryfile as bf\n",
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "import pandas as pd\n",
-    "from figspecs import USGSFigure"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e3836fab",
+   "id": "fdca92b4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,18 +80,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c9f1fe0e",
+   "id": "d05721ca",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mf2005_exe\n",
-    "exe_name_mt = config.mt3dms_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mf2005\"\n",
+    "exe_name_mt = \"mt3dms\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2fe5a6b7",
+   "id": "3cb62acc",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -107,7 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ffda52f7",
+   "id": "4edef11c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +110,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ec9bff6a",
+   "id": "26a622a0",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -126,7 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cb6aed7d",
+   "id": "5fb59464",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +129,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca9c6f7e",
+   "id": "59251472",
    "metadata": {},
    "source": [
     "Model units"
@@ -145,7 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8bf2348e",
+   "id": "98c9c842",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,7 +148,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e52c211f",
+   "id": "98ffca7e",
    "metadata": {},
    "source": [
     "Table Sagehen Model Parameters"
@@ -164,7 +157,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9edb16b8",
+   "id": "36c76c80",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -190,7 +183,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1dc3147",
+   "id": "8cd81e89",
    "metadata": {},
    "source": [
     "Additional model input preparation"
@@ -199,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c8672b4",
+   "id": "112993e2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "393e30da",
+   "id": "1bddbba5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c5c703e",
+   "id": "1a094d8b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +249,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "003714d9",
+   "id": "a1075693",
    "metadata": {},
    "source": [
     "Solver settings"
@@ -265,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10ecad5b",
+   "id": "8a6a21d7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -275,7 +268,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c06e7e39",
+   "id": "22ee3376",
    "metadata": {},
    "source": [
     "#### Prepping input for SFR package\n",
@@ -285,7 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d72d86b4",
+   "id": "3386d8c0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,7 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e6822471",
+   "id": "5272a293",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -311,7 +304,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc8b5190",
+   "id": "9acb4e01",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +337,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8cb962c6",
+   "id": "14c9e29c",
    "metadata": {},
    "source": [
     "#### Prepping input for DRN package"
@@ -353,7 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "171e670a",
+   "id": "30fe2e98",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -395,7 +388,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f3662b5a",
+   "id": "8c71b346",
    "metadata": {},
    "source": [
     "#### Prepping input for UZF package\n",
@@ -405,7 +398,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0dbaa133",
+   "id": "d5b936a7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,7 +415,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3eda01e7",
+   "id": "a97f36bb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,7 +430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "06650c77",
+   "id": "a87d1048",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -449,7 +442,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7006c5c",
+   "id": "d25bf3e2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -510,7 +503,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b44426d",
+   "id": "ffc7c81c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -535,7 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e7de3041",
+   "id": "920107f2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -552,7 +545,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7fe278fd",
+   "id": "526b4d5f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -580,7 +573,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bfb40131",
+   "id": "516f62f5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -592,7 +585,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87ddaa9b",
+   "id": "31128652",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -605,7 +598,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c9b1bba",
+   "id": "4749742a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -794,7 +787,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5cd1913b",
+   "id": "5f22919e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -805,7 +798,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c66963c",
+   "id": "29c41b41",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -818,7 +811,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6651bff4",
+   "id": "9d6c041e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -829,7 +822,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "597da333",
+   "id": "c1b51a8e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -848,7 +841,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "995c53bc",
+   "id": "66bcb08e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -859,7 +852,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a40490ee",
+   "id": "afd6a034",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1123,7 +1116,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22eb685d",
+   "id": "af27c925",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1139,7 +1132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "029a4f00",
+   "id": "e3873c86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1155,29 +1148,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c59b88b8",
+   "id": "24c15294",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "7f6a1ac4",
+   "id": "0f15b0ed",
    "metadata": {},
    "source": [
-    "### Sagehen Model Results\n",
-    "\n",
-    "Two-dimensional transport in a uniform flow field"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a388131f",
+   "id": "7233cf92",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(0)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Sagehen Model Results\n",
+    "    #\n",
+    "    # Two-dimensional transport in a uniform flow field\n",
+    "\n",
+    "    scenario(0)"
    ]
   }
  ],

--- a/notebooks/ex-gwf-sfr-p01.ipynb
+++ b/notebooks/ex-gwf-sfr-p01.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f72e45ec",
+   "id": "435525af",
    "metadata": {},
    "source": [
     "## Streamflow Routing (SFR) Package problem 1\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7aa8141",
+   "id": "c874447b",
    "metadata": {},
    "source": [
     "### SFR Package Problem 1 Setup\n",
@@ -25,13 +25,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ceeacc4",
+   "id": "3624e016",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21a28925",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
@@ -40,7 +48,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "490b30f4",
+   "id": "dc43ac23",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -49,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2cc31c86",
+   "id": "398c2067",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +66,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d4ae6bbe",
+   "id": "f2c14b1b",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -67,7 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95237a7f",
+   "id": "24372933",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fba2457b",
+   "id": "5e2aaece",
    "metadata": {},
    "source": [
     "Set figure properties specific to the"
@@ -86,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca4e3aaa",
+   "id": "0785d47c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90a92e0c",
+   "id": "af8769fe",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -105,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8d81611a",
+   "id": "e329c1f3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cda3729e",
+   "id": "3480f152",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -123,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c014dc7a",
+   "id": "b2551c38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +140,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2aa5b88",
+   "id": "7057e859",
    "metadata": {},
    "source": [
     "Model units"
@@ -141,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a40e7b82",
+   "id": "204b4b3e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -151,7 +159,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d947f38",
+   "id": "5b04b2ea",
    "metadata": {},
    "source": [
     "Table SFR Package Problem 1 Model Parameters"
@@ -160,7 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "108c2e2a",
+   "id": "83abc3b6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +190,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41ab0fb8",
+   "id": "f27d51d5",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -191,7 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44626286",
+   "id": "e925a461",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4713dbbc",
+   "id": "4ff6eb51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,7 +225,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46d2b57c",
+   "id": "8815eb23",
    "metadata": {},
    "source": [
     "Load the idomain, top, bottom, and evapotranspiration surface arrays"
@@ -226,7 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a99546c5",
+   "id": "32fee67a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +253,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37219626",
+   "id": "9e12ee88",
    "metadata": {},
    "source": [
     "Create hydraulic conductivity and specific yield"
@@ -254,7 +262,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eda099f3",
+   "id": "c62e791b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,7 +276,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1edc933d",
+   "id": "7c30a5a4",
    "metadata": {},
    "source": [
     "### Create SFR Package Problem 1 Model Boundary Conditions\n",
@@ -279,7 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2e6e59c8",
+   "id": "57b3320a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "023473c9",
+   "id": "e6f30845",
    "metadata": {},
    "source": [
     "Well boundary conditions"
@@ -300,7 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a29bb94",
+   "id": "eb8b1876",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,7 +333,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f95c934",
+   "id": "46cff455",
    "metadata": {},
    "source": [
     "SFR Package"
@@ -334,7 +342,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db4d44bd",
+   "id": "49d74927",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -921,7 +929,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77c8e113",
+   "id": "fe4ba175",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -968,7 +976,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4af129a3",
+   "id": "91986955",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -978,7 +986,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ea47f2ab",
+   "id": "0225083d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1004,7 +1012,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1db54d8",
+   "id": "4d9732ee",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -1013,7 +1021,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fcc0b5f6",
+   "id": "556201d2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1027,7 +1035,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "564c63e8",
+   "id": "29fb2264",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1040,7 +1048,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b5222452",
+   "id": "4cf0ceaf",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1050,7 +1058,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, sim_name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -1138,7 +1146,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d8b6980",
+   "id": "cf01699e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1149,7 +1157,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9cecb800",
+   "id": "1f69533a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1162,7 +1170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c97ba49",
+   "id": "c0c82f61",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1174,7 +1182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51b88c9d",
+   "id": "f1065336",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1192,7 +1200,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d0167772",
+   "id": "70e07aa1",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1203,7 +1211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "578c2551",
+   "id": "2f109498",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1384,7 +1392,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2671dab",
+   "id": "d852f748",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1395,7 +1403,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05e5df0f",
+   "id": "9114b448",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1534,7 +1542,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7acab5c",
+   "id": "514d6a6f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1545,7 +1553,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd7cd533",
+   "id": "26cb06d3",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1647,7 +1655,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aaaba1df",
+   "id": "26453693",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1658,7 +1666,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0e4b196",
+   "id": "af06383c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1677,7 +1685,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa3a376b",
+   "id": "ce75acbb",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1693,7 +1701,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0fd1feb8",
+   "id": "38c95801",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1712,33 +1720,40 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "09096382",
+   "id": "af4d2533",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "2cab18fb",
+   "id": "1bee925d",
    "metadata": {},
    "source": [
-    "### SFR Package Problem 1 Simulation\n",
-    "\n",
-    "Simulated heads in model the unconfined, middle, and lower aquifers (model layers\n",
-    "1, 3, and 5) are shown in the figure below. MODFLOW-2005 results for a quasi-3D\n",
-    "model are also shown. The location of drain (green) and well (gray) boundary\n",
-    "conditions, normalized specific discharge, and head contours (25 ft contour\n",
-    "intervals) are also shown."
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5ac6d78e",
+   "id": "e1407dff",
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation()"
+    "if __name__ == \"__main__\":\n",
+    "    # ### SFR Package Problem 1 Simulation\n",
+    "    #\n",
+    "    # Simulated heads in model the unconfined, middle, and lower aquifers (model layers\n",
+    "    # 1, 3, and 5) are shown in the figure below. MODFLOW-2005 results for a quasi-3D\n",
+    "    # model are also shown. The location of drain (green) and well (gray) boundary\n",
+    "    # conditions, normalized specific discharge, and head contours (25 ft contour\n",
+    "    # intervals) are also shown.\n",
+    "\n",
+    "    simulation()"
    ]
   }
  ],

--- a/notebooks/ex-gwf-sfr-p01b.ipynb
+++ b/notebooks/ex-gwf-sfr-p01b.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f1a5cf20",
+   "id": "a7ea5799",
    "metadata": {},
    "source": [
     "## Streamflow Routing (SFR) Package problem 1 with MVR applied among advanced packages\n",
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b93ab01d",
+   "id": "3becf664",
    "metadata": {},
    "source": [
     "### SFR Package Problem 1 with MVR Setup\n",
@@ -26,13 +26,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7e6d5d86",
+   "id": "4e8a3390",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99a101db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import flopy.utils.binaryfile as bf\n",
     "import matplotlib as mpl\n",
@@ -43,7 +51,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a3fb26b1",
+   "id": "280c21eb",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -52,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f5fea6f8",
+   "id": "ab838b3a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35881067",
+   "id": "09ef2cda",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -70,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8d678911",
+   "id": "9a41b40b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +88,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81d8dba4",
+   "id": "a221bd6d",
    "metadata": {},
    "source": [
     "Set figure properties specific to the"
@@ -89,7 +97,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41c4858e",
+   "id": "7ee90740",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +107,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76b150d7",
+   "id": "c461d237",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -108,7 +116,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "08cb9abc",
+   "id": "82c4f99c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +125,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31b423e7",
+   "id": "e6ab60ea",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -126,7 +134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c9ec98ea",
+   "id": "c484af58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,7 +143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3e8393a5",
+   "id": "67783265",
    "metadata": {},
    "source": [
     "Model units"
@@ -144,7 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fbcffa27",
+   "id": "636343d9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac0d82f4",
+   "id": "c8e1c54d",
    "metadata": {},
    "source": [
     "Table SFR Package Problem 1 with MVR Model Parameters"
@@ -163,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0bec3531",
+   "id": "c5c0bf8c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +194,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e36be55d",
+   "id": "fcb8be5c",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -195,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e9e00cb1",
+   "id": "cee36871",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72116e44",
+   "id": "a40b8851",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +250,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4a40a380",
+   "id": "133e623e",
    "metadata": {},
    "source": [
     "Load the idomain, lake locations, top, bottom, and evapotranspiration surface arrays"
@@ -251,7 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5366b125",
+   "id": "19d55862",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,7 +285,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c1aaa22b",
+   "id": "47cc7c0d",
    "metadata": {},
    "source": [
     "Create hydraulic conductivity and specific yield"
@@ -286,7 +294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7433819e",
+   "id": "6b96de25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +311,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a35bcc7a",
+   "id": "702de126",
    "metadata": {},
    "source": [
     "### Create SFR Package Problem 1 Model Boundary Conditions\n",
@@ -314,7 +322,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94f00a65",
+   "id": "65e4ae6e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,7 +334,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79fa2c01",
+   "id": "d6381bf7",
    "metadata": {},
    "source": [
     "Well boundary conditions"
@@ -335,7 +343,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a1651467",
+   "id": "2341641b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +473,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51db9128",
+   "id": "e77a1512",
    "metadata": {},
    "source": [
     "SFR Package"
@@ -474,7 +482,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b7635218",
+   "id": "72e16707",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -950,7 +958,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63905a1b",
+   "id": "c25ef086",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -992,7 +1000,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b87f3521",
+   "id": "0f260d28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1002,7 +1010,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b25e5146",
+   "id": "d73c227b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1016,7 +1024,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "909ee610",
+   "id": "75960bcd",
    "metadata": {},
    "source": [
     "UZF Package"
@@ -1025,7 +1033,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c9817f14",
+   "id": "e8fc6307",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1236,7 +1244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3435eed3",
+   "id": "a1567395",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3695,7 +3703,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "115f0c31",
+   "id": "e6642442",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3806,7 +3814,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0a4bfd2d",
+   "id": "d7fcd185",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3827,7 +3835,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "faf83fb9",
+   "id": "f2fc6c33",
    "metadata": {},
    "source": [
     "LAK Package"
@@ -3835,7 +3843,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddd0ac5e",
+   "id": "a72127a4",
    "metadata": {},
    "source": [
     "\n",
@@ -3886,7 +3894,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e08fca36",
+   "id": "085ac295",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3899,7 +3907,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce34845d",
+   "id": "47a8dbf4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3912,7 +3920,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e1420ed8",
+   "id": "f6f3d7a2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3933,7 +3941,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42af33d7",
+   "id": "ee07a7bc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4063,7 +4071,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27fb2f89",
+   "id": "6b65284e",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -4072,7 +4080,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3a09a76c",
+   "id": "4bd479d0",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -4086,7 +4094,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d49bd6d",
+   "id": "d8300852",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -4099,7 +4107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a883ec07",
+   "id": "205f41e0",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -4109,7 +4117,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, sim_name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -4384,7 +4392,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c1cb02b",
+   "id": "3781a712",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -4395,7 +4403,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57d93c79",
+   "id": "63ecbbaa",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -4408,7 +4416,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97cb2c81",
+   "id": "61199277",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -4420,7 +4428,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "881cf06a",
+   "id": "91968b82",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -4438,7 +4446,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5439a46",
+   "id": "2bef39aa",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -4449,7 +4457,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59f844d1",
+   "id": "c054fcb7",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -4628,7 +4636,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe865cb2",
+   "id": "58ed46ce",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -4639,7 +4647,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a8b288fa",
+   "id": "46120f61",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -4778,7 +4786,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6bfc18e1",
+   "id": "b1c5092e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -4789,7 +4797,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d393df6",
+   "id": "c4c5b62b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -4928,7 +4936,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45d50f36",
+   "id": "dba3c14e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -4939,7 +4947,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f40d1df0",
+   "id": "b74730bf",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -4996,7 +5004,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56f841a2",
+   "id": "c2bdbd71",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -5007,7 +5015,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e8afce7",
+   "id": "487cf0c0",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -5028,7 +5036,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee908d27",
+   "id": "b4d32b63",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -5044,7 +5052,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25abb33d",
+   "id": "93609108",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5063,33 +5071,40 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ffae6824",
+   "id": "1412be6b",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(0, silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "6331a0d2",
+   "id": "87c14269",
    "metadata": {},
    "source": [
-    "### SFR Package Problem 1 Simulation\n",
-    "\n",
-    "Simulated heads in model the unconfined, middle, and lower aquifers (model layers\n",
-    "1, 3, and 5) are shown in the figure below. MODFLOW-2005 results for a quasi-3D\n",
-    "model are also shown. The location of drain (green) and well (gray) boundary\n",
-    "conditions, normalized specific discharge, and head contours (25 ft contour\n",
-    "intervals) are also shown."
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50b4ec0a",
+   "id": "45271911",
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation(0)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### SFR Package Problem 1 Simulation\n",
+    "    #\n",
+    "    # Simulated heads in model the unconfined, middle, and lower aquifers (model layers\n",
+    "    # 1, 3, and 5) are shown in the figure below. MODFLOW-2005 results for a quasi-3D\n",
+    "    # model are also shown. The location of drain (green) and well (gray) boundary\n",
+    "    # conditions, normalized specific discharge, and head contours (25 ft contour\n",
+    "    # intervals) are also shown.\n",
+    "\n",
+    "    simulation(0)"
    ]
   }
  ],

--- a/notebooks/ex-gwf-spbc.ipynb
+++ b/notebooks/ex-gwf-spbc.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "e2a26012",
+   "id": "fdcfb257",
    "metadata": {},
    "source": [
     "## SPBC example\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d2c43b5",
+   "id": "1a3801fe",
    "metadata": {},
    "source": [
     "### SPBC Problem Setup\n",
@@ -25,13 +25,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b044b3e6",
+   "id": "d32aa47a",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f73e6edb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"
@@ -39,7 +47,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f3fec52c",
+   "id": "da970088",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -48,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8cff60c4",
+   "id": "dc33a7c5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +65,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c38f2c47",
+   "id": "32074beb",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -66,7 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "da947347",
+   "id": "f34e9b55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c802b3f",
+   "id": "6c800f7d",
    "metadata": {},
    "source": [
     "Set default figure properties"
@@ -85,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bad858f8",
+   "id": "2f1d8f97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +102,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "962af860",
+   "id": "0f4c10e6",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -103,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f0d1a5d",
+   "id": "ef507e3f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0ebb1731",
+   "id": "684ee581",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -121,7 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bd8eee83",
+   "id": "42703b60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +138,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "876bcfd6",
+   "id": "a53c291e",
    "metadata": {},
    "source": [
     "Model units"
@@ -139,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6b503806",
+   "id": "feb4a017",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +157,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de2b4f08",
+   "id": "d95bcfe8",
    "metadata": {},
    "source": [
     "Table SPBC Model Parameters"
@@ -158,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a442768e",
+   "id": "d49d9c9c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +185,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b03745cd",
+   "id": "66bdd9ba",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file\n",
@@ -189,7 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "850345ac",
+   "id": "49c6a9f7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,7 +209,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d914ba2f",
+   "id": "de270abb",
    "metadata": {},
    "source": [
     "assign botm"
@@ -210,7 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c309a369",
+   "id": "82b3b769",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,7 +227,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b675d4df",
+   "id": "a2c8add1",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -228,7 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90033978",
+   "id": "0eb818b6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +248,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c41d7905",
+   "id": "c4ddcd0f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -253,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3263553b",
+   "id": "9785f996",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -263,7 +271,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, sim_name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -337,7 +345,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e5b6e2b",
+   "id": "22c3922f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -348,7 +356,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36957068",
+   "id": "bfe607a5",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -361,7 +369,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81f98050",
+   "id": "a1c921a1",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -373,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55dafc52",
+   "id": "c92b3b14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -390,14 +398,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2a87d383",
+   "id": "1c6cef63",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Function to plot the SPBC model results.\n",
     "#\n",
-    "\n",
-    "\n",
     "def plot_grid(sim):\n",
     "    fs = USGSFigure(figure_type=\"map\", verbose=False)\n",
     "    sim_ws = os.path.join(ws, sim_name)\n",
@@ -441,7 +447,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c44157a",
+   "id": "c1e3d58a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -455,7 +461,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b492b9b8",
+   "id": "f9c74ad8",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -471,7 +477,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67508422",
+   "id": "e0f1cfbc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -486,29 +492,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4d524cb6",
+   "id": "c79f312f",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "3c4bbdbb",
+   "id": "a421a4ce",
    "metadata": {},
    "source": [
-    "### SPBC Simulation\n",
-    "\n",
-    "Model grid and simulation results"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f86027a",
+   "id": "ba13d58f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation()"
+    "if __name__ == \"__main__\":\n",
+    "    # ### SPBC Simulation\n",
+    "    #\n",
+    "    # Model grid and simulation results\n",
+    "\n",
+    "    simulation()"
    ]
   }
  ],

--- a/notebooks/ex-gwf-twri.ipynb
+++ b/notebooks/ex-gwf-twri.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a4e3eea0",
+   "id": "9c67bf5e",
    "metadata": {},
    "source": [
     "## Original TWRI MODFLOW example\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a7c6121",
+   "id": "3c076f38",
    "metadata": {},
    "source": [
     "### TWRI Problem Setup\n",
@@ -25,13 +25,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7decba16",
+   "id": "622cfee3",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26e48beb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"
@@ -39,7 +47,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d0b80378",
+   "id": "d1b5c951",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -48,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66a35005",
+   "id": "66e81f65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +65,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4ec2555d",
+   "id": "ed160c8d",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -66,7 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "085f9f7d",
+   "id": "8e348058",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3deba6d6",
+   "id": "0b85c74b",
    "metadata": {},
    "source": [
     "Set figure properties specific to the"
@@ -85,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "006ccea2",
+   "id": "113cde60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +102,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75e74d4e",
+   "id": "c850dea7",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -103,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0ec3a519",
+   "id": "62ef7a88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55140ea5",
+   "id": "577344bc",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -121,7 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ed18fad",
+   "id": "a4964e52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +138,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fb2e3e3a",
+   "id": "a545e2ab",
    "metadata": {},
    "source": [
     "Scenario parameter units - make sure there is at least one blank line before next item\n",
@@ -140,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48196058",
+   "id": "7a923d3e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +157,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bec76a40",
+   "id": "92b9b16e",
    "metadata": {},
    "source": [
     "Model units"
@@ -158,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc0ede40",
+   "id": "c4cc62fe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +176,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d2d666f9",
+   "id": "5065a537",
    "metadata": {},
    "source": [
     "Table TWRI Model Parameters"
@@ -177,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59c52e22",
+   "id": "ad270d07",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "675dfdb7",
+   "id": "6a235f5f",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -209,7 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8a02cf85",
+   "id": "5c0c6c86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +229,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "727e2d20",
+   "id": "ba26090b",
    "metadata": {},
    "source": [
     "parse parameter strings into tuples"
@@ -230,7 +238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "715e5045",
+   "id": "b375448f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +250,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2d803c2",
+   "id": "4e2e63e8",
    "metadata": {},
    "source": [
     "### Create TWRI Model Boundary Conditions\n",
@@ -254,7 +262,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b88fecfa",
+   "id": "99fe40e5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +274,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af35563d",
+   "id": "58bd2b92",
    "metadata": {},
    "source": [
     "Constant head cells for MODFLOW-2005 model"
@@ -275,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2fb131f5",
+   "id": "12f0fcf7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -287,7 +295,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cbeb6706",
+   "id": "efca84b8",
    "metadata": {},
    "source": [
     "Well boundary conditions"
@@ -296,7 +304,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf2e3eea",
+   "id": "7e0f9a91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,7 +331,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "09e05887",
+   "id": "20920993",
    "metadata": {},
    "source": [
     "Well boundary conditions for MODFLOW-2005 model"
@@ -332,7 +340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85551e5b",
+   "id": "986fc3e4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -348,7 +356,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8302faff",
+   "id": "66afb49c",
    "metadata": {},
    "source": [
     "Drain boundary conditions"
@@ -357,7 +365,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d04eae0",
+   "id": "cd8b6155",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -378,7 +386,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5fc6f920",
+   "id": "bbdb3bf7",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -387,7 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b101411e",
+   "id": "51350b71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -399,7 +407,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed56de1b",
+   "id": "9b7951f7",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -412,7 +420,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6e5354e0",
+   "id": "3e05f51b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -422,7 +430,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, sim_name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -473,7 +481,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86c98b07",
+   "id": "5b2bb7c6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -484,7 +492,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e07ab65",
+   "id": "66ab86ea",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -494,7 +502,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, sim_name, \"mf2005\")\n",
     "        mf = flopy.modflow.Modflow(\n",
-    "            modelname=sim_name, model_ws=sim_ws, exe_name=config.mf2005dbl_exe\n",
+    "            modelname=sim_name, model_ws=sim_ws, exe_name=\"mf2005dbl\"\n",
     "        )\n",
     "        flopy.modflow.ModflowDis(\n",
     "            mf,\n",
@@ -538,7 +546,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef319b02",
+   "id": "5b762162",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -549,7 +557,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "279dc78e",
+   "id": "a24234d2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -563,7 +571,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb50f285",
+   "id": "6af3bbc2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -575,7 +583,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "720e0059",
+   "id": "59d1569a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -598,7 +606,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2bca1844",
+   "id": "52f2ed58",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -609,7 +617,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a784c3ed",
+   "id": "f2debda6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -786,7 +794,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a105a821",
+   "id": "bc874821",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -802,7 +810,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f4a07166",
+   "id": "ec9bf32f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -821,33 +829,40 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1a33f81c",
+   "id": "56befbb7",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "6e90da60",
+   "id": "6eec2fa2",
    "metadata": {},
    "source": [
-    "### TWRI Simulation\n",
-    "\n",
-    "Simulated heads in model the unconfined, middle, and lower aquifers (model layers\n",
-    "1, 3, and 5) are shown in the figure below. MODFLOW-2005 results for a quasi-3D\n",
-    "model are also shown. The location of drain (green) and well (gray) boundary\n",
-    "conditions, normalized specific discharge, and head contours (25 ft contour\n",
-    "intervals) are also shown."
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f3daa774",
+   "id": "3ecba0bc",
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation()"
+    "if __name__ == \"__main__\":\n",
+    "    # ### TWRI Simulation\n",
+    "    #\n",
+    "    # Simulated heads in model the unconfined, middle, and lower aquifers (model layers\n",
+    "    # 1, 3, and 5) are shown in the figure below. MODFLOW-2005 results for a quasi-3D\n",
+    "    # model are also shown. The location of drain (green) and well (gray) boundary\n",
+    "    # conditions, normalized specific discharge, and head contours (25 ft contour\n",
+    "    # intervals) are also shown.\n",
+    "\n",
+    "    simulation()"
    ]
   }
  ],

--- a/notebooks/ex-gwf-u1disv.ipynb
+++ b/notebooks/ex-gwf-u1disv.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a1a0014b",
+   "id": "d32164ec",
    "metadata": {},
    "source": [
     "## USG1DISV example\n",
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5a476514",
+   "id": "e2c1d3a1",
    "metadata": {},
    "source": [
     "### USG1DISV Problem Setup\n",
@@ -26,13 +26,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f630ad3d",
+   "id": "55dea31b",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bff4b39f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import flopy.utils.cvfdutil\n",
     "import matplotlib.pyplot as plt\n",
@@ -41,7 +49,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47212d7f",
+   "id": "a4ff2766",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -50,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "773bdb03",
+   "id": "eedec58c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dfc18977",
+   "id": "da21b7aa",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -68,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "886c7717",
+   "id": "a16d8cc8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37bf25a7",
+   "id": "e348cd15",
    "metadata": {},
    "source": [
     "Set default figure properties"
@@ -87,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26e0b6be",
+   "id": "c72c8b03",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dfc566b4",
+   "id": "898d3fb8",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -105,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4aa25ba7",
+   "id": "6834e6fb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2abd3cd6",
+   "id": "5c2a5144",
    "metadata": {},
    "source": [
     "Model units"
@@ -123,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e5987060",
+   "id": "74cd9cf5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27572309",
+   "id": "3ce93751",
    "metadata": {},
    "source": [
     "Scenario parameters"
@@ -142,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b6168787",
+   "id": "6f4baf5f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +166,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37ceb175",
+   "id": "3325044d",
    "metadata": {},
    "source": [
     "Table USG1DISV Model Parameters"
@@ -167,7 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21b83b33",
+   "id": "38a14f93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +190,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d41f43e3",
+   "id": "4328be7d",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file\n",
@@ -194,7 +202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73e26b42",
+   "id": "a6f130d7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +214,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8289516f",
+   "id": "57cf4549",
    "metadata": {},
    "source": [
     "create the disv grid"
@@ -215,7 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e1767de1",
+   "id": "b3bf52ca",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "115eabd2",
+   "id": "03e983b9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +271,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01672576",
+   "id": "96ed796f",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -272,7 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8fbc2439",
+   "id": "d9578292",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +292,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "868a2f9f",
+   "id": "b8e1c9b8",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -297,7 +305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ef3398e",
+   "id": "743e863f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -307,7 +315,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, sim_name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -372,7 +380,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "98fa95e1",
+   "id": "33d917a2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -383,7 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31cde2cb",
+   "id": "288a0ee0",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -396,7 +404,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5839802f",
+   "id": "c2569469",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -408,7 +416,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5b83d868",
+   "id": "3b035558",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -425,14 +433,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56786026",
+   "id": "763c91d0",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Function to plot the USG1DISV model results.\n",
     "#\n",
-    "\n",
-    "\n",
     "def plot_grid(idx, sim):\n",
     "    fs = USGSFigure(figure_type=\"map\", verbose=False)\n",
     "    sim_name = list(parameters.keys())[idx]\n",
@@ -484,7 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78062b3a",
+   "id": "b9ef6825",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,7 +550,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c2f0b0d",
+   "id": "79e500b6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -560,7 +566,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "388279c9",
+   "id": "f3b09197",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -576,7 +582,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13b75778",
+   "id": "0b63e3b1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -593,47 +599,51 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82fdbd8f",
+   "id": "af642f7f",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(0, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5839db2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_02():\n",
+    "    simulation(1, silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "70c05c43",
+   "id": "609cd0b4",
    "metadata": {},
    "source": [
-    "### USG1DISV Simulation\n",
+    "nosetest end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da4199b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    # ### USG1DISV Simulation\n",
+    "    #\n",
+    "    # Simulated heads in the USG1DISV model without XT3D.\n",
     "\n",
-    "Simulated heads in the USG1DISV model without XT3D."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c1a1f4cf",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "93f63429",
-   "metadata": {},
-   "source": [
-    "Simulated heads in the USG1DISV model with XT3D."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e4f703ae",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(1)"
+    "    simulation(0)\n",
+    "\n",
+    "    # Simulated heads in the USG1DISV model with XT3D.\n",
+    "\n",
+    "    simulation(1)"
    ]
   }
  ],

--- a/notebooks/ex-gwf-u1gwfgwf.ipynb
+++ b/notebooks/ex-gwf-u1gwfgwf.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "c5385f28",
+   "id": "8e712002",
    "metadata": {},
    "source": [
     "## USG-ex1 with GWF-GWF Exchange and XT3D\n",
@@ -28,13 +28,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "289bed01",
+   "id": "c4b63938",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cbae84d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
@@ -44,7 +52,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1a421d16",
+   "id": "cb2b730f",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -53,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "688b433f",
+   "id": "ee209db2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +70,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cf869ba6",
+   "id": "5e428063",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -71,7 +79,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c16bddc5",
+   "id": "7ff3af73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +89,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f9b0825",
+   "id": "767419f2",
    "metadata": {},
    "source": [
     "Set default figure properties"
@@ -90,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ac4b08d",
+   "id": "0cef19d9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +108,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "306b68f0",
+   "id": "1ad9fca1",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -109,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c5f949d",
+   "id": "713269b2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2e39a42d",
+   "id": "c5d53a81",
    "metadata": {},
    "source": [
     "Model units"
@@ -127,7 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8859b387",
+   "id": "2e1a25ce",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0ad83cf4",
+   "id": "c5abee1a",
    "metadata": {},
    "source": [
     "Scenario parameters"
@@ -146,7 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96dc445a",
+   "id": "4f4d6d41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +180,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f4d5712",
+   "id": "bf3cfac7",
    "metadata": {},
    "source": [
     "Table with Model Parameters"
@@ -181,7 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6375a3ed",
+   "id": "16e86f22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,7 +206,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "407c1db5",
+   "id": "a7e3865b",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file\n",
@@ -209,7 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9c09f5d5",
+   "id": "5e36bd91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +229,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f87f12f0",
+   "id": "efeed491",
    "metadata": {},
    "source": [
     "Coarse model grid"
@@ -230,7 +238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53889714",
+   "id": "22aae35b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,7 +255,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "904c374b",
+   "id": "7b49a2e7",
    "metadata": {},
    "source": [
     "Refined model grid"
@@ -256,7 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f4e05092",
+   "id": "4f31c925",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,7 +280,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f5dda08a",
+   "id": "f9e05f92",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -281,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "212962d8",
+   "id": "e5996c64",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -295,7 +303,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fc9fb04d",
+   "id": "9da5ab89",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -308,15 +316,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51edefe2",
-   "metadata": {},
+   "id": "42744437",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "outputs": [],
    "source": [
     "def build_model(sim_name, XT3D_in_models, XT3D_at_exchange):\n",
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, sim_name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -480,8 +490,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d0d2a1a",
-   "metadata": {},
+   "id": "4a6b0d4b",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "Function to write model files"
    ]
@@ -489,8 +501,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d469318b",
-   "metadata": {},
+   "id": "1844a75b",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "outputs": [],
    "source": [
     "def write_model(sim, silent=True):\n",
@@ -500,8 +514,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca6c689b",
-   "metadata": {},
+   "id": "38da08d5",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "Function to run the model.\n",
     "True is returned if the model runs successfully\n"
@@ -510,8 +526,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "664f98b5",
-   "metadata": {},
+   "id": "94245f45",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "outputs": [],
    "source": [
     "@config.timeit\n",
@@ -526,8 +544,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "078ae534",
-   "metadata": {},
+   "id": "47d67cb4",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "Functions to plot model results.\n"
    ]
@@ -535,7 +555,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c5a23552",
+   "id": "70f88c78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -573,7 +593,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b60ef610",
+   "id": "12906597",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -690,7 +710,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd0b19cc",
+   "id": "2ade411b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -782,7 +802,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65faebca",
+   "id": "02790070",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -799,7 +819,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1adb2e0c",
+   "id": "be490a7e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -815,7 +835,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02bd5d97",
+   "id": "2353b47c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -832,83 +852,81 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d40b216",
+   "id": "5e872a16",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(0, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d1aab01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_02():\n",
+    "    simulation(1, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa9328c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_03():\n",
+    "    simulation(2, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2e0c073",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_04():\n",
+    "    simulation(3, silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "f19a7346",
+   "id": "d7fa4632",
    "metadata": {},
    "source": [
-    "### USG-ex1 GWF-GWF Exchange Simulation\n",
+    "nosetest end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ed62009",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    # ### USG-ex1 GWF-GWF Exchange Simulation\n",
+    "    #\n",
+    "    # Simulated heads without XT3D.\n",
     "\n",
-    "Simulated heads without XT3D."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0b65cb2a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d5490c4a",
-   "metadata": {},
-   "source": [
-    "Simulated heads with XT3D enabled globally, but not at the exchange"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "74d93a25",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "03598237",
-   "metadata": {},
-   "source": [
-    "Simulated heads with XT3D enabled globally"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e8e3b748",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(2)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d276daf4",
-   "metadata": {},
-   "source": [
-    "Simulated heads with XT3D enabled _only_ at the model interface."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d0ad3b9c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(3)"
+    "    simulation(0)\n",
+    "\n",
+    "    # Simulated heads with XT3D enabled globally, but not at the exchange\n",
+    "\n",
+    "    simulation(1)\n",
+    "\n",
+    "    # Simulated heads with XT3D enabled globally\n",
+    "\n",
+    "    simulation(2)\n",
+    "\n",
+    "    # Simulated heads with XT3D enabled _only_ at the model interface.\n",
+    "\n",
+    "    simulation(3)"
    ]
   }
  ],

--- a/notebooks/ex-gwf-whirl.ipynb
+++ b/notebooks/ex-gwf-whirl.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "196795f8",
+   "id": "e6177858",
    "metadata": {},
    "source": [
     "## Whirl example\n",
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3de3fe81",
+   "id": "a66e82bf",
    "metadata": {},
    "source": [
     "### Whirl Problem Setup\n",
@@ -26,13 +26,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d07f4ebd",
+   "id": "1ed490f5",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8396e2aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"
@@ -40,7 +48,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6d68b120",
+   "id": "46d64584",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -49,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "455c2a5a",
+   "id": "32e0ab80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +66,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e6291e7c",
+   "id": "8891246f",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -67,7 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2697c9e8",
+   "id": "2ab56a19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f8a47f2",
+   "id": "dfa0c576",
    "metadata": {},
    "source": [
     "Set default figure properties"
@@ -86,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6e16b753",
+   "id": "35b2b7e3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6b923b2",
+   "id": "9a45c4de",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -104,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "388f43e7",
+   "id": "f9f25a44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49a3d828",
+   "id": "cc245ce2",
    "metadata": {},
    "source": [
     "Model units"
@@ -123,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63803ace",
+   "id": "8ba7345c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cc207bb5",
+   "id": "3fa6cde2",
    "metadata": {},
    "source": [
     "Scenario parameters"
@@ -141,7 +149,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "165578ac",
+   "id": "50b28730",
    "metadata": {},
    "source": [
     "Table Whirl Model Parameters"
@@ -150,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7cf3ea32",
+   "id": "11ffda67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +181,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "456056ba",
+   "id": "d5a565fe",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file\n",
@@ -183,7 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "09bb7836",
+   "id": "eb369c7d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,7 +203,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d94e6785",
+   "id": "73ae9db1",
    "metadata": {},
    "source": [
     "Parse strings into lists"
@@ -204,7 +212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9eb5582b",
+   "id": "34520b1f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -215,7 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99d04c75",
+   "id": "f665a23e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,7 +235,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "07a9af85",
+   "id": "36e9cb49",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -240,7 +248,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8082a5cf",
+   "id": "7a7b99e7",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -250,7 +258,7 @@
     "    if config.buildModel:\n",
     "        sim_ws = os.path.join(ws, sim_name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -312,7 +320,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed043282",
+   "id": "d23dad6c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -323,7 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a1de7d7b",
+   "id": "3d84a5c3",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -336,7 +344,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e988d9e7",
+   "id": "f48adb3a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -348,7 +356,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9094bfac",
+   "id": "553bcad6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -366,7 +374,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac8703a9",
+   "id": "4bc9b62b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -377,7 +385,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2409e539",
+   "id": "7b1846f1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,7 +420,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af385859",
+   "id": "12af4a3b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -426,7 +434,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "578ae013",
+   "id": "416a8836",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -442,7 +450,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66c05310",
+   "id": "cd413a22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -457,29 +465,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71bd5505",
+   "id": "9b9172ff",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(0, silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "ecd70c34",
+   "id": "d61cc002",
    "metadata": {},
    "source": [
-    "### Whirl Simulation\n",
-    "\n",
-    "Simulated heads in the Whirl model with anisotropy in x direction."
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9efd4d2d",
+   "id": "8c4282f8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation(0)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Whirl Simulation\n",
+    "    #\n",
+    "    # Simulated heads in the Whirl model with anisotropy in x direction.\n",
+    "\n",
+    "    simulation(0)"
    ]
   }
  ],

--- a/notebooks/ex-gwf-zaidel.ipynb
+++ b/notebooks/ex-gwf-zaidel.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a65bb85d",
+   "id": "3c5a6931",
    "metadata": {},
    "source": [
     "## Zaidel (2013) example\n",
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4e3cbcfc",
+   "id": "fd0dfe99",
    "metadata": {},
    "source": [
     "### Zaidel (2013) Problem Setup\n",
@@ -24,13 +24,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12e5f18b",
+   "id": "c3311472",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d6a7fea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"
@@ -38,7 +46,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3a1b730",
+   "id": "dfdc39f8",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -47,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "020e7572",
+   "id": "56276bae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38c8523a",
+   "id": "b1ceea37",
    "metadata": {},
    "source": [
     "import common functionality"
@@ -65,7 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a2501f3f",
+   "id": "3a7058b3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,7 +83,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4ef1d97",
+   "id": "11eedf24",
    "metadata": {},
    "source": [
     "Set figure properties specific to the"
@@ -84,7 +92,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b9cdc747",
+   "id": "ab689948",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0297928a",
+   "id": "60550a7f",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -102,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79e61ad5",
+   "id": "41a75280",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d03b353",
+   "id": "3d856a96",
    "metadata": {},
    "source": [
     "Simulation name"
@@ -120,7 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1524ac0",
+   "id": "cd4d5b92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c324b92",
+   "id": "d7f93264",
    "metadata": {},
    "source": [
     "Model units"
@@ -138,7 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fd27ba3b",
+   "id": "2875163d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36f3ea64",
+   "id": "7ac75d70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +174,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85691a79",
+   "id": "f70c4dff",
    "metadata": {},
    "source": [
     "Table"
@@ -175,7 +183,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5030daca",
+   "id": "db630b55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,7 +202,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4b278e0f",
+   "id": "504f7661",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -203,7 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e1a0cf57",
+   "id": "0b8a6b18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +220,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37cc4baa",
+   "id": "8de93f36",
    "metadata": {},
    "source": [
     "Build stairway bottom"
@@ -221,7 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eb0ff94d",
+   "id": "08bbcb3d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,7 +243,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8f221bbc",
+   "id": "b37e1ca2",
    "metadata": {},
    "source": [
     "Solver parameters"
@@ -244,7 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "114360d1",
+   "id": "31fe359a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +264,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2cf74d17",
+   "id": "69af5fc9",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -269,7 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c969130",
+   "id": "df29a96f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -285,7 +293,7 @@
     "\n",
     "        sim_ws = os.path.join(ws, sim_name)\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=sim_name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "        flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "        flopy.mf6.ModflowIms(\n",
@@ -329,7 +337,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "278b782e",
+   "id": "2de894f6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -340,7 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e476bf5b",
+   "id": "baa68ca7",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -353,7 +361,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6b07d06",
+   "id": "c53f479a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -365,7 +373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab158d2e",
+   "id": "01d6e18e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -384,7 +392,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c30e0d14",
+   "id": "bda779e0",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -395,7 +403,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab00baf5",
+   "id": "992f4402",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -481,7 +489,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2ab1cb03",
+   "id": "871b8390",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -497,7 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b32b9f8",
+   "id": "0065d4b2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -518,47 +526,51 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef7c26a4",
+   "id": "83ab223a",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    simulation(0, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cdec902b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_02():\n",
+    "    simulation(1, silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "cac4c5ac",
+   "id": "b6f1f02f",
    "metadata": {},
    "source": [
-    "### Zaidel Simulation\n",
+    "nosetest end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0604e36f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    # ### Zaidel Simulation\n",
+    "    #\n",
+    "    # Simulated heads in the Zaidel model with H2 = 1.\n",
     "\n",
-    "Simulated heads in the Zaidel model with H2 = 1."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "599d39ef",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "56c80784",
-   "metadata": {},
-   "source": [
-    "Simulated heads in the Zaidel model with H2 = 10."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d381f8ff",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "simulation(1)"
+    "    simulation(0)\n",
+    "\n",
+    "    # Simulated heads in the Zaidel model with H2 = 10.\n",
+    "\n",
+    "    simulation(1)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-gwtgwt-p10.ipynb
+++ b/notebooks/ex-gwt-gwtgwt-p10.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9598dcdc",
+   "id": "305635f2",
    "metadata": {},
    "source": [
     "## Comparing MODFLOW 6 GWT-GWT to the single model results from MT3DMS problem 10\n",
@@ -17,21 +17,38 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc718163",
+   "id": "6ced9451",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c34cdc06",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Imports and extend system path to include the common subdirectory\n",
-    "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f86855b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "sys.path.append(os.path.join(\"..\", \"common\"))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec94526e",
+   "id": "e5224bdd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,16 +63,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f847e8c4",
+   "id": "77ba6305",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe"
+    "mf6exe = \"mf6\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "802bb667",
+   "id": "67762032",
    "metadata": {},
    "source": [
     "### Model Input Parameters"
@@ -64,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11c714cf",
+   "id": "eec277fe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,7 +92,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6fadb1f9",
+   "id": "c123766d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e57940b",
+   "id": "50a5b5d9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +116,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fa3fa120",
+   "id": "2c5487b9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a49aaca4",
+   "id": "3e92c623",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53567ff9",
+   "id": "4c4aaa2d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d23034a1",
+   "id": "626b671c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +183,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a4f59b13",
+   "id": "a6f78fa2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6cfca8df",
+   "id": "93f2f454",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f820bfd5",
+   "id": "40a2d776",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,7 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13f81aa7",
+   "id": "f804fece",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +242,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "743dcc80",
+   "id": "4c4d2e4e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,7 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "793af4fb",
+   "id": "6d05e751",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "856c09cb",
+   "id": "66507be2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,7 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "294077f4",
+   "id": "85351b9c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -287,7 +304,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "646e53e7",
+   "id": "de6bc9bf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,7 +317,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2d752bb8",
+   "id": "a1abbf30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,7 +330,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3a854bb4",
+   "id": "9fe84528",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -335,7 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "287d23b0",
+   "id": "725447cd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -356,7 +373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9615205d",
+   "id": "0af7660b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -382,7 +399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0965216",
+   "id": "9f26b467",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -396,7 +413,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79dfedfb",
+   "id": "6d752c02",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -407,10 +424,8 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "df36f697",
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "id": "044a2fd3",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Advection\n",
@@ -420,15 +435,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d989fde8",
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "id": "6298b73e",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# ### Build the MODFLOW 6 simulation\n",
-    "\n",
-    "\n",
     "def build_model(sim_name):\n",
     "    if not config.buildModel:\n",
     "        return\n",
@@ -468,13 +479,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59f6cfa2",
+   "id": "d002f68f",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Function to add the two GWF models, and their exchange\n",
-    "\n",
-    "\n",
     "def add_flow(sim):\n",
     "    global exgdata\n",
     "\n",
@@ -586,15 +595,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67ac4ebb",
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "id": "9de74e36",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create the outer GWF model\n",
-    "\n",
-    "\n",
     "def add_outer_gwfmodel(sim):\n",
     "    mname = gwfname_out\n",
     "\n",
@@ -700,15 +705,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b48113d7",
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "id": "a6057d5f",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create the inner GWF model\n",
-    "\n",
-    "\n",
     "def add_inner_gwfmodel(sim):\n",
     "    mname = gwfname_inn\n",
     "\n",
@@ -800,15 +801,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1447941e",
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "id": "6b7d52f8",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Function to add the transport models and exchange to the simulation\n",
-    "\n",
-    "\n",
     "def add_transport(sim):\n",
     "    # Create iterative model solution\n",
     "    imsgwt = flopy.mf6.ModflowIms(\n",
@@ -874,15 +871,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3af5cfd2",
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "id": "10cbece0",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create the outer GWT model\n",
-    "\n",
-    "\n",
     "def add_outer_gwtmodel(sim):\n",
     "    mname = gwtname_out\n",
     "    gwt = flopy.mf6.MFModel(\n",
@@ -968,15 +961,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1545fce3",
+   "id": "163e75f7",
    "metadata": {
-    "lines_to_next_cell": 1
+    "lines_to_next_cell": 2
    },
    "outputs": [],
    "source": [
     "# Create the inner GWT model\n",
-    "\n",
-    "\n",
     "def add_inner_gwtmodel(sim):\n",
     "    mname = gwtname_inn\n",
     "\n",
@@ -1064,8 +1055,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7e586ca2",
-   "metadata": {},
+   "id": "f60c5f9d",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "source": [
     "### Simulation Run and Results"
    ]
@@ -1073,15 +1066,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0a4a0b08",
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "id": "0e752a53",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Run the simulation and generate the results\n",
-    "\n",
-    "\n",
     "def run_model(sim):\n",
     "    success = True\n",
     "    if config.runModel:\n",
@@ -1094,15 +1083,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "08156083",
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "id": "7f04bec1",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Load MODFLOW 6 reference for the concentrations (GWT MT3DMS p10)\n",
-    "\n",
-    "\n",
     "def get_reference_data_conc():\n",
     "    fpath = open(\n",
     "        os.path.join(\n",
@@ -1135,15 +1120,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eac0e88a",
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "id": "ef5aafc0",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Load MODFLOW 6 reference for heads (GWT MT3DMS p10)\n",
-    "\n",
-    "\n",
     "def get_reference_data_heads():\n",
     "    fpath = open(\n",
     "        os.path.join(\n",
@@ -1176,15 +1157,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4795cc11",
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "id": "96f289b3",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Plot the inner and outer grid\n",
-    "\n",
-    "\n",
     "def plot_grids(sim):\n",
     "    xmin = xshift\n",
     "    ymin = yshift\n",
@@ -1208,17 +1185,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3181db6c",
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "id": "f9f30501",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Plot the difference in concentration after 1,500,750,1000 days\n",
     "# between this coupled model setup using a GWT-GWT exchange and the\n",
     "# single model reference\n",
-    "\n",
-    "\n",
     "def plot_difference_conc(sim):\n",
     "    conc_singlemodel_lay3 = get_reference_data_conc()\n",
     "\n",
@@ -1329,16 +1302,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20bd5715",
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "id": "a8394d00",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Plot the difference in head after 1,500,750,1000 days\n",
     "# between this coupled model and the single model reference\n",
-    "\n",
-    "\n",
     "def plot_difference_heads(sim):\n",
     "    head_singlemodel_lay3 = get_reference_data_heads()\n",
     "\n",
@@ -1449,15 +1418,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3a3615e6",
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "id": "327c9619",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Plot the concentration, this figure should be compared to the same figure in MT3DMS problem 10\n",
-    "\n",
-    "\n",
     "def plot_concentration(sim):\n",
     "    # Get the concentration output\n",
     "    gwt_outer = sim.get_model(gwtname_out)\n",
@@ -1550,13 +1515,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71c0fe77",
+   "id": "07338ba8",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Generates all plots\n",
-    "\n",
-    "\n",
     "def plot_results(sim):\n",
     "    if config.plotModel:\n",
     "        print(\"Plotting model results...\")\n",
@@ -1569,7 +1532,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1b8e1a80",
+   "id": "2abd0a43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1582,14 +1545,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77c676b2",
+   "id": "ad78e74f",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Main\n",
-    "sim = build_model(example_name)\n",
-    "run_model(sim)\n",
-    "plot_results(sim)"
+    "if __name__ == \"__main__\":\n",
+    "    sim = build_model(example_name)\n",
+    "    run_model(sim)\n",
+    "    plot_results(sim)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-hecht-mendez.ipynb
+++ b/notebooks/ex-gwt-hecht-mendez.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7fe0f339",
+   "id": "dd07cfae",
    "metadata": {},
    "source": [
     "## Three-Dimensional Heat Transport Study\n",
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "023ede5d",
+   "id": "50d02c09",
    "metadata": {},
    "source": [
     "### MODFLOW 6 GWT MT3DMS Heat Transport Problem Setup"
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "258a9f69",
+   "id": "cfc8920a",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -47,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62f66808",
+   "id": "11f91b15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bc4ac5b2",
+   "id": "338dad4f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "07743da6",
+   "id": "a88fbc7f",
    "metadata": {},
    "source": [
     "Imports"
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f5bfb50f",
+   "id": "23209383",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,18 +92,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e255327c",
+   "id": "623c4fac",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mf2005_exe\n",
-    "exe_name_mt = config.mt3dusgs_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mf2005\"\n",
+    "exe_name_mt = \"mt3dusgs\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "47d4e51d",
+   "id": "6c29eb2b",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -112,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a8271fac",
+   "id": "27c52309",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,7 +121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b34ab7e",
+   "id": "66b22e4b",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -130,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4109749a",
+   "id": "bfb03a2c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,7 +140,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "844f8bcd",
+   "id": "ca32ca80",
    "metadata": {},
    "source": [
     "Model units"
@@ -149,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c2f15e1e",
+   "id": "9b4f3086",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,7 +159,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9229ee4a",
+   "id": "e184bd10",
    "metadata": {},
    "source": [
     "Set scenario parameters (make sure there is at least one blank line before next item)\n",
@@ -169,7 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bb746ff2",
+   "id": "f52396bd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a77c7105",
+   "id": "ccb8c982",
    "metadata": {},
    "source": [
     "Scenario parameter units\n",
@@ -209,7 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae7ef76b",
+   "id": "ac4d4719",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -223,7 +223,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce81bd78",
+   "id": "8b686f35",
    "metadata": {},
    "source": [
     "Table Flow and transport parameters used in Hecht-Mendez example"
@@ -232,7 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d117c989",
+   "id": "19229924",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -261,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ecccb1c1",
+   "id": "a3f51176",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,7 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a3b1348e",
+   "id": "32d0d298",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3c9d8fe2",
+   "id": "2c3970a3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -329,7 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "984c021b",
+   "id": "38ed8299",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -354,7 +354,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74185f06",
+   "id": "e66d0ec9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -367,7 +367,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60e70b2c",
+   "id": "4534b425",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -379,7 +379,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91991720",
+   "id": "7dd1ad35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +398,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0060752b",
+   "id": "3beed627",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,7 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3676f4c8",
+   "id": "3452d84b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,7 +422,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49ed1634",
+   "id": "ec85c7d3",
    "metadata": {},
    "source": [
     "Solver settings"
@@ -431,7 +431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c1abf87e",
+   "id": "57648887",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -441,7 +441,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "594317a0",
+   "id": "e635e134",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -454,7 +454,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a376d62c",
+   "id": "5e08c2b6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -532,7 +532,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2fad659c",
+   "id": "b09cfc4a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -543,7 +543,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96f6df77",
+   "id": "32e34bc7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -560,7 +560,7 @@
     "        gwfname = \"gwf-\" + name\n",
     "        sim_ws = os.path.join(ws, sim_name, \"mf6gwf\")\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=gwfname, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=gwfname, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "\n",
     "        # Instantiating MODFLOW 6 time discretization\n",
@@ -675,7 +675,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f0c71e5",
+   "id": "c4ffbb8d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -750,7 +750,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5bbd5043",
+   "id": "adf762c8",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -770,7 +770,7 @@
     "        gwtname = \"gwt-\" + name\n",
     "        sim_ws = os.path.join(ws, sim_name, \"mf6gwt\")\n",
     "        sim = flopy.mf6.MFSimulation(\n",
-    "            sim_name=gwtname, sim_ws=sim_ws, exe_name=config.mf6_exe\n",
+    "            sim_name=gwtname, sim_ws=sim_ws, exe_name=\"mf6\"\n",
     "        )\n",
     "\n",
     "        # MF6 time discretization is a bit different than corresponding flow simulation\n",
@@ -915,7 +915,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11bacccd",
+   "id": "e21f02cd",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -926,7 +926,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c3576557",
+   "id": "90ddf0cd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -939,7 +939,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1dac109a",
+   "id": "412e0669",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -953,7 +953,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de9b8a84",
+   "id": "7b95a6a7",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -964,7 +964,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1477c8da",
+   "id": "4be829bc",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -989,7 +989,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08d9a5df",
+   "id": "abdf64a3",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1000,7 +1000,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cef6ee77",
+   "id": "36dde588",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1172,7 +1172,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4d11d22e",
+   "id": "82fcf9da",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1188,8 +1188,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ce940bd",
-   "metadata": {},
+   "id": "6a5a4458",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "outputs": [],
    "source": [
     "def scenario(idx, runMT3D=False, silent=True):\n",
@@ -1224,48 +1226,69 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "88d3ce7b",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "   scenario(0, silent=False)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32ba9bda",
+   "id": "2fff287b",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "def test_02():\n",
+    "    scenario(1, runMT3D=False, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3cfab0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_03():\n",
+    "    scenario(2, runMT3D=False, silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "ddae174e",
+   "id": "b829e269",
    "metadata": {},
    "source": [
-    "### Two-Dimensional Transport in a Diagonal Flow Field\n",
+    "nosetest end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8265c636",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    # ### Two-Dimensional Transport in a Diagonal Flow Field\n",
+    "    #\n",
+    "    # Compares the standard finite difference solutions between MT3D MF 6\n",
+    "    # when the Peclet number is 0\n",
+    "    # Not simulated because no known analytical solution to compare to\n",
+    "    # scenario(0, silent=False)\n",
     "\n",
-    "Compares the standard finite difference solutions between MT3D MF 6\n",
-    "when the Peclet number is 0\n",
-    "Not simulated because no known analytical solution to compare to\n",
-    "scenario(0, silent=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "56a0395f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Compares the standard finite difference solutions between MT3D MF 6\n",
-    "# when the Peclet number is 0\n",
-    "scenario(1, silent=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "be3de052",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Compares the standard finite difference solutions between MT3D MF 6\n",
-    "# when the Peclet number is 0\n",
-    "scenario(2, silent=False)"
+    "    # Compares the standard finite difference solutions between MT3D MF 6\n",
+    "    # when the Peclet number is 0\n",
+    "    scenario(1, silent=False)\n",
+    "\n",
+    "    # Compares the standard finite difference solutions between MT3D MF 6\n",
+    "    # when the Peclet number is 0\n",
+    "    scenario(2, silent=False)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-henry.ipynb
+++ b/notebooks/ex-gwt-henry.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d85493e7",
+   "id": "8d5df4ba",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9df4ab33",
+   "id": "cdcf7898",
    "metadata": {},
    "source": [
     "### Henry Problem Setup"
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2c55a0b4",
+   "id": "25f8c182",
    "metadata": {},
    "source": [
     "Imports"
@@ -32,13 +32,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a9fdbabc",
+   "id": "25ea2ca0",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4c79666",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"
@@ -46,7 +54,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ffef657",
+   "id": "0899adfe",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -55,7 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4bb3ada0",
+   "id": "97f1166d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +72,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9c50c08",
+   "id": "455a0f9f",
    "metadata": {},
    "source": [
     "Import common functionality"
@@ -73,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4d5338ce",
+   "id": "c3da6750",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,18 +92,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4c745e63",
+   "id": "3cd445f0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mf2005_exe\n",
-    "exe_name_mt = config.mt3dms_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mf2005\"\n",
+    "exe_name_mt = \"mt3dms\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "e569dfb2",
+   "id": "152e9662",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -104,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ff276cc4",
+   "id": "c1d7c9bb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54e504e3",
+   "id": "312b24d8",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -122,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f917fff",
+   "id": "69076a09",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db8bc46e",
+   "id": "edf8337f",
    "metadata": {},
    "source": [
     "Scenario parameters - make sure there is at least one blank line before next item"
@@ -140,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5df496d9",
+   "id": "9c51912d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,7 +164,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea9d3767",
+   "id": "e9706719",
    "metadata": {},
    "source": [
     "Scenario parameter units - make sure there is at least one blank line before next item\n",
@@ -166,7 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3bb26b2f",
+   "id": "5d6822a4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +185,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3afb0166",
+   "id": "ff53b72f",
    "metadata": {},
    "source": [
     "Model units"
@@ -186,7 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76b95585",
+   "id": "091a60fa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +204,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "221cba46",
+   "id": "d744040d",
    "metadata": {},
    "source": [
     "Table of model parameters"
@@ -205,7 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "945cf79d",
+   "id": "8fc554fc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90267cf7",
+   "id": "1ce35d9a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -239,7 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "045b3e2b",
+   "id": "0ab39671",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -251,7 +259,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3582128",
+   "id": "c765764c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -264,7 +272,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "962d1fc9",
+   "id": "f462add4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -274,7 +282,9 @@
     "    print(f\"Building model...{sim_folder}\")\n",
     "    name = \"flow\"\n",
     "    sim_ws = os.path.join(ws, sim_folder)\n",
-    "    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)\n",
+    "    sim = flopy.mf6.MFSimulation(\n",
+    "        sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
+    "    )\n",
     "    tdis_ds = ((perlen, nstp, 1.0),)\n",
     "    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)\n",
@@ -392,7 +402,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dfce19a8",
+   "id": "9eab2203",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -403,7 +413,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e5e6317",
+   "id": "3649595f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -417,7 +427,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1fa5f61",
+   "id": "f42ee407",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -429,7 +439,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65e53978",
+   "id": "f698721d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -448,7 +458,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aeed26fd",
+   "id": "4ec15f80",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -459,7 +469,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "535a50f7",
+   "id": "fedfc5ba",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -497,7 +507,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44031c85",
+   "id": "d6d85dc7",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -511,7 +521,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db4781bf",
+   "id": "a711f4f8",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -527,7 +537,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0d7c2062",
+   "id": "e3345cd4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,53 +554,51 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc5e3edd",
+   "id": "98be32c1",
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "88190460",
-   "metadata": {},
    "source": [
-    "### Henry Problem"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "56033530",
-   "metadata": {},
-   "source": [
-    "Scenario 1 - Classic henry problem"
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a537323b",
+   "id": "961d2c74",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(0)"
+    "def test_02():\n",
+    "    scenario(1, silent=False)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "33a8e43f",
+   "id": "ca52e2fb",
    "metadata": {},
    "source": [
-    "Scenario 2 - Modified Henry problem with half the inflow rate"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "075ccb13",
+   "id": "2e2fc97f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(1)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Henry Problem\n",
+    "\n",
+    "    # Scenario 1 - Classic henry problem\n",
+    "\n",
+    "    scenario(0)\n",
+    "\n",
+    "    # Scenario 2 - Modified Henry problem with half the inflow rate\n",
+    "\n",
+    "    scenario(1)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-keating.ipynb
+++ b/notebooks/ex-gwt-keating.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "44d1483b",
+   "id": "5b8ce9df",
    "metadata": {},
    "source": [
     "## Keating Problem\n",
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f06ef82d",
+   "id": "edfa4ced",
    "metadata": {},
    "source": [
     "### Keating Problem\n",
@@ -27,13 +27,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ba8514df",
+   "id": "07888591",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fbbbd628",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.patches\n",
     "import matplotlib.pyplot as plt\n",
@@ -42,7 +50,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c22b878",
+   "id": "8f8303d3",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -51,7 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac37c3a5",
+   "id": "7119bb03",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +68,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4d45990",
+   "id": "65bb434a",
    "metadata": {},
    "source": [
     "Import common functionality"
@@ -69,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3ee2d4b8",
+   "id": "7e4ddfc8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +87,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c5b772f",
+   "id": "597d7041",
    "metadata": {},
    "source": [
     "Set figure properties specific to the"
@@ -88,7 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f7406a4",
+   "id": "9622e971",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,7 +105,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9017835c",
+   "id": "e30fc71d",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -106,7 +114,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e3ffd006",
+   "id": "3bc6bc65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +124,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4cceb3c2",
+   "id": "43582b6a",
    "metadata": {},
    "source": [
     "Model units"
@@ -125,7 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e427bf1b",
+   "id": "193e9158",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,7 +143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "062f2e00",
+   "id": "4c8c1da9",
    "metadata": {},
    "source": [
     "Table of model parameters"
@@ -144,7 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b991553e",
+   "id": "5fb5b4cc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +183,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c5d5b35d",
+   "id": "3f27085f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6bf4202c",
+   "id": "498e65bf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,7 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f58a5739",
+   "id": "401b68a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +237,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f70da51b",
+   "id": "f7afee68",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -243,7 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f39c9b18",
+   "id": "e90b7100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -251,7 +259,9 @@
     "    print(f\"Building mf6gwf model...{sim_folder}\")\n",
     "    name = \"flow\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf6gwf\")\n",
-    "    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)\n",
+    "    sim = flopy.mf6.MFSimulation(\n",
+    "        sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
+    "    )\n",
     "    tdis_ds = ((period1, 1, 1.0), (period2, 1, 1.0))\n",
     "    flopy.mf6.ModflowTdis(\n",
     "        sim, nper=len(tdis_ds), perioddata=tdis_ds, time_units=time_units\n",
@@ -334,7 +344,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17dbdf96",
+   "id": "e8276dc7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -345,7 +355,7 @@
     "    sim = flopy.mf6.MFSimulation(\n",
     "        sim_name=name,\n",
     "        sim_ws=sim_ws,\n",
-    "        exe_name=config.mf6_exe,\n",
+    "        exe_name=\"mf6\",\n",
     "        continue_=True,\n",
     "    )\n",
     "    tdis_ds = ((period1, 73, 1.0), (period2, 2927, 1.0))\n",
@@ -435,7 +445,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "da158dbd",
+   "id": "eb374135",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -454,7 +464,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c5b47e2f",
+   "id": "f1ea1314",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -465,7 +475,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57dcdd5f",
+   "id": "bd4a1a29",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -481,7 +491,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2cd3c454",
+   "id": "571442f0",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -493,7 +503,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47f6563f",
+   "id": "d0b60b3d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -518,7 +528,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37e92418",
+   "id": "0091ec86",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -529,7 +539,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3558ff96",
+   "id": "2e5b985d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -547,7 +557,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92aa5379",
+   "id": "cc3bc122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -587,7 +597,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "088c5568",
+   "id": "ce5d9132",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -656,7 +666,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "08ce32c5",
+   "id": "e463aa80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -725,7 +735,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ee10591",
+   "id": "a5aeccda",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -803,7 +813,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cccb0c72",
+   "id": "29232771",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -819,7 +829,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b5a011d",
+   "id": "20d11806",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -834,35 +844,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37fdc7dd",
+   "id": "98186076",
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5c481271",
-   "metadata": {},
    "source": [
-    "### Simulate Keating Problem"
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d724c646",
+   "id": "f7040079",
    "metadata": {},
    "source": [
-    "Plot showing MODFLOW 6 results"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f887783",
+   "id": "2a253ae1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(0)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Simulate Keating Problem\n",
+    "\n",
+    "    # Plot showing MODFLOW 6 results\n",
+    "\n",
+    "    scenario(0)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-moc3d-p01.ipynb
+++ b/notebooks/ex-gwt-moc3d-p01.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9e2905e6",
+   "id": "429fb06c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f6e49e6",
+   "id": "1671df89",
    "metadata": {},
    "source": [
     "### One-Dimensional Steady Flow with Transport Problem Setup"
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45cc6d7c",
+   "id": "9fa9c9fa",
    "metadata": {},
    "source": [
     "Imports"
@@ -32,13 +32,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38f76dfe",
+   "id": "a3a5ed54",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "266377c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"
@@ -46,7 +54,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "689daf1c",
+   "id": "00dee7ca",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -55,7 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60a23a15",
+   "id": "91c4b922",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +72,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52123923",
+   "id": "0dcd267c",
    "metadata": {},
    "source": [
     "Import common functionality"
@@ -73,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17f4830e",
+   "id": "d92da603",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,18 +93,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae8a1bf2",
+   "id": "4ef6ca90",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mf2005_exe\n",
-    "exe_name_mt = config.mt3dms_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mf2005\"\n",
+    "exe_name_mt = \"mt3dms\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3bad18ab",
+   "id": "617d3608",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -105,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "741f527b",
+   "id": "9d31c657",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fec21f4c",
+   "id": "a33ceb07",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -123,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29f31810",
+   "id": "91aba9df",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65d571a5",
+   "id": "20ce23c6",
    "metadata": {},
    "source": [
     "Scenario parameters - make sure there is at least one blank line before next item"
@@ -142,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2b73d322",
+   "id": "04fc42f4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +180,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45a14d59",
+   "id": "598e56c7",
    "metadata": {},
    "source": [
     "Scenario parameter units - make sure there is at least one blank line before next item\n",
@@ -182,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4514532d",
+   "id": "22cc9951",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,7 +203,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46e6ca1d",
+   "id": "72c430c8",
    "metadata": {},
    "source": [
     "Model units"
@@ -204,7 +212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0bca6876",
+   "id": "1c566f9b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +222,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90c08e18",
+   "id": "beb8d83d",
    "metadata": {},
    "source": [
     "Table of model parameters"
@@ -223,7 +231,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb5e4d24",
+   "id": "06051f9e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -246,7 +254,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58279938",
+   "id": "defe2f49",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -259,7 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b0271ab",
+   "id": "a0f6a9b1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +290,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a0dda14",
+   "id": "561711fc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,7 +314,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5d34b967",
+   "id": "65ece80a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -316,7 +324,9 @@
     "    print(f\"Building mf6gwf model...{sim_folder}\")\n",
     "    name = \"flow\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf6gwf\")\n",
-    "    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)\n",
+    "    sim = flopy.mf6.MFSimulation(\n",
+    "        sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
+    "    )\n",
     "    tdis_ds = ((total_time, 1, 1.0),)\n",
     "    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "    flopy.mf6.ModflowIms(sim)\n",
@@ -369,7 +379,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "957b5bf7",
+   "id": "4ff21e5c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -380,7 +390,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4cbb12ad",
+   "id": "ef1cd9c3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -388,7 +398,9 @@
     "    print(f\"Building mf6gwt model...{sim_folder}\")\n",
     "    name = \"trans\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf6gwt\")\n",
-    "    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)\n",
+    "    sim = flopy.mf6.MFSimulation(\n",
+    "        sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
+    "    )\n",
     "    tdis_ds = ((total_time, 240, 1.0),)\n",
     "    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "    flopy.mf6.ModflowIms(sim, linear_acceleration=\"bicgstab\")\n",
@@ -449,7 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ee0959ac",
+   "id": "93b506a5",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -468,7 +480,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d78e229",
+   "id": "dd0d31f2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -479,7 +491,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05a461b3",
+   "id": "62336ab8",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -495,7 +507,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8edb9d9e",
+   "id": "0e2ab143",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -507,7 +519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01b6c786",
+   "id": "a00c3ec8",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -530,7 +542,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f30b1d0",
+   "id": "0bf39137",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -541,7 +553,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0c5d39c",
+   "id": "c14c001d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -617,7 +629,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0509c9b1",
+   "id": "9047ca5a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -693,7 +705,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62042224",
+   "id": "7a542a12",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -709,7 +721,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f0f44a8a",
+   "id": "9254e320",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -727,89 +739,81 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "016e0ac1",
+   "id": "d3e55848",
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "aae95310",
-   "metadata": {},
    "source": [
-    "### Simulated Zero-Order Growth in a Uniform Flow Field"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8c5e6257",
-   "metadata": {},
-   "source": [
-    "Scenario 1 - description"
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44c1c9a8",
+   "id": "5cd40673",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5aef7a04",
-   "metadata": {},
-   "source": [
-    "Scenario 2 - description"
+    "def test_02():\n",
+    "    scenario(1, silent=False)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72b6c04c",
+   "id": "5870619d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7ccbd3d7",
-   "metadata": {},
-   "source": [
-    "Scenario 3 - description"
+    "def test_03():\n",
+    "    scenario(2, silent=False)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce8bb856",
+   "id": "533edb98",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(2)"
+    "def test_04():\n",
+    "    scenario(3, silent=False)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "be0d6803",
+   "id": "756b8c41",
    "metadata": {},
    "source": [
-    "Scenario 4 - description"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13f7065f",
+   "id": "97ee9b03",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(3)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Simulated Zero-Order Growth in a Uniform Flow Field\n",
+    "\n",
+    "    # Scenario 1 - description\n",
+    "\n",
+    "    scenario(0)\n",
+    "\n",
+    "    # Scenario 2 - description\n",
+    "\n",
+    "    scenario(1)\n",
+    "\n",
+    "    # Scenario 3 - description\n",
+    "\n",
+    "    scenario(2)\n",
+    "\n",
+    "    # Scenario 4 - description\n",
+    "\n",
+    "    scenario(3)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-moc3d-p02.ipynb
+++ b/notebooks/ex-gwt-moc3d-p02.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "dcacc938",
+   "id": "310ca5f6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63933e7d",
+   "id": "cf14d46b",
    "metadata": {},
    "source": [
     "### Three-Dimensional Steady Flow with Transport Problem Setup"
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b06bca24",
+   "id": "d83ff1b9",
    "metadata": {},
    "source": [
     "Imports"
@@ -32,13 +32,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ec75141",
+   "id": "f6b152b5",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d9343ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"
@@ -46,7 +54,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f84389ae",
+   "id": "b1097e12",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -55,7 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "de511689",
+   "id": "ffbef287",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +72,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71d89a02",
+   "id": "f1ec2839",
    "metadata": {},
    "source": [
     "Import common functionality"
@@ -73,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51c43b92",
+   "id": "75bc96b2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,18 +93,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39a9f044",
+   "id": "fd14d67e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mf2005_exe\n",
-    "exe_name_mt = config.mt3dms_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mf2005\"\n",
+    "exe_name_mt = \"mt3dms\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "017ba5d6",
+   "id": "9e885df9",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -105,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd55fa26",
+   "id": "ba830cf0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "388d7e76",
+   "id": "6c7e96f6",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -123,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b5e41f00",
+   "id": "46f1c6fc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27649cf3",
+   "id": "63588a60",
    "metadata": {},
    "source": [
     "Model units"
@@ -142,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "abad56b2",
+   "id": "d1feae9f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15c4ce82",
+   "id": "da846553",
    "metadata": {},
    "source": [
     "Table of model parameters"
@@ -161,7 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f166f38",
+   "id": "a7b36728",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "870cbc07",
+   "id": "9328f368",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,7 +207,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d7af478",
+   "id": "63622610",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -212,7 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d815a579",
+   "id": "0823b4b7",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -222,7 +230,9 @@
     "    print(f\"Building mf6gwf model...{sim_folder}\")\n",
     "    name = \"flow\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf6gwf\")\n",
-    "    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)\n",
+    "    sim = flopy.mf6.MFSimulation(\n",
+    "        sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
+    "    )\n",
     "    tdis_ds = ((total_time, 1, 1.0),)\n",
     "    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "    flopy.mf6.ModflowIms(sim, print_option=\"summary\", inner_maximum=300)\n",
@@ -269,7 +279,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "adc5c759",
+   "id": "536855f1",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -280,7 +290,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "912a175a",
+   "id": "135c4e7a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +298,9 @@
     "    print(f\"Building mf6gwt model...{sim_folder}\")\n",
     "    name = \"trans\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf6gwt\")\n",
-    "    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)\n",
+    "    sim = flopy.mf6.MFSimulation(\n",
+    "        sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
+    "    )\n",
     "    tdis_ds = ((total_time, 400, 1.0),)\n",
     "    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "    flopy.mf6.ModflowIms(sim, linear_acceleration=\"bicgstab\")\n",
@@ -344,7 +356,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29fa1231",
+   "id": "96cc40f4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -361,7 +373,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "082dcd8e",
+   "id": "778e4626",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -372,7 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46b4fa20",
+   "id": "7299296f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -388,7 +400,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "517fc0ae",
+   "id": "50f2b949",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -400,7 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "022d6f4e",
+   "id": "dfe4ba1a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -423,7 +435,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "050864a2",
+   "id": "6d6bf40d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -434,7 +446,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2810a5ab",
+   "id": "2e5a05ca",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -468,7 +480,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cad214f5",
+   "id": "7f881c8e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -509,7 +521,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35cb8ec3",
+   "id": "28f3a8cf",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -525,7 +537,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6568c6c4",
+   "id": "19cf9592",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -540,35 +552,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79519e8a",
+   "id": "4dca1459",
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "168a6d98",
-   "metadata": {},
    "source": [
-    "### Model"
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1f2194f1",
+   "id": "0580ac5c",
    "metadata": {},
    "source": [
-    "Model run"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c54b0382",
+   "id": "151eeb32",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(0)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Model\n",
+    "\n",
+    "    # Model run\n",
+    "\n",
+    "    scenario(0)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-moc3d-p02tg.ipynb
+++ b/notebooks/ex-gwt-moc3d-p02tg.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7e4f65b5",
+   "id": "a2b950a8",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c94c0dde",
+   "id": "df2e80d4",
    "metadata": {},
    "source": [
     "### Three-Dimensional Steady Flow with Transport Problem Setup"
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "400efab3",
+   "id": "b1f02f75",
    "metadata": {},
    "source": [
     "Imports"
@@ -32,13 +32,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57156025",
+   "id": "600d54a1",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f7f48ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import flopy.utils.cvfdutil\n",
     "import matplotlib.pyplot as plt\n",
@@ -47,7 +55,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57db3f28",
+   "id": "533dff7b",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -56,7 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e65c6a3",
+   "id": "20d8a2e1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +73,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3bb02dcd",
+   "id": "ff27daa2",
    "metadata": {},
    "source": [
     "Import common functionality"
@@ -74,7 +82,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f769e2d8",
+   "id": "4aab7612",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,18 +94,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "afd75263",
+   "id": "aa311711",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mf2005_exe\n",
-    "exe_name_mt = config.mt3dms_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mf2005\"\n",
+    "exe_name_mt = \"mt3dms\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "958dc958",
+   "id": "0b7c7f8b",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -106,7 +114,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2a32bcf5",
+   "id": "9bcc10c0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,7 +123,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f64eff90",
+   "id": "28f0ca4d",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -124,7 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11012ce3",
+   "id": "2cab5d77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +142,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e429bfe5",
+   "id": "3d17de4b",
    "metadata": {},
    "source": [
     "Model units"
@@ -143,7 +151,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f0ef830d",
+   "id": "1a979f35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +161,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6231b8c7",
+   "id": "baa945fa",
    "metadata": {},
    "source": [
     "Table of model parameters"
@@ -162,7 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4369fc71",
+   "id": "37979dfb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce058274",
+   "id": "d4321980",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d70ced8",
+   "id": "76dd27da",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -213,7 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19eae577",
+   "id": "e1a5b9fe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,7 +255,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1e9ce62",
+   "id": "a95ace92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf6166a2",
+   "id": "7173ccd2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -301,7 +309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "610a62cc",
+   "id": "1025ca51",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -311,7 +319,9 @@
     "    print(f\"Building mf6gwf model...{sim_folder}\")\n",
     "    name = \"flow\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf6gwf\")\n",
-    "    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)\n",
+    "    sim = flopy.mf6.MFSimulation(\n",
+    "        sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
+    "    )\n",
     "    tdis_ds = ((total_time, 1, 1.0),)\n",
     "    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "    flopy.mf6.ModflowIms(\n",
@@ -367,7 +377,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85eeac38",
+   "id": "3ef089e4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -378,7 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e045fd47",
+   "id": "ebb33296",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -386,7 +396,9 @@
     "    print(f\"Building mf6gwt model...{sim_folder}\")\n",
     "    name = \"trans\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf6gwt\")\n",
-    "    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)\n",
+    "    sim = flopy.mf6.MFSimulation(\n",
+    "        sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
+    "    )\n",
     "    tdis_ds = ((total_time, 100, 1.0),)\n",
     "    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "    flopy.mf6.ModflowIms(\n",
@@ -452,7 +464,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "804286c2",
+   "id": "157f98ce",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -469,7 +481,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "daedc601",
+   "id": "71292887",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -480,7 +492,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0cc8f7b",
+   "id": "2c348683",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -496,7 +508,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e4e1442",
+   "id": "a4a57a2c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -508,7 +520,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dff1d786",
+   "id": "6f1b682d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -531,7 +543,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "68d1701e",
+   "id": "b448109f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -542,7 +554,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a8558615",
+   "id": "fa19236b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -576,7 +588,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1a5342db",
+   "id": "d1a74b6e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -607,7 +619,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a6ad7216",
+   "id": "cda5ddfd",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -652,7 +664,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7522774c",
+   "id": "0a6de8fa",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -668,7 +680,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b254364e",
+   "id": "02b26ad4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -684,35 +696,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cb8a11cd",
+   "id": "0e9d39a9",
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1da61b7c",
-   "metadata": {},
    "source": [
-    "### Model"
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d69155e3",
+   "id": "450aec06",
    "metadata": {},
    "source": [
-    "Model run"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fbb99093",
+   "id": "166d0332",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(0)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Model\n",
+    "\n",
+    "    # Model run\n",
+    "\n",
+    "    scenario(0)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-mt3dms-p01.ipynb
+++ b/notebooks/ex-gwt-mt3dms-p01.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "1e059745",
+   "id": "e5cd34be",
    "metadata": {},
    "source": [
     "## One-Dimensional Transport in a Uniform Flow Field Comparison of MODFLOW 6 transport with MT3DMS\n",
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43180263",
+   "id": "c0e33847",
    "metadata": {},
    "source": [
     "### MODFLOW 6 GWT MT3DMS Example 1 Problem Setup"
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3085c58a",
+   "id": "55ba84e0",
    "metadata": {},
    "source": [
     "Imports"
@@ -45,7 +45,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97a13a0f",
+   "id": "f4563b57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2fba920e",
+   "id": "9ef6f9c1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe74697d",
+   "id": "894c3e57",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c191490f",
+   "id": "c54c8a7a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82665da9",
+   "id": "6a9f7808",
    "metadata": {},
    "source": [
     "Import common functionality"
@@ -94,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89fe4dfe",
+   "id": "9ea9de38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,18 +105,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac13138a",
+   "id": "926dc04f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mf2005_exe\n",
-    "exe_name_mt = config.mt3dms_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mf2005\"\n",
+    "exe_name_mt = \"mt3dms\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "a36c66e7",
+   "id": "7c8ab521",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -125,7 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae59b9cc",
+   "id": "0f9ad310",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +134,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0be6d700",
+   "id": "a2da2cf1",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -143,7 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6ac99a6e",
+   "id": "65fbbaa0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +152,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d74eafc7",
+   "id": "e108bc61",
    "metadata": {},
    "source": [
     "Set scenario parameters (make sure there is at least one blank line before next item)\n",
@@ -162,7 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3dfd74c2",
+   "id": "e70dfb19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,7 +192,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4ed3a44e",
+   "id": "368a9962",
    "metadata": {},
    "source": [
     "Scenario parameter units\n",
@@ -204,7 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3ac2fa02",
+   "id": "bb7406e2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,7 +217,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b715d08",
+   "id": "0aa88fd3",
    "metadata": {},
    "source": [
     "Model units"
@@ -226,7 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "facf5757",
+   "id": "e91422bb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +236,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4c6bf10c",
+   "id": "7d81bd2f",
    "metadata": {},
    "source": [
     "Table MODFLOW 6 GWT MT3DMS Example 1"
@@ -245,7 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14ebc0d3",
+   "id": "6fe3bad0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,7 +264,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c6609eb",
+   "id": "a18313dd",
    "metadata": {},
    "source": [
     "Set some static model parameter values"
@@ -273,7 +273,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61a698a4",
+   "id": "f08e83fe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +296,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2a495f6",
+   "id": "df25ab43",
    "metadata": {},
    "source": [
     "Set some static transport related model parameter values"
@@ -305,7 +305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "707353e1",
+   "id": "dcbf564d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a5a5ddd0",
+   "id": "844212df",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -339,7 +339,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48392ffd",
+   "id": "ad1b497b",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -348,7 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "117fd462",
+   "id": "53b6c9bb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -358,7 +358,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "041212c6",
+   "id": "c8fa80bd",
    "metadata": {},
    "source": [
     "### Create MODFLOW 6 GWT MT3DMS Example 1 Boundary Conditions\n",
@@ -369,7 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4c262a60",
+   "id": "ef1796cf",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -382,7 +382,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4272b12",
+   "id": "9c8da769",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -395,7 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "652a3132",
+   "id": "e9f66889",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -731,7 +731,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0d3fa2e",
+   "id": "19c116d2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -742,7 +742,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1d119dbb",
+   "id": "c66e7d1c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -757,7 +757,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d4e20494",
+   "id": "6beaca7a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -769,7 +769,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fd8bfa34",
+   "id": "f42f263a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -789,7 +789,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3749047d",
+   "id": "9ad1b24c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -800,7 +800,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f5c1445",
+   "id": "8438a8c0",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -864,7 +864,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1c8eb12",
+   "id": "283e5807",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -880,7 +880,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83a4ab2b",
+   "id": "e478bba0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -900,7 +900,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41e9fdc4",
+   "id": "4b9fdec0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -912,7 +912,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e0865b91",
+   "id": "aa608166",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -923,7 +923,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a840f3f2",
+   "id": "bb042c01",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -934,7 +934,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7760ecf9",
+   "id": "0d6267e9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -944,7 +944,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cafc45c4",
+   "id": "09fc1ad6",
    "metadata": {},
    "source": [
     "nosetest end"
@@ -953,7 +953,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1cf2556",
+   "id": "afb3ff65",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/ex-gwt-mt3dms-p02.ipynb
+++ b/notebooks/ex-gwt-mt3dms-p02.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "bfabacff",
+   "id": "4195e9ab",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2dc157b",
+   "id": "c7184fc2",
    "metadata": {},
    "source": [
     "### One-Dimensional Steady Flow with Transport Problem Setup"
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e6d01f61",
+   "id": "45911755",
    "metadata": {},
    "source": [
     "Imports"
@@ -32,13 +32,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88250a39",
+   "id": "3235d267",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cca6739d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"
@@ -46,7 +54,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8f63e06a",
+   "id": "0a6572d0",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -55,7 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb9fbb4a",
+   "id": "a49f76c4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +72,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78fbc2a1",
+   "id": "a2f93979",
    "metadata": {},
    "source": [
     "Import common functionality"
@@ -73,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c3ddcb99",
+   "id": "6c8b11eb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,16 +93,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84bc0f09",
+   "id": "ae880fbf",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe"
+    "mf6exe = \"mf6\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9161ecaf",
+   "id": "d21f4673",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -103,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65ac7bba",
+   "id": "703cd1c1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18cfd135",
+   "id": "a6a8cb1f",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -121,7 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3fa27ed5",
+   "id": "59a59091",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4cab8aa",
+   "id": "573011e0",
    "metadata": {},
    "source": [
     "Scenario parameters - make sure there is at least one blank line before next item"
@@ -140,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2183ae9c",
+   "id": "81e4d7b5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +180,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5743667c",
+   "id": "4c5e6359",
    "metadata": {},
    "source": [
     "Scenario parameter units - make sure there is at least one blank line before next item\n",
@@ -182,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e039305e",
+   "id": "200de92a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,7 +206,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f1abd7f",
+   "id": "fa8f9310",
    "metadata": {},
    "source": [
     "Model units"
@@ -207,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "da149ba2",
+   "id": "909cb7b8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,7 +225,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d4d32b81",
+   "id": "0af3a255",
    "metadata": {},
    "source": [
     "Table of model parameters"
@@ -226,7 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a936181c",
+   "id": "4c652b7e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,7 +262,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c748bf0a",
+   "id": "436ee511",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +273,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c208cb4",
+   "id": "39745387",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -278,7 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e80768ec",
+   "id": "3ba99c13",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -288,7 +296,9 @@
     "    print(f\"Building mf6gwf model...{sim_folder}\")\n",
     "    name = \"flow\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf6gwf\")\n",
-    "    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)\n",
+    "    sim = flopy.mf6.MFSimulation(\n",
+    "        sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
+    "    )\n",
     "    tdis_ds = (\n",
     "        (period1, int(period1 / delta_time), 1.0),\n",
     "        (period2, int(period2 / delta_time), 1.0),\n",
@@ -354,7 +364,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "486ae917",
+   "id": "cfc8dc8e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -365,7 +375,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "df862c30",
+   "id": "eb6c6e85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,7 +385,9 @@
     "    print(f\"Building mf6gwt model...{sim_folder}\")\n",
     "    name = \"trans\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf6gwt\")\n",
-    "    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)\n",
+    "    sim = flopy.mf6.MFSimulation(\n",
+    "        sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
+    "    )\n",
     "    tdis_ds = (\n",
     "        (period1, int(period1 / delta_time), 1.0),\n",
     "        (period2, int(period2 / delta_time), 1.0),\n",
@@ -412,7 +424,7 @@
     "        sp2 = a\n",
     "    if S is not None:\n",
     "        sp2 = S\n",
-    "    volfracim = 0.\n",
+    "    volfracim = 0.0\n",
     "    if beta is not None:\n",
     "        if beta > 0:\n",
     "            volfracim = bulk_density / (bulk_density + porosity)\n",
@@ -430,10 +442,9 @@
     "    if beta is not None:\n",
     "        if beta > 0:\n",
     "            porosity_im = bulk_density / volfracim\n",
-    "            flopy.mf6.ModflowGwtist(gwt,\n",
-    "                                    volfrac=volfracim,\n",
-    "                                    porosity=porosity_im,\n",
-    "                                    zetaim=beta)\n",
+    "            flopy.mf6.ModflowGwtist(\n",
+    "                gwt, volfrac=volfracim, porosity=porosity_im, zetaim=beta\n",
+    "            )\n",
     "    pd = [\n",
     "        (\"GWFHEAD\", f\"../mf6gwf/flow.hds\", None),\n",
     "        (\"GWFBUDGET\", \"../mf6gwf/flow.bud\", None),\n",
@@ -462,7 +473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47a2b578",
+   "id": "ca52dfd1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -471,7 +482,7 @@
     "    name = \"flow\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf2005\")\n",
     "    mf = flopy.modflow.Modflow(\n",
-    "        modelname=name, model_ws=sim_ws, exe_name=config.mf2005_exe\n",
+    "        modelname=name, model_ws=sim_ws, exe_name=\"mf2005\"\n",
     "    )\n",
     "    perlen = [period1, period2]\n",
     "    dis = flopy.modflow.ModflowDis(\n",
@@ -503,7 +514,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d3755200",
+   "id": "6f451c1b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -523,7 +534,7 @@
     "    mt = flopy.mt3d.Mt3dms(\n",
     "        modelname=name,\n",
     "        model_ws=sim_ws,\n",
-    "        exe_name=config.mt3dms_exe,\n",
+    "        exe_name=\"mt3dms\",\n",
     "        modflowmodel=modflowmodel,\n",
     "        ftlfilename=\"../mf2005/mt3d_link.ftl\",\n",
     "    )\n",
@@ -560,7 +571,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fdc5471a",
+   "id": "2bf204eb",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -579,7 +590,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad0f18d0",
+   "id": "f74ad00a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -590,7 +601,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "019b852b",
+   "id": "a155f97f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -608,7 +619,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "afeeb68d",
+   "id": "813bd3ee",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -620,7 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8cd929bf",
+   "id": "49a604e6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -656,7 +667,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1a82e8e7",
+   "id": "00de1fe2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -667,7 +678,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "796a9e31",
+   "id": "662d320a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -723,7 +734,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b1174ac6",
+   "id": "cd35b593",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -780,7 +791,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12ee97ec",
+   "id": "9597e7e6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -796,7 +807,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "da436a74",
+   "id": "31e056aa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -813,136 +824,125 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c5cbc2e",
+   "id": "b8408a9f",
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c0ecf8a8",
-   "metadata": {},
    "source": [
-    "### Simulated Zero-Order Growth in a Uniform Flow Field"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f89ad716",
-   "metadata": {},
-   "source": [
-    "Scenario 1 - description"
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d6ceb24",
+   "id": "dbd3a578",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(0)"
+    "def test_02():\n",
+    "    scenario(1, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45dae845",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_03():\n",
+    "    scenario(2, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7c9dbd7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_04():\n",
+    "    scenario(3, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1422d5fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_05():\n",
+    "    scenario(4, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1fab8a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_06():\n",
+    "    scenario(5, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10a9cc36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_plot_results():\n",
+    "    plot_results()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8fce90d4",
+   "id": "360e0ee6",
    "metadata": {},
    "source": [
-    "Scenario 2 - description"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7373f057",
+   "id": "686236a3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "230c5c58",
-   "metadata": {},
-   "source": [
-    "Scenario 3 - description"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5e069eca",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "scenario(2)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b2980e8a",
-   "metadata": {},
-   "source": [
-    "Scenario 4 - description"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "10356d6d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "scenario(3)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "14013b62",
-   "metadata": {},
-   "source": [
-    "Scenario 5 - description"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0d590c75",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "scenario(4)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e4399595",
-   "metadata": {},
-   "source": [
-    "Scenario 6 - description"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ba7b26a8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "scenario(5)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f5c1e43a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Plot All Results\n",
-    "plot_results()"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Simulated Zero-Order Growth in a Uniform Flow Field\n",
+    "\n",
+    "    # Scenario 1 - description\n",
+    "\n",
+    "    scenario(0)\n",
+    "\n",
+    "    # Scenario 2 - description\n",
+    "\n",
+    "    scenario(1)\n",
+    "\n",
+    "    # Scenario 3 - description\n",
+    "\n",
+    "    scenario(2)\n",
+    "\n",
+    "    # Scenario 4 - description\n",
+    "\n",
+    "    scenario(3)\n",
+    "\n",
+    "    # Scenario 5 - description\n",
+    "\n",
+    "    scenario(4)\n",
+    "\n",
+    "    # Scenario 6 - description\n",
+    "\n",
+    "    scenario(5)\n",
+    "\n",
+    "    # Plot All Results\n",
+    "    plot_results()"
    ]
   }
  ],

--- a/notebooks/ex-gwt-mt3dms-p03.ipynb
+++ b/notebooks/ex-gwt-mt3dms-p03.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "6446626b",
+   "id": "049826f3",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58b290a3",
+   "id": "b6839824",
    "metadata": {},
    "source": [
     "### MODFLOW 6 GWT MT3DMS Example 3 Problem Setup"
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "762e5321",
+   "id": "b14c2736",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -47,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ee453f1",
+   "id": "6a11dc22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9af36229",
+   "id": "d1de6075",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "707d0c9d",
+   "id": "76702033",
    "metadata": {},
    "source": [
     "Imports"
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5747e7a8",
+   "id": "f38d57c9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,18 +90,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "028af561",
+   "id": "3eb9a5fb",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mf2005_exe\n",
-    "exe_name_mt = config.mt3dms_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mf2005\"\n",
+    "exe_name_mt = \"mt3dms\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "e84e62bd",
+   "id": "be29f521",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -110,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "691745df",
+   "id": "4359fad8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5e79545",
+   "id": "23006617",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -128,7 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7da8137d",
+   "id": "6272adf5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +138,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f76a36e2",
+   "id": "438039b1",
    "metadata": {},
    "source": [
     "Model units"
@@ -147,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "914fe576",
+   "id": "60507af1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,7 +157,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "04bbc724",
+   "id": "65fdd5a2",
    "metadata": {},
    "source": [
     "Table"
@@ -166,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e5b6df6a",
+   "id": "2cdfae13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,7 +188,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d7f21f49",
+   "id": "81cbd4e6",
    "metadata": {},
    "source": [
     "Additional model input"
@@ -197,7 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21807096",
+   "id": "7047cb88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c7c44aa5",
+   "id": "95d23565",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,7 +224,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6efdc0dc",
+   "id": "3442969e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +234,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "744600bc",
+   "id": "ade7b066",
    "metadata": {},
    "source": [
     "Initial conditions"
@@ -243,7 +243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75785cc6",
+   "id": "8653f7f5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -259,7 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1331fa5e",
+   "id": "4c63d7cc",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -280,7 +280,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b925c75d",
+   "id": "3a9bddf3",
    "metadata": {},
    "source": [
     "Set solver parameter values (and related)"
@@ -289,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a50fa44d",
+   "id": "0c4c1fe2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91fda1c0",
+   "id": "f7cc4a50",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -321,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "07c2dc2d",
+   "id": "4292290c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -333,7 +333,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a99e218",
+   "id": "7ba75214",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -346,7 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cb8895ed",
+   "id": "6366cff4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -669,7 +669,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36ba3e4c",
+   "id": "7865bdcc",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -680,7 +680,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c335aca",
+   "id": "21460c7e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -695,7 +695,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2cb1ca69",
+   "id": "30af7414",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -706,7 +706,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a41f9a6",
+   "id": "ce923849",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -726,7 +726,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43b9b6c1",
+   "id": "4beddf8f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -737,7 +737,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "359e4a02",
+   "id": "bc8c3360",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -807,7 +807,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ecdf2196",
+   "id": "acb51bf6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -823,7 +823,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cbd85247",
+   "id": "d1ae751c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -839,29 +839,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c18041f",
+   "id": "4508c5ed",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "d6c098db",
+   "id": "c4589549",
    "metadata": {},
    "source": [
-    "### Two-Dimensional Transport in a Uniform Flow Field\n",
-    "\n",
-    "Describe what is plotted here..."
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56aa7e77",
+   "id": "30339969",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(0)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Two-Dimensional Transport in a Uniform Flow Field\n",
+    "    #\n",
+    "    # Describe what is plotted here...\n",
+    "\n",
+    "    scenario(0)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-mt3dms-p04.ipynb
+++ b/notebooks/ex-gwt-mt3dms-p04.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "544c0461",
+   "id": "dd561f53",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af7f3f41",
+   "id": "cf65379d",
    "metadata": {},
    "source": [
     "### MODFLOW 6 GWT MT3DMS Example 4 Problem Setup"
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "158f2fa2",
+   "id": "e239dd25",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -47,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fef22d8a",
+   "id": "b1e5f095",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3025f162",
+   "id": "d98bb2db",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da869b09",
+   "id": "59355d8d",
    "metadata": {},
    "source": [
     "Imports"
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82c3bb02",
+   "id": "2a7484fa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,18 +90,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c1df30f",
+   "id": "7bdcb3ad",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mf2005_exe\n",
-    "exe_name_mt = config.mt3dms_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mf2005\"\n",
+    "exe_name_mt = \"mt3dms\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3ddaac23",
+   "id": "dab7ab84",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -110,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9643f075",
+   "id": "da181255",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "996af300",
+   "id": "4a0b5eb3",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -128,7 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3734fe8e",
+   "id": "0b3351c0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +138,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d8812d59",
+   "id": "29daf52b",
    "metadata": {},
    "source": [
     "Set scenario parameters (make sure there is at least one blank line before next item)\n",
@@ -148,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b685da60",
+   "id": "eaca04ff",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e56daf89",
+   "id": "d7e9f166",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +175,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a20f59f",
+   "id": "0428ecab",
    "metadata": {},
    "source": [
     "Setup some lists that will assist with labeling contours in the figures"
@@ -184,7 +184,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f40d9c5b",
+   "id": "e06357df",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,7 +194,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e944bc43",
+   "id": "033b7aae",
    "metadata": {},
    "source": [
     "Model units"
@@ -203,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75003eda",
+   "id": "a36aed80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +213,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc2ceaac",
+   "id": "07c97e38",
    "metadata": {},
    "source": [
     "Table"
@@ -222,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3c016d45",
+   "id": "becf86ed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +245,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59963a9a",
+   "id": "fef811b4",
    "metadata": {},
    "source": [
     "Additional model input"
@@ -254,7 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eeaeca72",
+   "id": "c0f5e7fd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,7 +273,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22e6cf48",
+   "id": "afc17357",
    "metadata": {},
    "source": [
     "Initial conditions"
@@ -282,7 +282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c461871",
+   "id": "f5d690a9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,7 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50ff79aa",
+   "id": "c25dd5e6",
    "metadata": {},
    "source": [
     "Active model domain"
@@ -308,7 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c3251a5",
+   "id": "86dd634f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,7 +320,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a89a6d55",
+   "id": "bb54fa26",
    "metadata": {},
    "source": [
     "Boundary conditions\n",
@@ -330,7 +330,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84937c45",
+   "id": "31986aa6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -340,7 +340,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0b15491b",
+   "id": "57677b21",
    "metadata": {},
    "source": [
     "MF6 pumping information\n",
@@ -350,7 +350,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f6a186a3",
+   "id": "b360e742",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +359,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8eecc464",
+   "id": "2549533f",
    "metadata": {},
    "source": [
     "MF6 constant head boundaries are defined below because additional variables\n",
@@ -368,7 +368,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8304898",
+   "id": "95c52236",
    "metadata": {},
    "source": [
     "Solver settings"
@@ -377,7 +377,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72aab30b",
+   "id": "35c558ee",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -388,7 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "596a5276",
+   "id": "132a8896",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -408,7 +408,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "84ecb8a8",
+   "id": "404b5d60",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -417,7 +417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "301107fa",
+   "id": "e6d4eb6c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -429,7 +429,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1364380e",
+   "id": "27073bb8",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -442,7 +442,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e7c875b6",
+   "id": "ec88dfae",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -762,7 +762,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fd00a7a2",
+   "id": "97692516",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -773,7 +773,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b5488ed3",
+   "id": "d240ade1",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -788,7 +788,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80469107",
+   "id": "30108b02",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -799,7 +799,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b64e80e7",
+   "id": "d73545a4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -819,7 +819,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0bd5944f",
+   "id": "a23b5cbc",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -830,7 +830,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70fc2d11",
+   "id": "0321b5db",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -894,7 +894,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "04936e30",
+   "id": "3e0b5d61",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -910,7 +910,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a1db3aca",
+   "id": "411761b2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -930,71 +930,66 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cefb5927",
+   "id": "fbb19bdc",
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "efa0b465",
-   "metadata": {},
    "source": [
-    "### Two-Dimensional Transport in a Diagonal Flow Field"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "147d2955",
-   "metadata": {},
-   "source": [
-    "Compares the standard finite difference solutions between MT3D MF 6"
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2a4e95f5",
+   "id": "a0fbf0e4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0ee4b74a",
-   "metadata": {},
-   "source": [
-    "Compares the respective TVD solutions between MT3D MF 6"
+    "def test_02():\n",
+    "    scenario(1, silent=False)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3ab145b0",
+   "id": "67bac2af",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(1)"
+    "def test_03():\n",
+    "    scenario(2, silent=False)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "e0bdb665",
+   "id": "6bc288b5",
    "metadata": {},
    "source": [
-    "Compares a MOC solution in MT3D with the standard FD method of MF 6"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "583715b4",
+   "id": "156be3ae",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(2)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Two-Dimensional Transport in a Diagonal Flow Field\n",
+    "\n",
+    "    # Compares the standard finite difference solutions between MT3D MF 6\n",
+    "\n",
+    "    scenario(0)\n",
+    "\n",
+    "    # Compares the respective TVD solutions between MT3D MF 6\n",
+    "\n",
+    "    scenario(1)\n",
+    "\n",
+    "    # Compares a MOC solution in MT3D with the standard FD method of MF 6\n",
+    "\n",
+    "    scenario(2)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-mt3dms-p05.ipynb
+++ b/notebooks/ex-gwt-mt3dms-p05.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "dd7757c8",
+   "id": "ac561e97",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5035212b",
+   "id": "23c1790c",
    "metadata": {},
    "source": [
     "### MODFLOW 6 GWT MT3DMS Example 5 Problem Setup"
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2269103",
+   "id": "9247f23e",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -47,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a377d4b",
+   "id": "b53d4274",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fbfd8b5d",
+   "id": "03d1dc8e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b332fd25",
+   "id": "767ee7ec",
    "metadata": {},
    "source": [
     "Imports"
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34b0bd53",
+   "id": "a43893b9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,18 +90,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "103564f3",
+   "id": "a8bc26a0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mf2005_exe\n",
-    "exe_name_mt = config.mt3dms_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mf2005\"\n",
+    "exe_name_mt = \"mt3dms\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "c7fb42eb",
+   "id": "84845fa9",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -110,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68a3d673",
+   "id": "589e482d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "366a662e",
+   "id": "813384ee",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -128,7 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2a0d1c34",
+   "id": "1df98586",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +138,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a5ae2f9c",
+   "id": "a6b3fd6b",
    "metadata": {},
    "source": [
     "Model units"
@@ -147,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d451037a",
+   "id": "ce001b86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,7 +157,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "430e8232",
+   "id": "a67004e5",
    "metadata": {},
    "source": [
     "Table"
@@ -166,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18fa1ebe",
+   "id": "4cbdb2d7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +189,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "892995f2",
+   "id": "eac45204",
    "metadata": {},
    "source": [
     "Additional model input"
@@ -198,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0acb243f",
+   "id": "450f6382",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,7 +219,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46126816",
+   "id": "6ecd175a",
    "metadata": {},
    "source": [
     "Active model domain"
@@ -228,7 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3abb7816",
+   "id": "11644d83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a776a2d",
+   "id": "08fc6040",
    "metadata": {},
    "source": [
     "Boundary conditions\n",
@@ -250,7 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65fbaad7",
+   "id": "763623ab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +260,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "99351db5",
+   "id": "c7f174dc",
    "metadata": {},
    "source": [
     "MF6 pumping information"
@@ -269,7 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b084694c",
+   "id": "8817d5a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,7 +279,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c75c02c",
+   "id": "df7ac4da",
    "metadata": {},
    "source": [
     "MF6 constant head boundaries:"
@@ -288,7 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "576945af",
+   "id": "ca208771",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,7 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44929595",
+   "id": "bf766b68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,7 +315,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08b6d409",
+   "id": "9f95f2cd",
    "metadata": {},
    "source": [
     "Solver settings"
@@ -324,7 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4073371e",
+   "id": "13892eeb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -346,7 +346,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b521453",
+   "id": "e8c5f514",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -355,7 +355,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62669c40",
+   "id": "05f0d29c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -365,7 +365,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f98e08da",
+   "id": "b7da7b76",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -378,7 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17086a90",
+   "id": "4ce34c6d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -695,7 +695,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3fb376d1",
+   "id": "eff6c939",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -706,7 +706,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8fab6d93",
+   "id": "f5a60c77",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -721,7 +721,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f38183c9",
+   "id": "2bb5d253",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -732,7 +732,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44dd3c64",
+   "id": "5b70a963",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -752,7 +752,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "933d3c14",
+   "id": "9f01cb45",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -763,7 +763,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72f6f7ff",
+   "id": "395ff38d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -865,7 +865,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f95428ab",
+   "id": "81414927",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -881,8 +881,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83d7176b",
-   "metadata": {},
+   "id": "02963123",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "outputs": [],
    "source": [
     "def scenario(idx, silent=True):\n",
@@ -897,24 +899,46 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6deda948",
-   "metadata": {},
-   "outputs": [],
-   "source": []
+   "cell_type": "markdown",
+   "id": "ba0182ca",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "nosetest - exclude block from this nosetest to the next nosetest"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45b9d686",
+   "id": "28968d7d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ### Two-Dimensional Transport in a Diagonal Flow Field\n",
-    "#\n",
-    "# Compares the standard finite difference solutions between MT3D MF 6\n",
-    "scenario(0)"
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "510c8c57",
+   "metadata": {},
+   "source": [
+    "nosetest end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6fa2f97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    # ### Two-Dimensional Transport in a Diagonal Flow Field\n",
+    "    #\n",
+    "    # Compares the standard finite difference solutions between MT3D MF 6\n",
+    "    scenario(0)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-mt3dms-p06.ipynb
+++ b/notebooks/ex-gwt-mt3dms-p06.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "35349f43",
+   "id": "1cdf832a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25924704",
+   "id": "7cab4300",
    "metadata": {},
    "source": [
     "### MODFLOW 6 GWT MT3DMS Example 6 Problem Setup"
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18ffd376",
+   "id": "c94688d6",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -47,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f8f40335",
+   "id": "97bfd849",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b71b619e",
+   "id": "7859401a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c5393006",
+   "id": "31d32d38",
    "metadata": {},
    "source": [
     "Imports"
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1dc71a38",
+   "id": "41b9afa9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,18 +90,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c3113429",
+   "id": "614e34ee",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mf2005_exe\n",
-    "exe_name_mt = config.mt3dusgs_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mf2005\"\n",
+    "exe_name_mt = \"mt3dusgs\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1aaaaf77",
+   "id": "64e2f377",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -110,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f2b33900",
+   "id": "51ce5d3f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "267d22b4",
+   "id": "63ed6783",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -128,7 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f03ce11d",
+   "id": "2aa77cd6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +138,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f14651b",
+   "id": "84d76d11",
    "metadata": {},
    "source": [
     "Model units"
@@ -147,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45feb9cb",
+   "id": "e8203344",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,7 +157,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5763d6ac",
+   "id": "b454629f",
    "metadata": {},
    "source": [
     "Table"
@@ -166,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "07322091",
+   "id": "f58419c3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +189,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4e97a3a",
+   "id": "38efc8a9",
    "metadata": {},
    "source": [
     "Additional model input"
@@ -198,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca511959",
+   "id": "975d04e4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c3d9a97e",
+   "id": "1f6ac3ee",
    "metadata": {},
    "source": [
     "Active model domain"
@@ -230,7 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eebb01a9",
+   "id": "38b51421",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +242,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ea3f269",
+   "id": "f62718ce",
    "metadata": {},
    "source": [
     "Boundary conditions\n",
@@ -252,7 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "035d7efe",
+   "id": "d921fb1f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,7 +271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "467b36cc",
+   "id": "ef7e7c8d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +282,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "892e5c94",
+   "id": "78526241",
    "metadata": {},
    "source": [
     "MF6 constant head boundaries:"
@@ -291,7 +291,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c73415ea",
+   "id": "3383e122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e1231b2",
+   "id": "8906350b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +318,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "369af703",
+   "id": "2e340341",
    "metadata": {},
    "source": [
     "Solver settings"
@@ -327,7 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e57aa599",
+   "id": "6a83b0a2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -349,7 +349,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "752a17d4",
+   "id": "5c0bfde3",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -358,7 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db0cfd2d",
+   "id": "4c280f3d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -368,7 +368,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "913294b8",
+   "id": "3784241d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -381,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2822e1d3",
+   "id": "eca76045",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -691,7 +691,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "510f03cb",
+   "id": "96eeacca",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -702,7 +702,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "858c5017",
+   "id": "af41a252",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -717,7 +717,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d972de9",
+   "id": "65892bc6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -728,7 +728,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40a7185d",
+   "id": "1605e770",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -748,7 +748,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20054560",
+   "id": "54e85f72",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -759,7 +759,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0204a38f",
+   "id": "4544bd3d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -832,7 +832,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c0ccc9a9",
+   "id": "9e5e0296",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -848,8 +848,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b3addc2",
-   "metadata": {},
+   "id": "7228b557",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "outputs": [],
    "source": [
     "def scenario(idx, silent=True):\n",
@@ -864,24 +866,46 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4b2bb0b4",
-   "metadata": {},
-   "outputs": [],
-   "source": []
+   "cell_type": "markdown",
+   "id": "f452fc0d",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "nosetest - exclude block from this nosetest to the next nosetest"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a2727b4a",
+   "id": "ff50e5ef",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ### Two-Dimensional Transport in a Diagonal Flow Field\n",
-    "#\n",
-    "# Compares the standard finite difference solutions between MT3D MF 6\n",
-    "scenario(0)"
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cdc5286c",
+   "metadata": {},
+   "source": [
+    "nosetest end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c3a31fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    # ### Two-Dimensional Transport in a Diagonal Flow Field\n",
+    "    #\n",
+    "    # Compares the standard finite difference solutions between MT3D MF 6\n",
+    "    scenario(0)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-mt3dms-p07.ipynb
+++ b/notebooks/ex-gwt-mt3dms-p07.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "2d848a9c",
+   "id": "ec961a25",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5ebd157",
+   "id": "5f279cf1",
    "metadata": {},
    "source": [
     "### MODFLOW 6 GWT MT3DMS Example 6 Problem Setup"
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "94d7201e",
+   "id": "d824665c",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -47,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0331c7b",
+   "id": "ef80d501",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4df28a22",
+   "id": "49fea876",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "986051c3",
+   "id": "28928fca",
    "metadata": {},
    "source": [
     "Imports"
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5da5ccc2",
+   "id": "01500510",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,18 +90,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "333cb2dc",
+   "id": "0b01c65c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mf2005_exe\n",
-    "exe_name_mt = config.mt3dusgs_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mf2005\"\n",
+    "exe_name_mt = \"mt3dusgs\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "0bf58156",
+   "id": "9a87e7d6",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -110,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29d6c11b",
+   "id": "ef9542d0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "580eaafe",
+   "id": "20f6b275",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -128,7 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72572158",
+   "id": "b6132cd4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +138,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29d17a68",
+   "id": "da4a5ca8",
    "metadata": {},
    "source": [
     "Model units"
@@ -147,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d61c3a23",
+   "id": "96d3ba2b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,7 +157,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14e95b3d",
+   "id": "0cb9d75b",
    "metadata": {},
    "source": [
     "Table"
@@ -166,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5b9262ef",
+   "id": "be062106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,7 +188,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2664a2d7",
+   "id": "62ebea5e",
    "metadata": {},
    "source": [
     "Additional model input"
@@ -197,7 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d82cd830",
+   "id": "9746d165",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,7 +227,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "595a29a7",
+   "id": "a2bc9354",
    "metadata": {},
    "source": [
     "Active model domain"
@@ -236,7 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5810ea23",
+   "id": "6a094ba4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +249,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12b940b5",
+   "id": "c6408c27",
    "metadata": {},
    "source": [
     "Boundary conditions\n",
@@ -259,7 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38a5965f",
+   "id": "7a87d9f5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -275,7 +275,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3977e408",
+   "id": "1d20430f",
    "metadata": {},
    "source": [
     "MF6 pumping information"
@@ -284,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1dda36a6",
+   "id": "83f9f436",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,7 +294,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c18a01af",
+   "id": "05598ccb",
    "metadata": {},
    "source": [
     "MF6 constant head boundaries:"
@@ -303,7 +303,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20e5d2bc",
+   "id": "951503ed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d8f24661",
+   "id": "12ae0670",
    "metadata": {},
    "source": [
     "Solver settings"
@@ -328,7 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "03fac340",
+   "id": "9acff24c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,7 +350,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97d30c14",
+   "id": "e68203bf",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -359,7 +359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39c3aa42",
+   "id": "79234a14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,7 +369,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b3065bf",
+   "id": "3c22bcf6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -382,7 +382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "813f165f",
+   "id": "b986dd5a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -687,7 +687,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47c36fa7",
+   "id": "960051e8",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -698,7 +698,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9fd3331d",
+   "id": "9f9e2110",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -713,7 +713,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4ad7e58f",
+   "id": "efc2ac0d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -724,7 +724,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99a8cd89",
+   "id": "1ba6af12",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -744,7 +744,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a7a1310",
+   "id": "e1287207",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -755,7 +755,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98950351",
+   "id": "0128746d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -870,7 +870,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "530fb218",
+   "id": "f6a27ad6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -886,7 +886,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb81c997",
+   "id": "d404718e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -901,22 +901,35 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2b206aa5",
+   "id": "0fa8b08c",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aaa6f84a",
+   "metadata": {},
+   "source": [
+    "nosetest end"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e9f78b40",
+   "id": "11efdaa1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ### Two-Dimensional Transport in a Diagonal Flow Field\n",
-    "#\n",
-    "# Compares the standard finite difference solutions between MT3D MF 6\n",
-    "scenario(0)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Two-Dimensional Transport in a Diagonal Flow Field\n",
+    "    #\n",
+    "    # Compares the standard finite difference solutions between MT3D MF 6\n",
+    "    scenario(0)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-mt3dms-p08.ipynb
+++ b/notebooks/ex-gwt-mt3dms-p08.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "42be9eea",
+   "id": "f139990a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf999706",
+   "id": "2dda63c0",
    "metadata": {},
    "source": [
     "### MODFLOW 6 GWT MT3DMS Example 6 Problem Setup"
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96ad21f1",
+   "id": "7385f060",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -47,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c61621c4",
+   "id": "aa8d5ff4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d8d5436c",
+   "id": "30efbd15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9890fe3",
+   "id": "ad3c7c53",
    "metadata": {},
    "source": [
     "Imports"
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92582ddd",
+   "id": "36b68163",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,18 +91,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3d68a8fd",
+   "id": "c69b1d34",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mf2005_exe\n",
-    "exe_name_mt = config.mt3dusgs_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mf2005\"\n",
+    "exe_name_mt = \"mt3dusgs\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1050a544",
+   "id": "fef231ef",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -111,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c33353ef",
+   "id": "ce47e66f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69dd903e",
+   "id": "ce11a766",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -129,7 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75d166c0",
+   "id": "ec1344be",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "99883e2c",
+   "id": "89aa6849",
    "metadata": {},
    "source": [
     "Model units"
@@ -148,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "df04951a",
+   "id": "dca3c4f6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "511a6c3c",
+   "id": "a063915f",
    "metadata": {},
    "source": [
     "Table MODFLOW 6 GWT MT3DMS Example 8"
@@ -167,7 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c28e3b99",
+   "id": "665cea58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,7 +190,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9dd8ed9f",
+   "id": "61499810",
    "metadata": {},
    "source": [
     "Additional model input"
@@ -199,7 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44ae39a2",
+   "id": "1604a980",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,7 +237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91640033",
+   "id": "9674ce5e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -251,7 +251,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ee8e742",
+   "id": "dd61b288",
    "metadata": {},
    "source": [
     "Boundary conditions\n",
@@ -261,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a3c669e5",
+   "id": "83b50961",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc4a654f",
+   "id": "6c57c992",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,7 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4193a639",
+   "id": "03fa6dfd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d641d645",
+   "id": "36a02f0b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +318,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56de74df",
+   "id": "694778a0",
    "metadata": {},
    "source": [
     "Solver settings"
@@ -327,7 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0cbf819",
+   "id": "d6a5bfd0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -349,7 +349,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16790055",
+   "id": "f9c687b5",
    "metadata": {},
    "source": [
     "Static temporal data used by TDIS file"
@@ -358,7 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "abf8ca66",
+   "id": "be8143e9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -368,7 +368,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e34679f8",
+   "id": "f14454f5",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -381,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a2c7d92",
+   "id": "cebda8c4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -744,7 +744,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1adaf6b",
+   "id": "13788f38",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -755,7 +755,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "179ff33a",
+   "id": "1211e546",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -770,7 +770,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "307e74d1",
+   "id": "b8bbf35a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -781,7 +781,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c947ae60",
+   "id": "230a8414",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -801,7 +801,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a5f8833",
+   "id": "0d63c76b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -812,7 +812,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aea1ff50",
+   "id": "6714448f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -994,7 +994,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2a757655",
+   "id": "30f1006a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1010,7 +1010,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f8e21f6",
+   "id": "64f4d6ef",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1025,22 +1025,35 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7b5e0e8",
+   "id": "e419375e",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1ec044c",
+   "metadata": {},
+   "source": [
+    "nosetest end"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eb0ef9f2",
+   "id": "aad49922",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ### Two-Dimensional Transport in a Diagonal Flow Field\n",
-    "#\n",
-    "# Compares the standard finite difference solutions between MT3D MF 6\n",
-    "scenario(0, silent=True)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Two-Dimensional Transport in a Diagonal Flow Field\n",
+    "    #\n",
+    "    # Compares the standard finite difference solutions between MT3D MF 6\n",
+    "    scenario(0, silent=True)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-mt3dms-p09.ipynb
+++ b/notebooks/ex-gwt-mt3dms-p09.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a5e72b57",
+   "id": "c98454f9",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "120d205b",
+   "id": "5a881c94",
    "metadata": {},
    "source": [
     "### MODFLOW 6 GWT MT3DMS Example 9 Problem Setup"
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2ab7ce8",
+   "id": "3f7ec249",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -47,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c69d1cb2",
+   "id": "f5219e7c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "947538be",
+   "id": "3b1f52a9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b9f4c79d",
+   "id": "54811074",
    "metadata": {},
    "source": [
     "Imports"
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25987bde",
+   "id": "3a303006",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,18 +91,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "591e56d6",
+   "id": "c8597a41",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mf2005_exe\n",
-    "exe_name_mt = config.mt3dusgs_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mf2005\"\n",
+    "exe_name_mt = \"mt3dusgs\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3fddb5a5",
+   "id": "3759c056",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -111,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9cdd477b",
+   "id": "cbc03946",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a06b177b",
+   "id": "096ffbfa",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -129,7 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9cc1938c",
+   "id": "484e8677",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d82cbf2",
+   "id": "b3352fad",
    "metadata": {},
    "source": [
     "Model units"
@@ -148,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7c30985",
+   "id": "6b27ef0f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9be384f",
+   "id": "0d9b955f",
    "metadata": {},
    "source": [
     "Table MODFLOW 6 GWT MT3DMS Example 8"
@@ -167,7 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b93b9526",
+   "id": "ea6ae01d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,7 +190,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37fa6171",
+   "id": "44b0ec78",
    "metadata": {},
    "source": [
     "Additional model input"
@@ -199,7 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dbce192c",
+   "id": "5d5a7a39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,7 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1bee6887",
+   "id": "dddd5226",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84718e7b",
+   "id": "99685b1d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -257,7 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a2b1eb5",
+   "id": "2392357a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +280,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7be49c24",
+   "id": "5b76ffad",
    "metadata": {},
    "source": [
     "Solver settings"
@@ -289,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68f2cfe8",
+   "id": "96675a49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e27b4bb4",
+   "id": "a7bcc7ee",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -325,7 +325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "403eb835",
+   "id": "bf9c7498",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -663,7 +663,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "968d6e17",
+   "id": "3674f04e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -674,7 +674,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16e5ffed",
+   "id": "62933796",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -689,7 +689,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8197ddf6",
+   "id": "48505509",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -700,7 +700,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52eadf6d",
+   "id": "2fee0cad",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -720,7 +720,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "698d0843",
+   "id": "7a1e9d8c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -731,7 +731,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bf32c04b",
+   "id": "a847477e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -820,7 +820,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4a048b34",
+   "id": "9b5ecb3a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -836,7 +836,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e614d145",
+   "id": "3093ce41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -851,22 +851,35 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fa681fed",
+   "id": "497575f0",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30e7346a",
+   "metadata": {},
+   "source": [
+    "nosetest end"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16dabf98",
+   "id": "b5c5f8de",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ### Two-Dimensional Transport in a Diagonal Flow Field\n",
-    "#\n",
-    "# Compares the standard finite difference solutions between MT3D MF 6\n",
-    "scenario(0, silent=True)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Two-Dimensional Transport in a Diagonal Flow Field\n",
+    "    #\n",
+    "    # Compares the standard finite difference solutions between MT3D MF 6\n",
+    "    scenario(0, silent=True)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-mt3dms-p10.ipynb
+++ b/notebooks/ex-gwt-mt3dms-p10.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "58749b9c",
+   "id": "8217a726",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c0a86e8a",
+   "id": "7f9e1e75",
    "metadata": {},
    "source": [
     "### MODFLOW 6 GWT MT3DMS Example 10 Problem Setup"
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b9d82a8f",
+   "id": "2620ad92",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -47,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "210376ff",
+   "id": "486d0215",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bee2d25f",
+   "id": "b5c08c2d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1440dc78",
+   "id": "4d1b6bb5",
    "metadata": {},
    "source": [
     "Imports"
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ff0ef6e1",
+   "id": "ca4d17b2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,18 +91,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b1de7559",
+   "id": "e2207476",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mf2005_exe\n",
-    "exe_name_mt = config.mt3dusgs_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mf2005\"\n",
+    "exe_name_mt = \"mt3dusgs\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9ffe5c30",
+   "id": "b24fd59e",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -111,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "654a0e31",
+   "id": "e911d235",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0eb54eea",
+   "id": "90c7daf4",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -129,7 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e4f03840",
+   "id": "1775afb4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eaec978f",
+   "id": "7c338d2b",
    "metadata": {},
    "source": [
     "Model units"
@@ -148,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a421695",
+   "id": "68f93933",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1eea59e",
+   "id": "dc296c36",
    "metadata": {},
    "source": [
     "Table MODFLOW 6 GWT MT3DMS Example 8"
@@ -167,7 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7de6d2e0",
+   "id": "45df37bb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d6b1abf1",
+   "id": "d436121f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a0e24e98",
+   "id": "9f28dcff",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -275,7 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3bab60f3",
+   "id": "863b4a55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -329,7 +329,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81b67549",
+   "id": "763387a2",
    "metadata": {},
    "source": [
     "Solver settings"
@@ -338,7 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6d2231c0",
+   "id": "83cd3518",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -361,7 +361,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5cbc454c",
+   "id": "bf65be41",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -374,7 +374,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0259e4b7",
+   "id": "7ad9a9de",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -745,7 +745,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e47b856e",
+   "id": "3492b488",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -756,7 +756,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95fa7542",
+   "id": "68fb5909",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -771,7 +771,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7fa82b7a",
+   "id": "aabedc58",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -782,7 +782,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f54caa5",
+   "id": "4848f07a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -802,7 +802,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed890653",
+   "id": "9abc4cc3",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -813,7 +813,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e7e65336",
+   "id": "2496bfe9",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -960,7 +960,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bffd6b2d",
+   "id": "c1eef9ac",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -976,7 +976,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "885427b2",
+   "id": "ace00d93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -991,22 +991,35 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e202234b",
+   "id": "f2c2d524",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4041b866",
+   "metadata": {},
+   "source": [
+    "nosetest end"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2b7b002e",
+   "id": "dae9863b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ### Two-Dimensional Transport in a Diagonal Flow Field\n",
-    "#\n",
-    "# Compares the standard finite difference solutions between MT3D MF 6\n",
-    "scenario(0, silent=True)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Two-Dimensional Transport in a Diagonal Flow Field\n",
+    "    #\n",
+    "    # Compares the standard finite difference solutions between MT3D MF 6\n",
+    "    scenario(0, silent=True)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-mt3dsupp631.ipynb
+++ b/notebooks/ex-gwt-mt3dsupp631.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8f0ebc43",
+   "id": "60724ff2",
    "metadata": {},
    "source": [
     "## Zero-Order Growth in a Uniform Flow Field\n",
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83c6cc51",
+   "id": "d3a0148e",
    "metadata": {},
    "source": [
     "### Zero-Order Growth in a Uniform Flow Field Problem Setup\n",
@@ -24,13 +24,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72ba061a",
+   "id": "4867eb73",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49dc955c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"
@@ -38,7 +46,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3959096f",
+   "id": "606348d7",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -47,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "da06f8d4",
+   "id": "bd35a78b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82034ec9",
+   "id": "d2c2658e",
    "metadata": {},
    "source": [
     "Import common functionality"
@@ -65,7 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6d164237",
+   "id": "fcd5ac58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,7 +83,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1757cbd9",
+   "id": "aeab18ca",
    "metadata": {},
    "source": [
     "Set figure properties specific to the"
@@ -84,7 +92,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3c1d4585",
+   "id": "c601a6f5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef950cb9",
+   "id": "ba10ada2",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -102,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a92627c",
+   "id": "ec901b5f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37e5ae1b",
+   "id": "bd14b923",
    "metadata": {},
    "source": [
     "Model units"
@@ -121,7 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6ac2d9ea",
+   "id": "818f672c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01d9740d",
+   "id": "287f5b7c",
    "metadata": {},
    "source": [
     "Table of model parameters"
@@ -140,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db79228d",
+   "id": "f9baa76c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +171,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2ec33a60",
+   "id": "10d25b5e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -177,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96993573",
+   "id": "f71009fe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +193,13 @@
     "    print(f\"Building mf6gwf model...{sim_folder}\")\n",
     "    name = \"flow\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf6gwf\")\n",
+    "<<<<<<< HEAD\n",
     "    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)\n",
+    "=======\n",
+    "    sim = flopy.mf6.MFSimulation(\n",
+    "        sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
+    "    )\n",
+    ">>>>>>> e12eafd (refactor: discover exes on path)\n",
     "    tdis_ds = (\n",
     "        (source_duration, 1, 1.0),\n",
     "        (total_time - source_duration, 1, 1.0),\n",
@@ -237,7 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cff8725c",
+   "id": "6b1b4437",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +259,13 @@
     "    print(f\"Building mf6gwt model...{sim_folder}\")\n",
     "    name = \"trans\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf6gwt\")\n",
+    "<<<<<<< HEAD\n",
     "    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)\n",
+    "=======\n",
+    "    sim = flopy.mf6.MFSimulation(\n",
+    "        sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
+    "    )\n",
+    ">>>>>>> e12eafd (refactor: discover exes on path)\n",
     "    pertim1 = source_duration\n",
     "    pertim2 = total_time - source_duration\n",
     "    tdis_ds = ((pertim1, 16, 1.0), (pertim2, 84, 1.0))\n",
@@ -296,7 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40275ebb",
+   "id": "c6812834",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -305,7 +325,7 @@
     "    name = \"flow\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf2005\")\n",
     "    mf = flopy.modflow.Modflow(\n",
-    "        modelname=name, model_ws=sim_ws, exe_name=config.mf2005_exe\n",
+    "        modelname=name, model_ws=sim_ws, exe_name=\"mf2005\"\n",
     "    )\n",
     "    pertim1 = source_duration\n",
     "    pertim2 = total_time - source_duration\n",
@@ -338,7 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec3541a5",
+   "id": "1889b011",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -349,7 +369,7 @@
     "    mt = flopy.mt3d.Mt3dms(\n",
     "        modelname=name,\n",
     "        model_ws=sim_ws,\n",
-    "        exe_name=config.mt3dms_exe,\n",
+    "        exe_name=\"mt3dms\",\n",
     "        modflowmodel=modflowmodel,\n",
     "        ftlfilename=\"../mf2005/mt3d_link.ftl\",\n",
     "    )\n",
@@ -372,7 +392,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b9feeba3",
+   "id": "70a22302",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -391,7 +411,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4a8c7509",
+   "id": "e0eada43",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -402,7 +422,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bb36534b",
+   "id": "87f08b15",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -420,7 +440,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32cccd8a",
+   "id": "5f7fc466",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -432,7 +452,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc44c6ee",
+   "id": "f13dfaa4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -463,7 +483,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe3ca88e",
+   "id": "da69233d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -474,7 +494,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5e744863",
+   "id": "2f32fcc2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -525,7 +545,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d2db65dc",
+   "id": "0cbd879e",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -541,7 +561,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c9859b67",
+   "id": "e12e0f20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -556,35 +576,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68ac69b5",
+   "id": "4b38291a",
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f7453096",
-   "metadata": {},
    "source": [
-    "### Simulated Zero-Order Growth in a Uniform Flow Field"
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3db6b7aa",
+   "id": "b35c50bb",
    "metadata": {},
    "source": [
-    "Add a description of the plot(s)"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a9aba11",
+   "id": "410818fa",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(0)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Simulated Zero-Order Growth in a Uniform Flow Field\n",
+    "\n",
+    "    # Add a description of the plot(s)\n",
+    "\n",
+    "    scenario(0)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-mt3dsupp632.ipynb
+++ b/notebooks/ex-gwt-mt3dsupp632.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9ed50cc8",
+   "id": "45490707",
    "metadata": {},
    "source": [
     "## Zero-Order Production in a Dual-Domain System\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d4c85207",
+   "id": "b4425ff5",
    "metadata": {},
    "source": [
     "### Zero-Order Production in a Dual-Domain System Problem Setup"
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48c48bd1",
+   "id": "19a2e9fa",
    "metadata": {},
    "source": [
     "Imports"
@@ -31,13 +31,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "07a5c061",
+   "id": "dea7c1e4",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7304ecc7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"
@@ -45,7 +53,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4c9181c4",
+   "id": "6e1f8789",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -54,7 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9c26dcd5",
+   "id": "c32258d5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +71,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42e1773b",
+   "id": "af2e67d1",
    "metadata": {},
    "source": [
     "Import common functionality"
@@ -72,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ad42812",
+   "id": "b0d4c4e5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +90,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "daf15640",
+   "id": "d12cb1a7",
    "metadata": {},
    "source": [
     "Set figure properties specific to the"
@@ -91,7 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "647ddff6",
+   "id": "d3e9745d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +108,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f6c0697",
+   "id": "0fb28793",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -109,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3066416d",
+   "id": "45847e4e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "05cb1c43",
+   "id": "c6e7b6b3",
    "metadata": {},
    "source": [
     "Scenario parameters - make sure there is at least one blank line before next item"
@@ -127,7 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "032659ed",
+   "id": "29a4d0f5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c14ad913",
+   "id": "0778e219",
    "metadata": {},
    "source": [
     "Scenario parameter units - make sure there is at least one blank line before next item\n",
@@ -162,7 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f00a7bf",
+   "id": "9f05c877",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +183,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d690692",
+   "id": "8c354317",
    "metadata": {},
    "source": [
     "Model units"
@@ -184,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61f3540e",
+   "id": "f4d74dc2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,7 +202,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bcf5836d",
+   "id": "91ab67f6",
    "metadata": {},
    "source": [
     "Table of model parameters"
@@ -203,7 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36f5d746",
+   "id": "6b119cee",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +238,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "221d27f6",
+   "id": "e9ea752d",
    "metadata": {},
    "source": [
     "Flags that can be adjusted to change example configuration"
@@ -239,7 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49992e8b",
+   "id": "0080dd8d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +257,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72a9caea",
+   "id": "adb2b257",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -262,7 +270,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e758deb5",
+   "id": "f2e4598d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -270,7 +278,9 @@
     "    print(f\"Building mf6gwf model...{sim_folder}\")\n",
     "    name = \"flow\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf6gwf\")\n",
-    "    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)\n",
+    "    sim = flopy.mf6.MFSimulation(\n",
+    "        sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
+    "    )\n",
     "    tdis_ds = (\n",
     "        (source_duration, 1, 1.0),\n",
     "        (total_time - source_duration, 1, 1.0),\n",
@@ -317,7 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "255e1247",
+   "id": "b506c211",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,7 +335,9 @@
     "    print(f\"Building mf6gwt model...{sim_folder}\")\n",
     "    name = \"trans\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf6gwt\")\n",
-    "    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)\n",
+    "    sim = flopy.mf6.MFSimulation(\n",
+    "        sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
+    "    )\n",
     "    pertim1 = source_duration\n",
     "    pertim2 = total_time - source_duration\n",
     "    tdis_ds = ((pertim1, 10, 1.0), (pertim2, 90, 1.0))\n",
@@ -416,7 +428,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0ba4ff0",
+   "id": "4688b3bc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -425,7 +437,7 @@
     "    name = \"flow\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf2005\")\n",
     "    mf = flopy.modflow.Modflow(\n",
-    "        modelname=name, model_ws=sim_ws, exe_name=config.mf2005_exe\n",
+    "        modelname=name, model_ws=sim_ws, exe_name=\"mf2005\"\n",
     "    )\n",
     "    pertim1 = source_duration\n",
     "    pertim2 = total_time - source_duration\n",
@@ -458,7 +470,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e5fa87a",
+   "id": "03104678",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -471,7 +483,7 @@
     "    mt = flopy.mt3d.Mt3dms(\n",
     "        modelname=name,\n",
     "        model_ws=sim_ws,\n",
-    "        exe_name=config.mt3dms_exe,\n",
+    "        exe_name=\"mt3dms\",\n",
     "        modflowmodel=modflowmodel,\n",
     "        ftlfilename=\"../mf2005/mt3d_link.ftl\",\n",
     "    )\n",
@@ -526,7 +538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "905b36d6",
+   "id": "a1778a17",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -549,7 +561,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5bd576c6",
+   "id": "bbc4e40a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -560,7 +572,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f6ba4dd0",
+   "id": "36b552b3",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -578,7 +590,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1bb5f978",
+   "id": "186949fb",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -590,7 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4249f691",
+   "id": "1d7bbe2d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -621,7 +633,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63b0cff6",
+   "id": "6980b7a2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -632,7 +644,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5cb2317a",
+   "id": "3a95c782",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -684,7 +696,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33f8b84a",
+   "id": "83e24f85",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -734,7 +746,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e5e63496",
+   "id": "4bfde770",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -750,7 +762,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "638b5d62",
+   "id": "e40d9713",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -768,98 +780,96 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27167943",
+   "id": "83ac226e",
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "623fc8ca",
-   "metadata": {},
    "source": [
-    "### Case 1\n",
-    "\n",
-    "ex-gwt-mt3dsupp632a\n",
-    "* distribution_coefficient = 0.25\n",
-    "* decay = 0.0\n",
-    "* decay_sorbed = -1.0e-3"
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c65d6d0c",
+   "id": "84f7a1d2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "dd0e68bf",
-   "metadata": {},
-   "source": [
-    "### Case 2\n",
-    "\n",
-    "ex-gwt-mt3dsupp632a\n",
-    "* distribution_coefficient = 0.25\n",
-    "* decay = -5.e-4\n",
-    "* decay_sorbed = -5.e-4"
+    "def test_02():\n",
+    "    scenario(1, silent=False)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0eeae222",
+   "id": "78680887",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ab1d1f94",
-   "metadata": {},
-   "source": [
-    "### Case 3\n",
-    "\n",
-    "ex-gwt-mt3dsupp632a\n",
-    "* distribution_coefficient = 0.\n",
-    "* decay = -1.0e-3\n",
-    "* decay_sorbed = 0."
+    "def test_03():\n",
+    "    scenario(2, silent=False)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b04c40e2",
+   "id": "29c61510",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(2)"
+    "def test_plot_results():\n",
+    "    plot_results()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4d2ac999",
+   "id": "82646be6",
    "metadata": {},
    "source": [
-    "### Plot the Zero-Order Production in a Dual-Domain System Problem results\n",
-    "\n",
-    "Plot the results for all 3 scenarios in one plot"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85823fcd",
+   "id": "50e72537",
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_results()"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Case 1\n",
+    "    #\n",
+    "    # ex-gwt-mt3dsupp632a\n",
+    "    # * distribution_coefficient = 0.25\n",
+    "    # * decay = 0.0\n",
+    "    # * decay_sorbed = -1.0e-3\n",
+    "\n",
+    "    scenario(0)\n",
+    "\n",
+    "    # ### Case 2\n",
+    "    #\n",
+    "    # ex-gwt-mt3dsupp632a\n",
+    "    # * distribution_coefficient = 0.25\n",
+    "    # * decay = -5.e-4\n",
+    "    # * decay_sorbed = -5.e-4\n",
+    "\n",
+    "    scenario(1)\n",
+    "\n",
+    "    # ### Case 3\n",
+    "    #\n",
+    "    # ex-gwt-mt3dsupp632a\n",
+    "    # * distribution_coefficient = 0.\n",
+    "    # * decay = -1.0e-3\n",
+    "    # * decay_sorbed = 0.\n",
+    "\n",
+    "    scenario(2)\n",
+    "\n",
+    "    # ### Plot the Zero-Order Production in a Dual-Domain System Problem results\n",
+    "    #\n",
+    "    # Plot the results for all 3 scenarios in one plot\n",
+    "\n",
+    "    plot_results()"
    ]
   }
  ],

--- a/notebooks/ex-gwt-mt3dsupp82.ipynb
+++ b/notebooks/ex-gwt-mt3dsupp82.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "3625c17e",
+   "id": "b3b1471c",
    "metadata": {},
    "source": [
     "## Simulating Effect of Recirculation Well\n",
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e96a7f06",
+   "id": "589af1f7",
    "metadata": {},
    "source": [
     "### Simulating Effect of Recirculation Well Problem Setup\n",
@@ -24,13 +24,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d6429f37",
+   "id": "bfc66c85",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c20bb98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"
@@ -38,7 +46,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30bc8514",
+   "id": "ffe77471",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -47,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f067ac6d",
+   "id": "b13c052d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44d59493",
+   "id": "54b3842f",
    "metadata": {},
    "source": [
     "Import common functionality"
@@ -65,7 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "450c1530",
+   "id": "5883485b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,7 +83,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de9b8e83",
+   "id": "102199e6",
    "metadata": {},
    "source": [
     "Set figure properties specific to the"
@@ -84,7 +92,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45b6da09",
+   "id": "de950ca5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7595e1ed",
+   "id": "79fa13f8",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -102,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c5a7b2d1",
+   "id": "09e39d76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6390ccd8",
+   "id": "15ff0a6c",
    "metadata": {},
    "source": [
     "Model units"
@@ -121,7 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ded2fd13",
+   "id": "b9d943c1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27c1afc3",
+   "id": "ca4175e4",
    "metadata": {},
    "source": [
     "Table of model parameters"
@@ -140,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1bb89c7c",
+   "id": "6e55f32d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -164,7 +172,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1699f8e",
+   "id": "c2d2bec4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -178,7 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce2ecf89",
+   "id": "10848181",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +194,9 @@
     "    print(f\"Building mf6gwf model...{sim_folder}\")\n",
     "    name = \"flow\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf6gwf\")\n",
-    "    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)\n",
+    "    sim = flopy.mf6.MFSimulation(\n",
+    "        sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
+    "    )\n",
     "    tdis_ds = ((total_time, 1, 1.0),)\n",
     "    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "    flopy.mf6.ModflowIms(sim)\n",
@@ -289,7 +299,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e0bcb342",
+   "id": "c947c03d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,7 +307,9 @@
     "    print(f\"Building mf6gwt model...{sim_folder}\")\n",
     "    name = \"trans\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf6gwt\")\n",
-    "    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)\n",
+    "    sim = flopy.mf6.MFSimulation(\n",
+    "        sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
+    "    )\n",
     "    tdis_ds = ((total_time, 20, 1.0),)\n",
     "    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
     "    flopy.mf6.ModflowIms(sim, linear_acceleration=\"bicgstab\")\n",
@@ -382,7 +394,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f94ee86",
+   "id": "19a8b400",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +403,7 @@
     "    name = \"flow\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf2005\")\n",
     "    mf = flopy.modflow.Modflow(\n",
-    "        modelname=name, model_ws=sim_ws, exe_name=config.mf2005_exe\n",
+    "        modelname=name, model_ws=sim_ws, exe_name=\"mf2005\"\n",
     "    )\n",
     "    perlen = [total_time]\n",
     "    dis = flopy.modflow.ModflowDis(\n",
@@ -431,7 +443,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bff98b12",
+   "id": "6535f106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,7 +454,7 @@
     "    mt = flopy.mt3d.Mt3dms(\n",
     "        modelname=name,\n",
     "        model_ws=sim_ws,\n",
-    "        exe_name=config.mt3dms_exe,\n",
+    "        exe_name=\"mt3dms\",\n",
     "        modflowmodel=modflowmodel,\n",
     "        ftlfilename=\"../mf2005/mt3d_link.ftl\",\n",
     "    )\n",
@@ -466,7 +478,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5f15ba52",
+   "id": "69650f48",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -485,7 +497,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f8725cb",
+   "id": "dd35b876",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -496,7 +508,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3730e497",
+   "id": "2aaf79e2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -514,7 +526,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f5500c55",
+   "id": "2a65dbf5",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -526,7 +538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76cebb14",
+   "id": "65950050",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -557,7 +569,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0ead636",
+   "id": "ec21fad3",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -568,7 +580,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2b416e36",
+   "id": "0fb18b5d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -623,7 +635,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19df6711",
+   "id": "67ced6e6",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -639,7 +651,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a40170f7",
+   "id": "371c4eec",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -654,35 +666,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93d4bc08",
+   "id": "f493aa1d",
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9174b926",
-   "metadata": {},
    "source": [
-    "### Simulated Zero-Order Growth in a Uniform Flow Field"
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "14062228",
+   "id": "76ed0138",
    "metadata": {},
    "source": [
-    "Add a description of the plot(s)"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a0a29e27",
+   "id": "c2ad9cb4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(0)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Simulated Zero-Order Growth in a Uniform Flow Field\n",
+    "\n",
+    "    # Add a description of the plot(s)\n",
+    "\n",
+    "    scenario(0)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-prudic2004t2.ipynb
+++ b/notebooks/ex-gwt-prudic2004t2.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "87e25cc6",
+   "id": "851f2e6d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21287b8c",
+   "id": "0a96304f",
    "metadata": {},
    "source": [
     "### Stream-Lake Interaction with Solute Transport Problem Setup"
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8028b8d",
+   "id": "c93fd680",
    "metadata": {},
    "source": [
     "Imports"
@@ -32,13 +32,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6b3df4d7",
+   "id": "b58d829e",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "229b3397",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"
@@ -46,7 +54,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70e7ce77",
+   "id": "517e3d7a",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -55,7 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b585fda4",
+   "id": "7cb38b9f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +72,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe778e20",
+   "id": "f6620336",
    "metadata": {},
    "source": [
     "Import common functionality"
@@ -73,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67f78c8f",
+   "id": "665f9c49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,18 +92,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "693ac85c",
+   "id": "04405e9e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mf2005_exe\n",
-    "exe_name_mt = config.mt3dms_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mf2005\"\n",
+    "exe_name_mt = \"mt3dms\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "e8eb6745",
+   "id": "5bfbfc2c",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -104,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3680e125",
+   "id": "123806eb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7cca890",
+   "id": "e80509e9",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -122,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7846a029",
+   "id": "f52930ca",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f961b51",
+   "id": "0ff20a57",
    "metadata": {},
    "source": [
     "Model units"
@@ -142,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f5a12add",
+   "id": "11d6d864",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67533530",
+   "id": "4bf27090",
    "metadata": {},
    "source": [
     "Table of model parameters"
@@ -161,7 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0878a3d",
+   "id": "e1188cf3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,7 +202,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39c3b4ee",
+   "id": "5578630f",
    "metadata": {},
    "source": [
     "Load Data Arrays"
@@ -203,7 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d91d7c0",
+   "id": "bd475dcc",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -221,7 +229,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2de83168",
+   "id": "5c3e1714",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -231,7 +239,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ec3df81",
+   "id": "36835199",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -244,7 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c28da90e",
+   "id": "c491dc26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -317,7 +325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "516ec035",
+   "id": "397a05d5",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -328,7 +336,9 @@
     "    print(f\"Building mf6gwf model...{sim_folder}\")\n",
     "    name = \"flow\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf6gwf\")\n",
-    "    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)\n",
+    "    sim = flopy.mf6.MFSimulation(\n",
+    "        sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
+    "    )\n",
     "    tdis_data = [(total_time, 1, 1.0)]\n",
     "    flopy.mf6.ModflowTdis(\n",
     "        sim, nper=len(tdis_data), perioddata=tdis_data, time_units=time_units\n",
@@ -482,7 +492,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee458483",
+   "id": "f831c98a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -493,7 +503,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc3a1918",
+   "id": "01127c36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -501,7 +511,9 @@
     "    print(f\"Building mf6gwt model...{sim_folder}\")\n",
     "    name = \"trans\"\n",
     "    sim_ws = os.path.join(ws, sim_folder, \"mf6gwt\")\n",
-    "    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)\n",
+    "    sim = flopy.mf6.MFSimulation(\n",
+    "        sim_name=name, sim_ws=sim_ws, exe_name=\"mf6\"\n",
+    "    )\n",
     "    tdis_data = ((total_time, 300, 1.0),)\n",
     "    flopy.mf6.ModflowTdis(\n",
     "        sim, nper=len(tdis_data), perioddata=tdis_data, time_units=time_units\n",
@@ -657,7 +669,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac031b8a",
+   "id": "783f9c1b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -674,7 +686,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c36d1bc9",
+   "id": "52d3d46f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -685,7 +697,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30edc1bc",
+   "id": "094c6743",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -701,7 +713,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f372e17",
+   "id": "5fa26714",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -713,7 +725,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e0685322",
+   "id": "a5938f93",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -736,7 +748,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4a2d9c66",
+   "id": "1e8b0fae",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -747,7 +759,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e32cb293",
+   "id": "b3bf7fce",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -768,7 +780,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62032c8a",
+   "id": "adfbbdb4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -781,7 +793,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12d454b1",
+   "id": "ac4017db",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -833,7 +845,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71b55ec5",
+   "id": "5b8d2d2b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -942,7 +954,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2dd0ea13",
+   "id": "b948f955",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -958,7 +970,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b6952e6f",
+   "id": "1df2a91a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -973,35 +985,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1ffedcad",
+   "id": "f7a22204",
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0bd6df80",
-   "metadata": {},
    "source": [
-    "### Model"
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4e466c19",
+   "id": "730db190",
    "metadata": {},
    "source": [
-    "Model run"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f263e8a2",
+   "id": "1dfb2135",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(0)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Model\n",
+    "\n",
+    "    # Model run\n",
+    "\n",
+    "    scenario(0)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-rotate.ipynb
+++ b/notebooks/ex-gwt-rotate.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "c8f64e9d",
+   "id": "f5973cda",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b31917df",
+   "id": "6e14580c",
    "metadata": {},
    "source": [
     "### Rotating Interface Problem Setup"
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70d81fbf",
+   "id": "ce733dbd",
    "metadata": {},
    "source": [
     "Imports"
@@ -32,13 +32,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "422d6fd3",
+   "id": "73292c02",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e64d207c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"
@@ -46,7 +54,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55f26f75",
+   "id": "4e64a1f1",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -55,7 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0e4c8495",
+   "id": "78682049",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +72,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49fb7d34",
+   "id": "b974a3b6",
    "metadata": {},
    "source": [
     "Import common functionality"
@@ -73,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "645f946d",
+   "id": "13a34fdc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,18 +93,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c02d629",
+   "id": "8d31983a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mf2005_exe\n",
-    "exe_name_mt = config.mt3dms_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mf2005\"\n",
+    "exe_name_mt = \"mt3dms\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "22148e30",
+   "id": "9cb9111f",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -105,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e257151",
+   "id": "4981d1bc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a2422baa",
+   "id": "970f5d3c",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -123,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a5ce454c",
+   "id": "701bf19d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dab84411",
+   "id": "b64ef5ac",
    "metadata": {},
    "source": [
     "Model units"
@@ -142,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "372e2f48",
+   "id": "6705d4e8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "03331816",
+   "id": "38ba0db8",
    "metadata": {},
    "source": [
     "Table of model parameters"
@@ -161,7 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca38f1cd",
+   "id": "26e853a3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,7 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b133bf53",
+   "id": "a1b752be",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dff04492",
+   "id": "9143299a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -220,7 +228,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef5c4a0f",
+   "id": "465d906d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -233,7 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fd2f09e7",
+   "id": "22955d3c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35f80132",
+   "id": "f7fd7791",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -271,7 +279,7 @@
     "    sim = flopy.mf6.MFSimulation(\n",
     "        sim_name=name,\n",
     "        sim_ws=sim_ws,\n",
-    "        exe_name=config.mf6_exe,\n",
+    "        exe_name=\"mf6\",\n",
     "        continue_=True,\n",
     "    )\n",
     "    tdis_ds = ((perlen, nstp, 1.0),)\n",
@@ -370,7 +378,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "563970f2",
+   "id": "71eb95b4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -381,7 +389,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0702f004",
+   "id": "294c2702",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -395,7 +403,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe2bf58f",
+   "id": "bd5c4f18",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -407,7 +415,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61c44ac3",
+   "id": "fd159c3f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -426,7 +434,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e78cb7ef",
+   "id": "e01ac1ff",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -437,7 +445,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d20dd4d1",
+   "id": "d6299c46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -521,7 +529,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c7d5a379",
+   "id": "96620d1f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -589,7 +597,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7aefc1b2",
+   "id": "e74e79f6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -632,7 +640,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bfc68823",
+   "id": "8b70f39d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -649,7 +657,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65a3030b",
+   "id": "17f27612",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -665,7 +673,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c5171be6",
+   "id": "7e49c9e7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -680,35 +688,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "537258f8",
+   "id": "d2dd4583",
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7076b347",
-   "metadata": {},
    "source": [
-    "### Rotating Interface Problem"
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6efada06",
+   "id": "ed51be92",
    "metadata": {},
    "source": [
-    "Plot showing MODFLOW 6 results"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e2196571",
+   "id": "a1ab7bb2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(0)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Rotating Interface Problem\n",
+    "\n",
+    "    # Plot showing MODFLOW 6 results\n",
+    "\n",
+    "    scenario(0)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-saltlake.ipynb
+++ b/notebooks/ex-gwt-saltlake.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "63c9043b",
+   "id": "ad3f2063",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "baa500d0",
+   "id": "98773a8a",
    "metadata": {},
    "source": [
     "### Salt Lake Problem Setup"
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6f04c2a6",
+   "id": "fbfff7d7",
    "metadata": {},
    "source": [
     "Imports"
@@ -32,13 +32,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c83fab3",
+   "id": "6fc1f3f5",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "436ce8ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"
@@ -46,7 +54,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c8b291b8",
+   "id": "b0ce4789",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -55,7 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9b1e33d2",
+   "id": "550dca77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +72,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "789770d1",
+   "id": "5a235486",
    "metadata": {},
    "source": [
     "Import common functionality"
@@ -73,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4bdb9d99",
+   "id": "fc924ace",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,18 +92,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9168b4f2",
+   "id": "aa7329c5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mf2005_exe\n",
-    "exe_name_mt = config.mt3dms_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mf2005\"\n",
+    "exe_name_mt = \"mt3dms\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b29fa8e5",
+   "id": "3baae9a6",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -104,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae7fec4f",
+   "id": "044c875f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca1da864",
+   "id": "24be04fc",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -122,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b149d1c2",
+   "id": "5409b7b2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +140,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cfcf1f3a",
+   "id": "1c676abb",
    "metadata": {},
    "source": [
     "Model units"
@@ -141,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c0fe5c7",
+   "id": "757bdb0c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -151,7 +159,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b94a21d0",
+   "id": "d05e7f33",
    "metadata": {},
    "source": [
     "Table of model parameters"
@@ -160,7 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87ca17fc",
+   "id": "f19ae1ae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1a19f219",
+   "id": "f1bcac85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c2556454",
+   "id": "68f651de",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -220,7 +228,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71285c76",
+   "id": "109f6e14",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -233,7 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e980816a",
+   "id": "1713b490",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -246,7 +254,7 @@
     "    sim = flopy.mf6.MFSimulation(\n",
     "        sim_name=name,\n",
     "        sim_ws=sim_ws,\n",
-    "        exe_name=config.mf6_exe,\n",
+    "        exe_name=\"mf6\",\n",
     "    )\n",
     "    tdis_ds = ((perlen, nstp, 1.0),)\n",
     "    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)\n",
@@ -371,7 +379,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "862b4f9f",
+   "id": "5141d5fb",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -382,7 +390,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e61d4796",
+   "id": "1b9d1397",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -396,7 +404,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2a4b784",
+   "id": "758e5168",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -408,7 +416,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0fb8840f",
+   "id": "bd4716de",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -427,7 +435,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "004ad3de",
+   "id": "fc6b7389",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -438,7 +446,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13a2dc87",
+   "id": "78d0e1b7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -511,7 +519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "021a9bcd",
+   "id": "af6e5668",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -553,7 +561,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fadcc080",
+   "id": "639f5f3c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -569,7 +577,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd6ff161",
+   "id": "2119b988",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -585,7 +593,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c822eb9",
+   "id": "0fe4aaeb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -600,35 +608,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b30649d0",
+   "id": "65cd9c65",
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5ca94661",
-   "metadata": {},
    "source": [
-    "### Salt Lake Problem"
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "7ccc5efc",
+   "id": "48ef756b",
    "metadata": {},
    "source": [
-    "Plot showing MODFLOW 6 results"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "880ba513",
+   "id": "d7be4bd6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(0)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Salt Lake Problem\n",
+    "\n",
+    "    # Plot showing MODFLOW 6 results\n",
+    "\n",
+    "    scenario(0)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-stallman.ipynb
+++ b/notebooks/ex-gwt-stallman.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "c11d566a",
+   "id": "2af8e304",
    "metadata": {},
    "source": [
     "## Stallman Problem\n",
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92d37006",
+   "id": "3ce80720",
    "metadata": {},
    "source": [
     "### Stallman Problem Setup"
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ce44dec",
+   "id": "9ae54325",
    "metadata": {},
    "source": [
     "Imports"
@@ -30,13 +30,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99b6b1be",
+   "id": "2cf17b87",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import sys\n",
-    "\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0194ccb3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import flopy\n",
     "import matplotlib.animation as animation\n",
     "import matplotlib.pyplot as plt\n",
@@ -45,7 +53,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e54237d",
+   "id": "7d6f83fa",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -54,7 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a684dfa1",
+   "id": "fb240c3a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +71,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6853c86",
+   "id": "2f7d99a4",
    "metadata": {},
    "source": [
     "Import common functionality"
@@ -72,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43f3b926",
+   "id": "75bb5408",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,16 +92,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bbf93d1e",
+   "id": "f108988c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe"
+    "mf6exe = \"mf6\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "40e515bf",
+   "id": "e751924b",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -102,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd9612c9",
+   "id": "ee1461ba",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24cc7450",
+   "id": "6d1b6977",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -120,7 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f48f1ebe",
+   "id": "0e0d12dd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +138,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7fafdf5c",
+   "id": "543c119a",
    "metadata": {},
    "source": [
     "Model units"
@@ -139,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "afaf3ee7",
+   "id": "5b899ffd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +157,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "03ecd493",
+   "id": "fe387a8d",
    "metadata": {},
    "source": [
     "Table of model parameters"
@@ -158,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a6db82b",
+   "id": "aeee4072",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78e4bba5",
+   "id": "849a4e1b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,7 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65453c88",
+   "id": "3eb7199f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -220,7 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a81e5052",
+   "id": "aadff01c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +242,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5e1c297c",
+   "id": "7d6599a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86e4889e",
+   "id": "e1a17ec5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +268,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd168a11",
+   "id": "26b8e04b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -270,7 +278,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5143c20",
+   "id": "3b4ab007",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -283,7 +291,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a7a93e46",
+   "id": "b7030a34",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -296,7 +304,7 @@
     "    sim = flopy.mf6.MFSimulation(\n",
     "        sim_name=name,\n",
     "        sim_ws=sim_ws,\n",
-    "        exe_name=config.mf6_exe,\n",
+    "        exe_name=\"mf6\",\n",
     "    )\n",
     "    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=per_mf6, time_units=time_units)\n",
     "    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)\n",
@@ -409,7 +417,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "673ba113",
+   "id": "979bd72a",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -420,7 +428,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "578c17d3",
+   "id": "b9c04a3f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -434,7 +442,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0dc08fae",
+   "id": "2111d4ec",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -446,7 +454,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d4f77232",
+   "id": "b15f5eda",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -466,7 +474,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "193e9488",
+   "id": "3ff08281",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -477,7 +485,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66019b21",
+   "id": "e65c42a4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -548,7 +556,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3560f06f",
+   "id": "d35bdc57",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -559,7 +567,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f397e7df",
+   "id": "08b54dba",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -627,7 +635,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef2ce814",
+   "id": "bd6b1971",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -645,7 +653,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1e96fda",
+   "id": "2d838860",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -661,7 +669,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b235ce1",
+   "id": "eddef77e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -676,35 +684,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bfc4ef75",
+   "id": "9540c972",
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "55afbe8c",
-   "metadata": {},
    "source": [
-    "### Salt Lake Problem"
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4884331e",
+   "id": "7cd3e3fa",
    "metadata": {},
    "source": [
-    "Plot showing MODFLOW 6 results"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e43177f",
+   "id": "b24f3a51",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(0)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Salt Lake Problem\n",
+    "\n",
+    "    # Plot showing MODFLOW 6 results\n",
+    "\n",
+    "    scenario(0)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-synthetic-valley.ipynb
+++ b/notebooks/ex-gwt-synthetic-valley.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "aaf71d91",
+   "id": "1699ef4a",
    "metadata": {},
    "source": [
     "## Synthetic Valley Problem\n",
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "371d63e5",
+   "id": "878bd666",
    "metadata": {},
    "source": [
     "### Synthetic Valley Problem\n",
@@ -24,7 +24,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0888cb5e",
+   "id": "844a60b6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +36,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bd3533e2",
+   "id": "2ecfd770",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7b8ef44",
+   "id": "abd101d0",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -64,7 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2b14e00d",
+   "id": "78d9f10b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,7 +73,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57181bad",
+   "id": "dda3d3a5",
    "metadata": {},
    "source": [
     "Import common functionality"
@@ -82,7 +82,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a75faea",
+   "id": "49febee2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,7 +97,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eea22843",
+   "id": "51f94238",
    "metadata": {},
    "source": [
     "Set figure properties specific to the example"
@@ -106,7 +106,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ce3e5bb",
+   "id": "1cdfc86e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ba7272c",
+   "id": "093b0fb2",
    "metadata": {},
    "source": [
     "set figure element defaults"
@@ -126,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54b8f910",
+   "id": "db0fc624",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2dd2c632",
+   "id": "311e150b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +189,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e991fda6",
+   "id": "a198032e",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -198,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b16824fd",
+   "id": "511524be",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29065e41",
+   "id": "50bb38fa",
    "metadata": {},
    "source": [
     "Conversion factors"
@@ -217,7 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e244ea58",
+   "id": "fb586cb6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +230,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4acd1fa6",
+   "id": "b04b62d3",
    "metadata": {},
    "source": [
     "Model units"
@@ -239,7 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa2cb8cf",
+   "id": "732809fe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +249,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ccc4be96",
+   "id": "e2cce6a4",
    "metadata": {},
    "source": [
     "Table of model parameters"
@@ -258,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c9bee804",
+   "id": "a5b782b6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,7 +286,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8ea1ef33",
+   "id": "e8b10ac2",
    "metadata": {},
    "source": [
     "build voronoi grid"
@@ -295,7 +295,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3eadc91f",
+   "id": "84785bbe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +334,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84bf93ac",
+   "id": "68aba0fd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -368,7 +368,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f1fdb54",
+   "id": "1d691856",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -381,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c835d7a",
+   "id": "cb00a88e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +397,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f085539",
+   "id": "7d42de7d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -416,7 +416,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39cb8454",
+   "id": "2ac7d72a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -455,7 +455,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8cce0181",
+   "id": "20f5db82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -473,7 +473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fe6b2d8c",
+   "id": "14d17918",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,7 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bad86472",
+   "id": "e56e4c0a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -508,7 +508,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2d328078",
+   "id": "0595cdbc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -570,7 +570,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9677f5de",
+   "id": "e03238ae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -598,7 +598,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d4dedb06",
+   "id": "cddfc035",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -618,7 +618,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33b45414",
+   "id": "50ba9812",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -642,7 +642,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79098287",
+   "id": "6dc73d3c",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -656,7 +656,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "be823b90",
+   "id": "f6f9f38e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -667,7 +667,7 @@
     "    sim = flopy.mf6.MFSimulation(\n",
     "        sim_name=name,\n",
     "        sim_ws=sim_ws,\n",
-    "        exe_name=config.mf6_exe,\n",
+    "        exe_name=\"mf6\",\n",
     "        continue_=True,\n",
     "    )\n",
     "    tdis = flopy.mf6.ModflowTdis(sim, time_units=\"days\", perioddata=((pertim, 1, 1.0),))\n",
@@ -762,7 +762,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b3ead623",
+   "id": "c8271f62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -773,7 +773,7 @@
     "    sim = flopy.mf6.MFSimulation(\n",
     "        sim_name=name,\n",
     "        sim_ws=sim_ws,\n",
-    "        exe_name=config.mf6_exe,\n",
+    "        exe_name=\"mf6\",\n",
     "        continue_=True,\n",
     "    )\n",
     "    tdis = flopy.mf6.ModflowTdis(\n",
@@ -847,7 +847,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ffef1dec",
+   "id": "b470b12b",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -866,7 +866,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7fdbf9d0",
+   "id": "4fac15e0",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -877,7 +877,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e0fc140",
+   "id": "d15aef39",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -893,7 +893,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed8b8e70",
+   "id": "dde7af75",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -905,7 +905,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0648b24b",
+   "id": "97c0969d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -929,13 +929,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43d9e19e",
+   "id": "30d09769",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Functions to plot the model results\n",
-    "\n",
-    "\n",
     "def plot_wells(ax=None, ms=None):\n",
     "    if ax is None:\n",
     "        ax = plt.gca()\n",
@@ -946,7 +944,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a294653e",
+   "id": "49a22b61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -960,7 +958,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0d2982bf",
+   "id": "ee24cb78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -978,7 +976,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1a49995f",
+   "id": "befa3b35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1030,7 +1028,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3bff988f",
+   "id": "17e4c2e6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1051,7 +1049,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9528cd52",
+   "id": "43aeda75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1084,7 +1082,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0522be4b",
+   "id": "5bc045e5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1100,7 +1098,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "07e36db3",
+   "id": "2103c3bc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1204,7 +1202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "08fd3b32",
+   "id": "eabe49bc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1390,7 +1388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0d376a54",
+   "id": "0bba7fde",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1519,7 +1517,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffe90fcd",
+   "id": "288b012d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1535,7 +1533,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f8cda098",
+   "id": "4e33aa69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1550,35 +1548,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99443c47",
+   "id": "e0e68f20",
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "71a2f113",
-   "metadata": {},
    "source": [
-    "### Simulate Synthetic Valley Problem (Hughes and others 2023)"
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=False)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2294bffb",
+   "id": "71c29993",
    "metadata": {},
    "source": [
-    "Plot showing MODFLOW 6 results"
+    "nosetest end"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f3d2af26",
+   "id": "57f27a4a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(0)"
+    "if __name__ == \"__main__\":\n",
+    "    # ### Simulate Synthetic Valley Problem (Hughes and others 2023)\n",
+    "\n",
+    "    # Plot showing MODFLOW 6 results\n",
+    "\n",
+    "    scenario(0)"
    ]
   }
  ],

--- a/notebooks/ex-gwt-uzt-2d.ipynb
+++ b/notebooks/ex-gwt-uzt-2d.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "73e5d1e6",
+   "id": "54824a9b",
    "metadata": {},
    "source": [
     "## Two-Dimensional Transport with the UZF and UZT packages active.\n",
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56eb7c22",
+   "id": "bbbe4aed",
    "metadata": {},
    "source": [
     "### MODFLOW 6 2D UZT/GWT Problem Setup"
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5346b82e",
+   "id": "14b7b0d6",
    "metadata": {},
    "source": [
     "Append to system path to include the common subdirectory"
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aca60bed",
+   "id": "721b855f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +41,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3971d616",
+   "id": "003250c1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e84d2bb7",
+   "id": "db77311f",
    "metadata": {},
    "source": [
     "Imports"
@@ -59,7 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "da4501b7",
+   "id": "2c63307d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,18 +73,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2e4f3210",
+   "id": "2241df4e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "mf6exe = config.mf6_exe\n",
-    "exe_name_mf = config.mfnwt_exe\n",
-    "exe_name_mt = config.mt3dusgs_exe"
+    "mf6exe = \"mf6\"\n",
+    "exe_name_mf = \"mfnwt\"\n",
+    "exe_name_mt = \"mt3dusgs\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "7344be70",
+   "id": "d4aeebf9",
    "metadata": {},
    "source": [
     "Set figure properties specific to this problem"
@@ -93,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "790b2ede",
+   "id": "52c8d4ca",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +102,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9935cd29",
+   "id": "24f73ecf",
    "metadata": {},
    "source": [
     "Base simulation and model name and workspace"
@@ -111,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95692a25",
+   "id": "c39c914d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "801af936",
+   "id": "d49a33df",
    "metadata": {},
    "source": [
     "Set scenario parameters (make sure there is at least one blank line before next item)\n",
@@ -130,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7b1f2d07",
+   "id": "97d2bf2b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -215,7 +215,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b567cd4d",
+   "id": "7222eaed",
    "metadata": {},
    "source": [
     "Scenario parameter units\n",
@@ -227,7 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "705a94f6",
+   "id": "04ab87c8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39b131af",
+   "id": "f8b90fd7",
    "metadata": {},
    "source": [
     "Model units"
@@ -249,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7595e5fa",
+   "id": "88ffdcce",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -259,7 +259,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "263cc075",
+   "id": "7e59ef1c",
    "metadata": {},
    "source": [
     "Table MODFLOW 6 GWT MT3DMS Example 8"
@@ -268,7 +268,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "987cbc56",
+   "id": "404416c2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,7 +299,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33be2cd3",
+   "id": "85abcd70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,7 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02239563",
+   "id": "e077f367",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -346,7 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "466258a0",
+   "id": "dca023ed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -423,7 +423,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3c937501",
+   "id": "4fd316bc",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -436,7 +436,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "058dddbf",
+   "id": "4be500f9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -447,7 +447,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a3187bd0",
+   "id": "b8b8cbdf",
    "metadata": {},
    "source": [
     "Solver settings"
@@ -456,7 +456,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1997bd6f",
+   "id": "fde68829",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -478,7 +478,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e5cb2737",
+   "id": "cbbb8a28",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -491,7 +491,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8f0d1899",
+   "id": "02d8fbc7",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -974,7 +974,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be827e85",
+   "id": "d89d95c4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -985,7 +985,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd489e00",
+   "id": "739e1223",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1000,7 +1000,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7d1dcc7",
+   "id": "33131248",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1011,7 +1011,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "235846e5",
+   "id": "b06d9637",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1031,7 +1031,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97b65132",
+   "id": "c5e30101",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1042,7 +1042,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d44e27da",
+   "id": "3b86f466",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1211,7 +1211,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33f05276",
+   "id": "ef2b0860",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1227,7 +1227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ffaee192",
+   "id": "00e75b40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1245,32 +1245,48 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01f5e1e3",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e6888ea8",
+   "id": "cbcbc473",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ### Two-Dimensional Transport in a Diagonal Flow Field\n",
-    "#\n",
-    "# Compares the standard finite difference solutions between MT3D & MF 6\n",
-    "scenario(0, silent=True)"
+    "# nosetest - exclude block from this nosetest to the next nosetest\n",
+    "def test_01():\n",
+    "    scenario(0, silent=True)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85cf8304",
+   "id": "c6b21293",
    "metadata": {},
    "outputs": [],
    "source": [
-    "scenario(1, silent=True)"
+    "def test_02():\n",
+    "    scenario(1, silent=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70e30a34",
+   "metadata": {},
+   "source": [
+    "nosetest end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ffa424f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == \"__main__\":\n",
+    "    # ### Two-Dimensional Transport in a Diagonal Flow Field\n",
+    "    #\n",
+    "    # Compares the standard finite difference solutions between MT3D & MF 6\n",
+    "    scenario(0, silent=True)\n",
+    "\n",
+    "    scenario(1, silent=True)"
    ]
   }
  ],

--- a/scripts/ex-gwf-advtidal.py
+++ b/scripts/ex-gwf-advtidal.py
@@ -145,7 +145,7 @@ def build_model():
         sim = flopy.mf6.MFSimulation(
             sim_name=sim_name,
             sim_ws=sim_ws,
-            exe_name=config.mf6_exe,
+            exe_name="mf6",
             verbosity_level=0,
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)

--- a/scripts/ex-gwf-bcf2ss.py
+++ b/scripts/ex-gwf-bcf2ss.py
@@ -134,7 +134,7 @@ def build_model(name, rewet, wetfct, iwetit, ihdwet, linear_acceleration, newton
     if config.buildModel:
         sim_ws = os.path.join(ws, name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-bump.py
+++ b/scripts/ex-gwf-bump.py
@@ -134,7 +134,7 @@ def build_model(
     if config.buildModel:
         sim_ws = os.path.join(ws, name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         if newton:

--- a/scripts/ex-gwf-capture.py
+++ b/scripts/ex-gwf-capture.py
@@ -148,7 +148,7 @@ def build_model():
         sim = flopy.mf6.MFSimulation(
             sim_name=sim_name,
             sim_ws=sim_ws,
-            exe_name=config.mf6_exe,
+            exe_name="mf6",
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(
@@ -269,7 +269,9 @@ def get_streamflow(mobj):
 def run_model():
     success = True
     if config.runModel:
-        libmf6_path = pl.Path(shutil.which(config.mf6_exe)).parent / config.libmf6_exe
+        libmf6_path = (
+            pl.Path(shutil.which("mf6")).parent / f"libmf6{config.soext}"
+        )
         sim_ws = os.path.join(ws, sim_name)
         mf6 = modflowapi.ModflowApi(libmf6_path, working_directory=sim_ws)
         qbase = capture_fraction_iteration(mf6, cf_q)

--- a/scripts/ex-gwf-csub-p01.py
+++ b/scripts/ex-gwf-csub-p01.py
@@ -137,7 +137,7 @@ def build_model():
     if config.buildModel:
         sim_ws = os.path.join(ws, sim_name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-csub-p02.py
+++ b/scripts/ex-gwf-csub-p02.py
@@ -128,7 +128,7 @@ def build_model(
         if subdir_name is not None:
             sim_ws = os.path.join(sim_ws, subdir_name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-csub-p03.py
+++ b/scripts/ex-gwf-csub-p03.py
@@ -490,7 +490,7 @@ def build_model(
         if subdir_name is not None:
             sim_ws = os.path.join(sim_ws, subdir_name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-csub-p04.py
+++ b/scripts/ex-gwf-csub-p04.py
@@ -189,7 +189,7 @@ def build_model():
     if config.buildModel:
         sim_ws = os.path.join(ws, sim_name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-disvmesh.py
+++ b/scripts/ex-gwf-disvmesh.py
@@ -138,7 +138,7 @@ def build_model(sim_name):
     if config.buildModel:
         sim_ws = os.path.join(ws, sim_name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-drn-p01.py
+++ b/scripts/ex-gwf-drn-p01.py
@@ -955,7 +955,7 @@ def build_model(name, uzf_gwseep=None):
     if config.buildModel:
         sim_ws = os.path.join(ws, name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-fhb.py
+++ b/scripts/ex-gwf-fhb.py
@@ -90,7 +90,7 @@ def build_model():
     if config.buildModel:
         sim_ws = os.path.join(ws, sim_name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-hani.py
+++ b/scripts/ex-gwf-hani.py
@@ -86,7 +86,7 @@ def build_model(sim_name, angle1, xt3d):
     if config.buildModel:
         sim_ws = os.path.join(ws, sim_name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-lak-p01.py
+++ b/scripts/ex-gwf-lak-p01.py
@@ -177,7 +177,7 @@ def build_model():
     if config.buildModel:
         sim_ws = os.path.join(ws, sim_name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-lak-p02.py
+++ b/scripts/ex-gwf-lak-p02.py
@@ -596,7 +596,7 @@ def build_model():
     if config.buildModel:
         sim_ws = os.path.join(ws, sim_name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-lgr.py
+++ b/scripts/ex-gwf-lgr.py
@@ -21,9 +21,9 @@ import numpy as np
 from figspecs import USGSFigure
 from flopy.utils.lgrutil import Lgr
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mf2005_exe
-exe_name_mt = config.mt3dms_exe
+mf6exe = "mf6"
+exe_name_mf = "mf2005"
+exe_name_mt = "mt3dms"
 
 # Set figure properties specific to this problem
 

--- a/scripts/ex-gwf-lgrv.py
+++ b/scripts/ex-gwf-lgrv.py
@@ -209,7 +209,7 @@ def riv_resample(icoarsen, nrow, ncol, rivdat, idomain, rowcolspan):
 def build_lgr_model(sim_name):
     sim_ws = os.path.join(ws, sim_name)
     sim = flopy.mf6.MFSimulation(
-        sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+        sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
     )
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -333,7 +333,7 @@ def build_model(
         if sim is None:
             sim_ws = os.path.join(ws, sim_name)
             sim = flopy.mf6.MFSimulation(
-                sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+                sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
             )
             flopy.mf6.ModflowTdis(
                 sim, nper=nper, perioddata=tdis_ds, time_units=time_units

--- a/scripts/ex-gwf-maw-p01.py
+++ b/scripts/ex-gwf-maw-p01.py
@@ -131,7 +131,7 @@ def build_model(name, rate=0.0):
     if config.buildModel:
         sim_ws = os.path.join(ws, name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-maw-p02.py
+++ b/scripts/ex-gwf-maw-p02.py
@@ -122,7 +122,7 @@ def build_model():
     if config.buildModel:
         sim_ws = os.path.join(ws, sim_name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-maw-p03.py
+++ b/scripts/ex-gwf-maw-p03.py
@@ -263,7 +263,7 @@ def build_model(name, simulation="regional"):
 def build_regional(name):
     sim_ws = os.path.join(ws, name)
     sim = flopy.mf6.MFSimulation(
-        sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+        sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
     )
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -341,7 +341,7 @@ def build_local(name, simulation):
 
     sim_ws = os.path.join(ws, name)
     sim = flopy.mf6.MFSimulation(
-        sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+        sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
     )
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-nwt-p02.py
+++ b/scripts/ex-gwf-nwt-p02.py
@@ -134,7 +134,7 @@ def build_model(
     if config.buildModel:
         sim_ws = os.path.join(ws, name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         if newton:

--- a/scripts/ex-gwf-nwt-p03.py
+++ b/scripts/ex-gwf-nwt-p03.py
@@ -134,7 +134,7 @@ def build_model(
     if config.buildModel:
         sim_ws = os.path.join(ws, name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-radial.py
+++ b/scripts/ex-gwf-radial.py
@@ -213,7 +213,7 @@ def build_model(name):
     if config.buildModel:
         sim_ws = os.path.join(ws, name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(
             sim, nper=nper, perioddata=tdis_ds, time_units=time_units

--- a/scripts/ex-gwf-sagehen.py
+++ b/scripts/ex-gwf-sagehen.py
@@ -26,9 +26,9 @@ from figspecs import USGSFigure
 sys.path.append(os.path.join("..", "data", "ex-gwf-sagehen"))
 import sfr_static as sfrDat
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mf2005_exe
-exe_name_mt = config.mt3dms_exe
+mf6exe = "mf6"
+exe_name_mf = "mf2005"
+exe_name_mt = "mt3dms"
 
 # Set figure properties specific to this problem
 

--- a/scripts/ex-gwf-sfr-p01.py
+++ b/scripts/ex-gwf-sfr-p01.py
@@ -785,7 +785,7 @@ def build_model():
     if config.buildModel:
         sim_ws = os.path.join(ws, sim_name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-sfr-p01b.py
+++ b/scripts/ex-gwf-sfr-p01b.py
@@ -3762,7 +3762,7 @@ def build_model():
     if config.buildModel:
         sim_ws = os.path.join(ws, sim_name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-spbc.py
+++ b/scripts/ex-gwf-spbc.py
@@ -86,7 +86,7 @@ def build_model():
     if config.buildModel:
         sim_ws = os.path.join(ws, sim_name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-twri.py
+++ b/scripts/ex-gwf-twri.py
@@ -161,7 +161,7 @@ def build_model():
     if config.buildModel:
         sim_ws = os.path.join(ws, sim_name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(
@@ -217,7 +217,7 @@ def build_mf5model():
     if config.buildModel:
         sim_ws = os.path.join(ws, sim_name, "mf2005")
         mf = flopy.modflow.Modflow(
-            modelname=sim_name, model_ws=sim_ws, exe_name=config.mf2005dbl_exe
+            modelname=sim_name, model_ws=sim_ws, exe_name="mf2005dbl"
         )
         flopy.modflow.ModflowDis(
             mf,

--- a/scripts/ex-gwf-u1disv.py
+++ b/scripts/ex-gwf-u1disv.py
@@ -122,7 +122,7 @@ def build_model(sim_name, xt3d):
     if config.buildModel:
         sim_ws = os.path.join(ws, sim_name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-u1gwfgwf.py
+++ b/scripts/ex-gwf-u1gwfgwf.py
@@ -131,7 +131,7 @@ def build_model(sim_name, XT3D_in_models, XT3D_at_exchange):
     if config.buildModel:
         sim_ws = os.path.join(ws, sim_name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-whirl.py
+++ b/scripts/ex-gwf-whirl.py
@@ -87,7 +87,7 @@ def build_model():
     if config.buildModel:
         sim_ws = os.path.join(ws, sim_name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-zaidel.py
+++ b/scripts/ex-gwf-zaidel.py
@@ -100,7 +100,7 @@ def build_model(H2=1.0):
 
         sim_ws = os.path.join(ws, sim_name)
         sim = flopy.mf6.MFSimulation(
-            sim_name=sim_name, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6"
         )
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwt-gwtgwt-p10.py
+++ b/scripts/ex-gwt-gwtgwt-p10.py
@@ -20,7 +20,7 @@ import numpy as np
 from figspecs import USGSFigure
 from flopy.utils.util_array import read1d
 
-mf6exe = config.mf6_exe
+mf6exe = "mf6"
 
 # ### Model Input Parameters
 

--- a/scripts/ex-gwt-hecht-mendez.py
+++ b/scripts/ex-gwt-hecht-mendez.py
@@ -39,9 +39,9 @@ import numpy as np
 from figspecs import USGSFigure
 from flopy.utils.util_array import read1d
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mf2005_exe
-exe_name_mt = config.mt3dusgs_exe
+mf6exe = "mf6"
+exe_name_mf = "mf2005"
+exe_name_mt = "mt3dusgs"
 
 # Set figure properties specific to this problem
 
@@ -302,7 +302,7 @@ def build_mf6_flow_model(
         gwfname = "gwf-" + name
         sim_ws = os.path.join(ws, sim_name, "mf6gwf")
         sim = flopy.mf6.MFSimulation(
-            sim_name=gwfname, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=gwfname, sim_ws=sim_ws, exe_name="mf6"
         )
 
         # Instantiating MODFLOW 6 time discretization
@@ -496,7 +496,7 @@ def build_mf6_transport_model(
         gwtname = "gwt-" + name
         sim_ws = os.path.join(ws, sim_name, "mf6gwt")
         sim = flopy.mf6.MFSimulation(
-            sim_name=gwtname, sim_ws=sim_ws, exe_name=config.mf6_exe
+            sim_name=gwtname, sim_ws=sim_ws, exe_name="mf6"
         )
 
         # MF6 time discretization is a bit different than corresponding flow simulation

--- a/scripts/ex-gwt-henry.py
+++ b/scripts/ex-gwt-henry.py
@@ -25,9 +25,9 @@ sys.path.append(os.path.join("..", "common"))
 import config
 from figspecs import USGSFigure
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mf2005_exe
-exe_name_mt = config.mt3dms_exe
+mf6exe = "mf6"
+exe_name_mf = "mf2005"
+exe_name_mt = "mt3dms"
 
 # Set figure properties specific to this problem
 
@@ -94,7 +94,9 @@ def build_model(sim_folder, inflow):
     print(f"Building model...{sim_folder}")
     name = "flow"
     sim_ws = os.path.join(ws, sim_folder)
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=sim_ws, exe_name="mf6"
+    )
     tdis_ds = ((perlen, nstp, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)

--- a/scripts/ex-gwt-keating.py
+++ b/scripts/ex-gwt-keating.py
@@ -109,7 +109,9 @@ def build_mf6gwf(sim_folder):
     print(f"Building mf6gwf model...{sim_folder}")
     name = "flow"
     sim_ws = os.path.join(ws, sim_folder, "mf6gwf")
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=sim_ws, exe_name="mf6"
+    )
     tdis_ds = ((period1, 1, 1.0), (period2, 1, 1.0))
     flopy.mf6.ModflowTdis(
         sim, nper=len(tdis_ds), perioddata=tdis_ds, time_units=time_units
@@ -196,7 +198,7 @@ def build_mf6gwt(sim_folder):
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         sim_ws=sim_ws,
-        exe_name=config.mf6_exe,
+        exe_name="mf6",
         continue_=True,
     )
     tdis_ds = ((period1, 73, 1.0), (period2, 2927, 1.0))

--- a/scripts/ex-gwt-moc3d-p01.py
+++ b/scripts/ex-gwt-moc3d-p01.py
@@ -26,9 +26,9 @@ import analytical
 import config
 from figspecs import USGSFigure
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mf2005_exe
-exe_name_mt = config.mt3dms_exe
+mf6exe = "mf6"
+exe_name_mf = "mf2005"
+exe_name_mt = "mt3dms"
 
 # Set figure properties specific to this problem
 
@@ -139,7 +139,9 @@ def build_mf6gwf(sim_folder):
     print(f"Building mf6gwf model...{sim_folder}")
     name = "flow"
     sim_ws = os.path.join(ws, sim_folder, "mf6gwf")
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=sim_ws, exe_name="mf6"
+    )
     tdis_ds = ((total_time, 1, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(sim)
@@ -197,7 +199,9 @@ def build_mf6gwt(sim_folder, longitudinal_dispersivity, retardation_factor, deca
     print(f"Building mf6gwt model...{sim_folder}")
     name = "trans"
     sim_ws = os.path.join(ws, sim_folder, "mf6gwt")
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=sim_ws, exe_name="mf6"
+    )
     tdis_ds = ((total_time, 240, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(sim, linear_acceleration="bicgstab")

--- a/scripts/ex-gwt-moc3d-p02.py
+++ b/scripts/ex-gwt-moc3d-p02.py
@@ -26,9 +26,9 @@ import analytical
 import config
 from figspecs import USGSFigure
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mf2005_exe
-exe_name_mt = config.mt3dms_exe
+mf6exe = "mf6"
+exe_name_mf = "mf2005"
+exe_name_mt = "mt3dms"
 
 # Set figure properties specific to this problem
 
@@ -79,7 +79,9 @@ def build_mf6gwf(sim_folder):
     print(f"Building mf6gwf model...{sim_folder}")
     name = "flow"
     sim_ws = os.path.join(ws, sim_folder, "mf6gwf")
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=sim_ws, exe_name="mf6"
+    )
     tdis_ds = ((total_time, 1, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(sim, print_option="summary", inner_maximum=300)
@@ -131,7 +133,9 @@ def build_mf6gwt(sim_folder):
     print(f"Building mf6gwt model...{sim_folder}")
     name = "trans"
     sim_ws = os.path.join(ws, sim_folder, "mf6gwt")
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=sim_ws, exe_name="mf6"
+    )
     tdis_ds = ((total_time, 400, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(sim, linear_acceleration="bicgstab")

--- a/scripts/ex-gwt-moc3d-p02tg.py
+++ b/scripts/ex-gwt-moc3d-p02tg.py
@@ -27,9 +27,9 @@ import analytical
 import config
 from figspecs import USGSFigure
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mf2005_exe
-exe_name_mt = config.mt3dms_exe
+mf6exe = "mf6"
+exe_name_mf = "mf2005"
+exe_name_mt = "mt3dms"
 
 # Set figure properties specific to this problem
 
@@ -147,7 +147,9 @@ def build_mf6gwf(sim_folder):
     print(f"Building mf6gwf model...{sim_folder}")
     name = "flow"
     sim_ws = os.path.join(ws, sim_folder, "mf6gwf")
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=sim_ws, exe_name="mf6"
+    )
     tdis_ds = ((total_time, 1, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -208,7 +210,9 @@ def build_mf6gwt(sim_folder):
     print(f"Building mf6gwt model...{sim_folder}")
     name = "trans"
     sim_ws = os.path.join(ws, sim_folder, "mf6gwt")
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=sim_ws, exe_name="mf6"
+    )
     tdis_ds = ((total_time, 100, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(

--- a/scripts/ex-gwt-mt3dms-p01.py
+++ b/scripts/ex-gwt-mt3dms-p01.py
@@ -39,9 +39,9 @@ sys.path.append(os.path.join("..", "common"))
 import config
 from figspecs import USGSFigure
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mf2005_exe
-exe_name_mt = config.mt3dms_exe
+mf6exe = "mf6"
+exe_name_mf = "mf2005"
+exe_name_mt = "mt3dms"
 
 # Set figure properties specific to this problem
 

--- a/scripts/ex-gwt-mt3dms-p02.py
+++ b/scripts/ex-gwt-mt3dms-p02.py
@@ -26,7 +26,7 @@ import analytical
 import config
 from figspecs import USGSFigure
 
-mf6exe = config.mf6_exe
+mf6exe = "mf6"
 
 # Set figure properties specific to this problem
 
@@ -117,7 +117,9 @@ def build_mf6gwf(sim_folder):
     print(f"Building mf6gwf model...{sim_folder}")
     name = "flow"
     sim_ws = os.path.join(ws, sim_folder, "mf6gwf")
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=sim_ws, exe_name="mf6"
+    )
     tdis_ds = (
         (period1, int(period1 / delta_time), 1.0),
         (period2, int(period2 / delta_time), 1.0),
@@ -190,7 +192,9 @@ def build_mf6gwt(
     print(f"Building mf6gwt model...{sim_folder}")
     name = "trans"
     sim_ws = os.path.join(ws, sim_folder, "mf6gwt")
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=sim_ws, exe_name="mf6"
+    )
     tdis_ds = (
         (period1, int(period1 / delta_time), 1.0),
         (period2, int(period2 / delta_time), 1.0),
@@ -278,7 +282,7 @@ def build_mf2005(sim_folder):
     name = "flow"
     sim_ws = os.path.join(ws, sim_folder, "mf2005")
     mf = flopy.modflow.Modflow(
-        modelname=name, model_ws=sim_ws, exe_name=config.mf2005_exe
+        modelname=name, model_ws=sim_ws, exe_name="mf2005"
     )
     perlen = [period1, period2]
     dis = flopy.modflow.ModflowDis(
@@ -323,7 +327,7 @@ def build_mt3dms(
     mt = flopy.mt3d.Mt3dms(
         modelname=name,
         model_ws=sim_ws,
-        exe_name=config.mt3dms_exe,
+        exe_name="mt3dms",
         modflowmodel=modflowmodel,
         ftlfilename="../mf2005/mt3d_link.ftl",
     )

--- a/scripts/ex-gwt-mt3dms-p03.py
+++ b/scripts/ex-gwt-mt3dms-p03.py
@@ -36,9 +36,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 from figspecs import USGSFigure
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mf2005_exe
-exe_name_mt = config.mt3dms_exe
+mf6exe = "mf6"
+exe_name_mf = "mf2005"
+exe_name_mt = "mt3dms"
 
 # Set figure properties specific to this problem
 

--- a/scripts/ex-gwt-mt3dms-p04.py
+++ b/scripts/ex-gwt-mt3dms-p04.py
@@ -36,9 +36,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 from figspecs import USGSFigure
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mf2005_exe
-exe_name_mt = config.mt3dms_exe
+mf6exe = "mf6"
+exe_name_mf = "mf2005"
+exe_name_mt = "mt3dms"
 
 # Set figure properties specific to this problem
 

--- a/scripts/ex-gwt-mt3dms-p05.py
+++ b/scripts/ex-gwt-mt3dms-p05.py
@@ -36,9 +36,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 from figspecs import USGSFigure
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mf2005_exe
-exe_name_mt = config.mt3dms_exe
+mf6exe = "mf6"
+exe_name_mf = "mf2005"
+exe_name_mt = "mt3dms"
 
 # Set figure properties specific to this problem
 

--- a/scripts/ex-gwt-mt3dms-p06.py
+++ b/scripts/ex-gwt-mt3dms-p06.py
@@ -36,9 +36,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 from figspecs import USGSFigure
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mf2005_exe
-exe_name_mt = config.mt3dusgs_exe
+mf6exe = "mf6"
+exe_name_mf = "mf2005"
+exe_name_mt = "mt3dusgs"
 
 # Set figure properties specific to this problem
 

--- a/scripts/ex-gwt-mt3dms-p07.py
+++ b/scripts/ex-gwt-mt3dms-p07.py
@@ -36,9 +36,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 from figspecs import USGSFigure
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mf2005_exe
-exe_name_mt = config.mt3dusgs_exe
+mf6exe = "mf6"
+exe_name_mf = "mf2005"
+exe_name_mt = "mt3dusgs"
 
 # Set figure properties specific to this problem
 

--- a/scripts/ex-gwt-mt3dms-p08.py
+++ b/scripts/ex-gwt-mt3dms-p08.py
@@ -37,9 +37,9 @@ import numpy as np
 from figspecs import USGSFigure
 from flopy.utils.util_array import read1d
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mf2005_exe
-exe_name_mt = config.mt3dusgs_exe
+mf6exe = "mf6"
+exe_name_mf = "mf2005"
+exe_name_mt = "mt3dusgs"
 
 # Set figure properties specific to this problem
 

--- a/scripts/ex-gwt-mt3dms-p09.py
+++ b/scripts/ex-gwt-mt3dms-p09.py
@@ -37,9 +37,9 @@ import numpy as np
 from figspecs import USGSFigure
 from flopy.utils.util_array import read1d
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mf2005_exe
-exe_name_mt = config.mt3dusgs_exe
+mf6exe = "mf6"
+exe_name_mf = "mf2005"
+exe_name_mt = "mt3dusgs"
 
 # Set figure properties specific to this problem
 

--- a/scripts/ex-gwt-mt3dms-p10.py
+++ b/scripts/ex-gwt-mt3dms-p10.py
@@ -37,9 +37,9 @@ import numpy as np
 from figspecs import USGSFigure
 from flopy.utils.util_array import read1d
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mf2005_exe
-exe_name_mt = config.mt3dusgs_exe
+mf6exe = "mf6"
+exe_name_mf = "mf2005"
+exe_name_mt = "mt3dusgs"
 
 # Set figure properties specific to this problem
 

--- a/scripts/ex-gwt-mt3dsupp631.py
+++ b/scripts/ex-gwt-mt3dsupp631.py
@@ -67,7 +67,9 @@ def build_mf6gwf(sim_folder):
     print(f"Building mf6gwf model...{sim_folder}")
     name = "flow"
     sim_ws = os.path.join(ws, sim_folder, "mf6gwf")
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=sim_ws, exe_name="mf6"
+    )
     tdis_ds = (
         (source_duration, 1, 1.0),
         (total_time - source_duration, 1, 1.0),
@@ -120,7 +122,9 @@ def build_mf6gwt(sim_folder):
     print(f"Building mf6gwt model...{sim_folder}")
     name = "trans"
     sim_ws = os.path.join(ws, sim_folder, "mf6gwt")
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=sim_ws, exe_name="mf6"
+    )
     pertim1 = source_duration
     pertim2 = total_time - source_duration
     tdis_ds = ((pertim1, 16, 1.0), (pertim2, 84, 1.0))
@@ -173,7 +177,7 @@ def build_mf2005(sim_folder):
     name = "flow"
     sim_ws = os.path.join(ws, sim_folder, "mf2005")
     mf = flopy.modflow.Modflow(
-        modelname=name, model_ws=sim_ws, exe_name=config.mf2005_exe
+        modelname=name, model_ws=sim_ws, exe_name="mf2005"
     )
     pertim1 = source_duration
     pertim2 = total_time - source_duration
@@ -210,7 +214,7 @@ def build_mt3dms(sim_folder, modflowmodel):
     mt = flopy.mt3d.Mt3dms(
         modelname=name,
         model_ws=sim_ws,
-        exe_name=config.mt3dms_exe,
+        exe_name="mt3dms",
         modflowmodel=modflowmodel,
         ftlfilename="../mf2005/mt3d_link.ftl",
     )

--- a/scripts/ex-gwt-mt3dsupp632.py
+++ b/scripts/ex-gwt-mt3dsupp632.py
@@ -104,7 +104,9 @@ def build_mf6gwf(sim_folder):
     print(f"Building mf6gwf model...{sim_folder}")
     name = "flow"
     sim_ws = os.path.join(ws, sim_folder, "mf6gwf")
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=sim_ws, exe_name="mf6"
+    )
     tdis_ds = (
         (source_duration, 1, 1.0),
         (total_time - source_duration, 1, 1.0),
@@ -152,7 +154,9 @@ def build_mf6gwt(sim_folder, distribution_coefficient, decay, decay_sorbed):
     print(f"Building mf6gwt model...{sim_folder}")
     name = "trans"
     sim_ws = os.path.join(ws, sim_folder, "mf6gwt")
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=sim_ws, exe_name="mf6"
+    )
     pertim1 = source_duration
     pertim2 = total_time - source_duration
     tdis_ds = ((pertim1, 10, 1.0), (pertim2, 90, 1.0))
@@ -245,7 +249,7 @@ def build_mf2005(sim_folder):
     name = "flow"
     sim_ws = os.path.join(ws, sim_folder, "mf2005")
     mf = flopy.modflow.Modflow(
-        modelname=name, model_ws=sim_ws, exe_name=config.mf2005_exe
+        modelname=name, model_ws=sim_ws, exe_name="mf2005"
     )
     pertim1 = source_duration
     pertim2 = total_time - source_duration
@@ -284,7 +288,7 @@ def build_mt3dms(
     mt = flopy.mt3d.Mt3dms(
         modelname=name,
         model_ws=sim_ws,
-        exe_name=config.mt3dms_exe,
+        exe_name="mt3dms",
         modflowmodel=modflowmodel,
         ftlfilename="../mf2005/mt3d_link.ftl",
     )

--- a/scripts/ex-gwt-mt3dsupp82.py
+++ b/scripts/ex-gwt-mt3dsupp82.py
@@ -67,7 +67,9 @@ def build_mf6gwf(sim_folder):
     print(f"Building mf6gwf model...{sim_folder}")
     name = "flow"
     sim_ws = os.path.join(ws, sim_folder, "mf6gwf")
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=sim_ws, exe_name="mf6"
+    )
     tdis_ds = ((total_time, 1, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(sim)
@@ -171,7 +173,9 @@ def build_mf6gwt(sim_folder):
     print(f"Building mf6gwt model...{sim_folder}")
     name = "trans"
     sim_ws = os.path.join(ws, sim_folder, "mf6gwt")
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=sim_ws, exe_name="mf6"
+    )
     tdis_ds = ((total_time, 20, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(sim, linear_acceleration="bicgstab")
@@ -258,7 +262,7 @@ def build_mf2005(sim_folder):
     name = "flow"
     sim_ws = os.path.join(ws, sim_folder, "mf2005")
     mf = flopy.modflow.Modflow(
-        modelname=name, model_ws=sim_ws, exe_name=config.mf2005_exe
+        modelname=name, model_ws=sim_ws, exe_name="mf2005"
     )
     perlen = [total_time]
     dis = flopy.modflow.ModflowDis(
@@ -302,7 +306,7 @@ def build_mt3dms(sim_folder, modflowmodel):
     mt = flopy.mt3d.Mt3dms(
         modelname=name,
         model_ws=sim_ws,
-        exe_name=config.mt3dms_exe,
+        exe_name="mt3dms",
         modflowmodel=modflowmodel,
         ftlfilename="../mf2005/mt3d_link.ftl",
     )

--- a/scripts/ex-gwt-prudic2004t2.py
+++ b/scripts/ex-gwt-prudic2004t2.py
@@ -25,9 +25,9 @@ sys.path.append(os.path.join("..", "common"))
 import config
 from figspecs import USGSFigure
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mf2005_exe
-exe_name_mt = config.mt3dms_exe
+mf6exe = "mf6"
+exe_name_mf = "mf2005"
+exe_name_mt = "mt3dms"
 
 # Set figure properties specific to this problem
 
@@ -164,7 +164,9 @@ def build_mf6gwf(sim_folder):
     print(f"Building mf6gwf model...{sim_folder}")
     name = "flow"
     sim_ws = os.path.join(ws, sim_folder, "mf6gwf")
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=sim_ws, exe_name="mf6"
+    )
     tdis_data = [(total_time, 1, 1.0)]
     flopy.mf6.ModflowTdis(
         sim, nper=len(tdis_data), perioddata=tdis_data, time_units=time_units
@@ -323,7 +325,9 @@ def build_mf6gwt(sim_folder):
     print(f"Building mf6gwt model...{sim_folder}")
     name = "trans"
     sim_ws = os.path.join(ws, sim_folder, "mf6gwt")
-    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name=config.mf6_exe)
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=sim_ws, exe_name="mf6"
+    )
     tdis_data = ((total_time, 300, 1.0),)
     flopy.mf6.ModflowTdis(
         sim, nper=len(tdis_data), perioddata=tdis_data, time_units=time_units

--- a/scripts/ex-gwt-rotate.py
+++ b/scripts/ex-gwt-rotate.py
@@ -26,9 +26,9 @@ import config
 from analytical import BakkerRotatingInterface
 from figspecs import USGSFigure
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mf2005_exe
-exe_name_mt = config.mt3dms_exe
+mf6exe = "mf6"
+exe_name_mf = "mf2005"
+exe_name_mt = "mt3dms"
 
 # Set figure properties specific to this problem
 
@@ -112,7 +112,7 @@ def build_model(sim_folder):
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         sim_ws=sim_ws,
-        exe_name=config.mf6_exe,
+        exe_name="mf6",
         continue_=True,
     )
     tdis_ds = ((perlen, nstp, 1.0),)

--- a/scripts/ex-gwt-saltlake.py
+++ b/scripts/ex-gwt-saltlake.py
@@ -25,9 +25,9 @@ sys.path.append(os.path.join("..", "common"))
 import config
 from figspecs import USGSFigure
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mf2005_exe
-exe_name_mt = config.mt3dms_exe
+mf6exe = "mf6"
+exe_name_mf = "mf2005"
+exe_name_mt = "mt3dms"
 
 # Set figure properties specific to this problem
 
@@ -94,7 +94,7 @@ def build_model(sim_folder):
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         sim_ws=sim_ws,
-        exe_name=config.mf6_exe,
+        exe_name="mf6",
     )
     tdis_ds = ((perlen, nstp, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)

--- a/scripts/ex-gwt-stallman.py
+++ b/scripts/ex-gwt-stallman.py
@@ -26,7 +26,7 @@ import config
 from analytical import Stallman
 from figspecs import USGSFigure
 
-mf6exe = config.mf6_exe
+mf6exe = "mf6"
 
 # Set figure properties specific to this problem
 
@@ -114,7 +114,7 @@ def build_model(sim_folder):
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         sim_ws=sim_ws,
-        exe_name=config.mf6_exe,
+        exe_name="mf6",
     )
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=per_mf6, time_units=time_units)
     gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)

--- a/scripts/ex-gwt-synthetic-valley.py
+++ b/scripts/ex-gwt-synthetic-valley.py
@@ -420,7 +420,7 @@ def build_mf6gwf(sim_folder):
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         sim_ws=sim_ws,
-        exe_name=config.mf6_exe,
+        exe_name="mf6",
         continue_=True,
     )
     tdis = flopy.mf6.ModflowTdis(sim, time_units="days", perioddata=((pertim, 1, 1.0),))
@@ -519,7 +519,7 @@ def build_mf6gwt(sim_folder):
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         sim_ws=sim_ws,
-        exe_name=config.mf6_exe,
+        exe_name="mf6",
         continue_=True,
     )
     tdis = flopy.mf6.ModflowTdis(

--- a/scripts/ex-gwt-uzt-2d.py
+++ b/scripts/ex-gwt-uzt-2d.py
@@ -20,9 +20,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 from figspecs import USGSFigure
 
-mf6exe = config.mf6_exe
-exe_name_mf = config.mfnwt_exe
-exe_name_mt = config.mt3dusgs_exe
+mf6exe = "mf6"
+exe_name_mf = "mfnwt"
+exe_name_mt = "mt3dusgs"
 
 # Set figure properties specific to this problem
 

--- a/scripts/pytest.ini
+++ b/scripts/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = ex-*.py


### PR DESCRIPTION
Previously executable paths were imported with the `config` object from `common/config.py`. Discover exes by name on the system path instead

Removes the need for exes to live in `bin` in the project root or else modify `common/config.py`. First time use could now be

- clone the repo
- create/activate a Python environment e.g. venv or conda
- install dependencies, e.g. `pip install -r etc/requirements.pip.txt` etc...
- install modflow somewhere with `get-modflow :`

Whichever location is selected, `get-modflow` will add binaries to the path.

Also:
- update developer docs to reflect above
- add `pytest.ini` to scripts folder so scripts are collectable
- add dependencies to `doc/requirements.rtd.txt
  - `recommonmark`
  - `sphinx-rtd-theme`