### PR TITLE
refactor(curvilinear): support python 3.8

### DIFF
--- a/scripts/ex-gwf-curvilinear-90.py
+++ b/scripts/ex-gwf-curvilinear-90.py
@@ -26,6 +26,7 @@ import os
 import pathlib as pl
 from itertools import cycle
 from math import sqrt
+from typing import List
 
 import flopy
 import matplotlib.pyplot as plt
@@ -147,10 +148,10 @@ class DisvPropertyContainer:
     nlay: int
     ncpl: int
     nvert: int
-    vertices: list[list]  # [[iv, xv, yv], ...]
-    cell2d: list[list]  # [[ic, xc, yc, ncvert, icvert], ...]
+    vertices: List[list]  # [[iv, xv, yv], ...]
+    cell2d: List[list]  # [[ic, xc, yc, ncvert, icvert], ...]
     top: np.ndarray
-    botm: list[np.ndarray]
+    botm: List[np.ndarray]
     origin_x: float
     origin_y: float
     rotation: float

--- a/scripts/ex-gwf-curvilinear.py
+++ b/scripts/ex-gwf-curvilinear.py
@@ -25,6 +25,7 @@ import copy
 import os
 import pathlib as pl
 from itertools import cycle
+from typing import List
 
 import flopy
 import matplotlib.pyplot as plt
@@ -146,10 +147,10 @@ class DisvPropertyContainer:
     nlay: int
     ncpl: int
     nvert: int
-    vertices: list[list]  # [[iv, xv, yv], ...]
-    cell2d: list[list]  # [[ic, xc, yc, ncvert, icvert], ...]
+    vertices: List[list]  # [[iv, xv, yv], ...]
+    cell2d: List[list]  # [[ic, xc, yc, ncvert, icvert], ...]
     top: np.ndarray
-    botm: list[np.ndarray]
+    botm: List[np.ndarray]
     origin_x: float
     origin_y: float
     rotation: float


### PR DESCRIPTION
* using `typing.List[...]` for type hints instead of `list[...]`
* support python 3.8 until EOL [later this year](https://devguide.python.org/versions/)