### PR TITLE
fix: support Python 3.8

### DIFF
--- a/common/DisvPropertyContainer.py
+++ b/common/DisvPropertyContainer.py
@@ -1,5 +1,6 @@
 import copy
 from itertools import cycle
+from typing import List
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -103,10 +104,10 @@ class DisvPropertyContainer:
     nlay: int
     ncpl: int
     nvert: int
-    vertices: list[list]  # [[iv, xv, yv], ...]
-    cell2d: list[list]  # [[ic, xc, yc, ncvert, icvert], ...]
+    vertices: List[list]  # [[iv, xv, yv], ...]
+    cell2d: List[list]  # [[ic, xc, yc, ncvert, icvert], ...]
     top: np.ndarray
-    botm: list[np.ndarray]
+    botm: List[np.ndarray]
     origin_x: float
     origin_y: float
     rotation: float

--- a/etc/conftest.py
+++ b/etc/conftest.py
@@ -13,4 +13,6 @@ def pytest_generate_tests(metafunc):
             for file_name in sorted(os.listdir(os.path.join("..", "scripts")))
             if file_name.endswith(".py") and file_name.startswith("ex-")
         }
-        metafunc.parametrize("build", scripts_dict.values(), ids=scripts_dict.keys())
+        metafunc.parametrize(
+            "build", scripts_dict.values(), ids=scripts_dict.keys()
+        )


### PR DESCRIPTION
Before Python 3.9, standard library containers (e.g. `list`) [did not support subscripted type variables in type annotations](https://docs.python.org/3.9/library/typing.html#module-contents). Could switch back when flopy and other modflow-related projects drop support for Python 3.8, but maybe best to keep the min supported version consistent across projects at 3.8 for now