### PR TITLE
ci: run on branches that start with ci-

### DIFF
--- a/.github/workflows/ex-rtd.yml
+++ b/.github/workflows/ex-rtd.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
       - develop
+      - ci-*
     paths-ignore:
       - 'README.md'
       - 'DEVELOPER.md'

--- a/.github/workflows/ex-workflow.yml
+++ b/.github/workflows/ex-workflow.yml
@@ -7,6 +7,7 @@ on:
     branches: 
       - master
       - develop
+      - ci-*
     paths-ignore:
       - 'README.md'
       - 'DEVELOPER.md'


### PR DESCRIPTION
Added `ci-*` to the `.github/workflows/ex-*.yaml` files so that branches that start with `ci-` will run the autotests.