### PR TITLE
fix(.gitattributes): enforce unix line endings for data files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,5 +14,6 @@
 *.jpg binary
 *.pdf binary
 
+# Later lines modify earlier lines
 data/** text eol=lf
 data/**/*.tif binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,6 @@
 *.png binary
 *.jpg binary
 *.pdf binary
+
+data/** text eol=lf
+data/**/*.tif binary


### PR DESCRIPTION
Automatic lf -> crlf conversion on Windows caused pooch hash check to fail, enforce lf for all text files in the `data/` directory. Followup to
  * #137 
  * #153

For Windows developers it may be necessary to refresh the repository [as described here](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#refreshing-a-repository-after-changing-line-endings) after rebasing with this change.

Other resources
* https://en.wikipedia.org/wiki/Newline#Representation
* https://stackoverflow.com/q/10418975/6514033
* https://git-scm.com/docs/gitattributes