### PR TITLE
fix: scripts/process-scripts.py latex table builder to work with black

### DIFF
--- a/scripts/process-scripts.py
+++ b/scripts/process-scripts.py
@@ -214,7 +214,7 @@ def make_tables():
                         continue
                     # get content on right side of "="
                     val = obj.value
-                    if val.lineno == val.end_lineno:
+                    if obj.lineno == obj.end_lineno:
                         value = line[val.col_offset : val.end_col_offset]
                     else:
                         # string may span more than one line


### PR DESCRIPTION
Fixed an issue with #108 that used the wrong line when building the latex tables using `scripts/process-scripts.py`.
This primarily was an issue when assignments span more than one line.
Such as:
```
k33_str = (
    "1179., 30., 30., 30., 30."  # Vertical hydraulic conductivity ($ft/d$)
)
```

should the assignment string `1179., 30., 30., 30., 30.` and comment `Vertical hydraulic conductivity ($ft/d$)`, but would extract the assignment as `k33_str = (`.

This allows for `scripts/process-scripts.py` to process files that have been reformatted by `black`.