### PR TITLE
ci(rtd): trigger rtd build on push to any branch on main repo

### DIFF
--- a/.github/workflows/ex-rtd.yml
+++ b/.github/workflows/ex-rtd.yml
@@ -112,13 +112,12 @@ jobs:
     name: rtd-trigger
     needs: rtd_build
     runs-on: ubuntu-latest
-
-    if: github.repository_owner == 'MODFLOW-USGS' && github.event_name == 'push' && github.ref_name == 'master'
+    if: github.repository_owner == 'MODFLOW-USGS' && github.event_name == 'push'
     steps:
       - name: Checkout MODFLOW6 examples repo
         uses: actions/checkout@v4
 
-      - name: Trigger RTDs build on push to repo branches
+      - name: Trigger RTDs build
         uses: dfm/rtds-action@v1
         with:
           webhook_url: ${{ secrets.RTDS_WEBHOOK_URL }}


### PR DESCRIPTION
* trigger on any branch, as done for [flopy](https://github.com/modflowpy/flopy/blob/9318d62fd2283c688403b411d840fe3e7e23e160/.github/workflows/rtd.yml#L92) &mdash; let RTD settings control which branches are active/inactive