### PR TITLE
fix(ex-gwt-uzt-2d): fix model units typo (meter -> meters)

### DIFF
--- a/scripts/ex-gwt-uzt-2d.py
+++ b/scripts/ex-gwt-uzt-2d.py
@@ -125,7 +125,7 @@ parameter_units = {
 }
 
 # Model units
-length_units = "meter"
+length_units = "meters"
 time_units = "days"
 
 # Model parameters


### PR DESCRIPTION
* discovered by @rbwinst-usgs