### PR TITLE
docs(rtd): fix .readthedocs.yml (add build section)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: .doc/conf.py
@@ -19,7 +25,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - requirements: etc/requirements.pip.txt
     - requirements: .doc/requirements.rtd.txt


### PR DESCRIPTION
* [`build` section](https://docs.readthedocs.io/en/stable/config-file/v2.html#build) is now required