### PR TITLE
docs(RTD): include ex-gwe-radial example

### DIFF
--- a/.doc/conf.py
+++ b/.doc/conf.py
@@ -27,15 +27,12 @@ ex_regex = re.compile("\\\\input{sections/(.*?)\\}")
 pth = os.path.join("..", "doc", "body.tex")
 with open(pth) as f:
     lines = f.read()
-gwf_list = []
-gwt_list = []
+examples = []
 for v in ex_regex.findall(lines):
-    if "ex-gwf-" in v:
-        gwf_list.append(v.replace(".tex", ""))
-    elif "ex-gwt-" in v:
-        gwt_list.append(v.replace(".tex", ""))
+    if "ex-" in v:
+        examples.append(v.replace(".tex", ""))
 
-# -- Build examples.rst for notebooks to .doc --------------------------------
+# -- Build notebook_examples.rst ---------------------------------------------
 with open("notebook_examples.rst", "w") as f:
     lines = "Example notebooks\n"
     lines += (len(lines) - 1) * "-" + "\n\n"
@@ -47,9 +44,7 @@ with open("notebook_examples.rst", "w") as f:
 
     lines = ".. nbgallery::\n"
     lines += "    :name: Examples gallery\n\n"
-    for base_name in gwf_list:
-        lines += f"   _notebooks/{base_name}\n"
-    for base_name in gwt_list:
+    for base_name in examples:
         lines += f"   _notebooks/{base_name}\n"
     lines += "\n\n"
     f.write(lines)

--- a/.doc/examples.rst
+++ b/.doc/examples.rst
@@ -1,11 +1,11 @@
-====================
 Example descriptions
-====================
+--------------------
 
+An overview of each MODFLOW 6 example problem.
 
 .. toctree::
-   :numbered:
-   :maxdepth: 1
+    :numbered:
+    :maxdepth: 1
 
    _examples/ex-gwf-twri.rst
    _examples/ex-gwf-bcf2ss.rst
@@ -37,9 +37,6 @@ Example descriptions
    _examples/ex-gwf-drn-p01.rst
    _examples/ex-gwf-sagehen.rst
    _examples/ex-gwf-capture.rst
-   _examples/ex-gwf-radial.rst
-   _examples/ex-gwf-curvilinear-90.rst
-   _examples/ex-gwf-curvilinear.rst
    _examples/ex-gwt-keating.rst
    _examples/ex-gwt-moc3d-p01.rst
    _examples/ex-gwt-moc3d-p02.rst
@@ -66,3 +63,9 @@ Example descriptions
    _examples/ex-gwt-hecht-mendez.rst
    _examples/ex-gwt-stallman.rst
    _examples/ex-gwt-synthetic-valley.rst
+   _examples/ex-gwf-radial.rst
+   _examples/ex-gwf-curvilinear-90.rst
+   _examples/ex-gwf-curvilinear.rst
+   _examples/ex-gwe-radial.rst
+
+

--- a/.doc/notebook_examples.rst
+++ b/.doc/notebook_examples.rst
@@ -37,9 +37,6 @@ each of the MODFLOW 6 `examples <examples.html>`_.
    _notebooks/ex-gwf-drn-p01
    _notebooks/ex-gwf-sagehen
    _notebooks/ex-gwf-capture
-   _notebooks/ex-gwf-radial
-   _notebooks/ex-gwf-curvilinear-90
-   _notebooks/ex-gwf-curvilinear
    _notebooks/ex-gwt-keating
    _notebooks/ex-gwt-moc3d-p01
    _notebooks/ex-gwt-moc3d-p02
@@ -66,5 +63,9 @@ each of the MODFLOW 6 `examples <examples.html>`_.
    _notebooks/ex-gwt-hecht-mendez
    _notebooks/ex-gwt-stallman
    _notebooks/ex-gwt-synthetic-valley
+   _notebooks/ex-gwf-radial
+   _notebooks/ex-gwf-curvilinear-90
+   _notebooks/ex-gwf-curvilinear
+   _notebooks/ex-gwe-radial
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,4 @@ notebooks/
 
 **.DS_Store
 **.zip
+**.ipynb

--- a/etc/ci_create_examples_rst.py
+++ b/etc/ci_create_examples_rst.py
@@ -30,15 +30,11 @@ else:
 pth = os.path.join("..", "doc", "body.tex")
 with open(pth) as f:
     lines = f.read()
-gwf_list = []
-gwt_list = []
+examples = []
 ex_regex = re.compile("\\\\input{sections/(.*?)\\}")
 for v in ex_regex.findall(lines):
-    if "ex-gwf-" in v:
-        gwf_list.append(v.replace(".tex", ""))
-    elif "ex-gwt-" in v:
-        gwt_list.append(v.replace(".tex", ""))
-ex_list = gwf_list + gwt_list
+    if "ex-" in v:
+        examples.append(v.replace(".tex", ""))
 
 # get list of example problems
 ex_dirs = []
@@ -51,15 +47,18 @@ for name in sorted(os.listdir(ex_pth)):
 # create examples rst
 print(f"creating...'{pth}'")
 with open(os.path.join("..", ".doc", "examples.rst"), "w") as f:
-    line = "====================\n"
-    line += "Example descriptions\n"
-    line += "====================\n\n\n"
-    line += ".. toctree::\n"
-    line += "   :numbered:\n"
-    line += "   :maxdepth: 1\n\n"
-    for ex in ex_list:
-        line += f"   _examples/{ex}.rst\n"
-    f.write(line)
+    lines = "Example descriptions\n"
+    lines += (len(lines) - 1) * "-" + "\n\n"
+    lines += "An overview of each MODFLOW 6 example problem.\n\n"
+    f.write(lines)
+
+    lines = ".. toctree::\n"
+    lines += "    :numbered:\n"
+    lines += "    :maxdepth: 1\n\n"
+    for base_name in examples:
+        lines += f"   _examples/{base_name}.rst\n"
+    lines += "\n\n"
+    f.write(lines)
 
 # create rtd examples directory
 dst = os.path.join("..", ".doc", "_examples")
@@ -77,7 +76,7 @@ with open(pth) as f:
 latex_tag = "\\input{./body.tex}"
 frontmatter_tag = "\\input{./frontmatter.tex}"
 doc_pth = os.path.join("..", "doc")
-for ex in ex_list:
+for ex in examples:
     print(f"creating restructured text file for {ex} example")
     src = os.path.join("..", "doc", "ex.tex")
     with open(src, "w") as f:

--- a/scripts/ex-gwe-radial.py
+++ b/scripts/ex-gwe-radial.py
@@ -9,15 +9,12 @@
 # +
 import os
 import pathlib as pl
-import sys
 from pprint import pformat
 
 import flopy
 import numpy as np
 import pandas as pd
-import matplotlib as mpl
 import matplotlib.pyplot as plt
-import matplotlib.pylab as pylab
 import matplotlib.patches as mpatches
 import math
 import pooch
@@ -135,6 +132,7 @@ tsmult = [1.0]
 tdis_ds = list(zip(perlen, nstp, tsmult))
 
 # Functions for building the DISV mesh
+
 
 def generate_starting_vert_lst(basedata):
     verts = []
@@ -822,15 +820,19 @@ def write_mf6_models(sim_mf6gwe, sim_mf6gwf=None, silent=True):
     sim_mf6gwe.write_simulation(silent=silent)
 
 
+@timed
 def run_model(sim, silent=True):
     success = True
     success, buff = sim.run_simulation(silent=silent, report=True)
     assert success, pformat(buff)
+
+
 # -
 
 # ### Plotting results
 #
 # Define functions to plot model results.
+
 
 # +
 def plot_grid(sim):
@@ -863,7 +865,7 @@ def plot_grid(sim):
 
 
 def plot_grid_inset(sim):
-    with styles.USGSPlot() as fs:
+    with styles.USGSPlot():
         simname = sim.name
         gwf = sim.get_model("gwf-" + simname.split("-")[2])
 
@@ -903,7 +905,7 @@ def plot_head(sim):
     gwf = sim.get_model("gwf-" + simname.split("-")[2])
     head = gwf.output.head().get_data()[:, 0, :]
 
-    with styles.USGSPlot() as fs:
+    with styles.USGSPlot():
         fig = plt.figure(figsize=figure_size)
         fig.tight_layout()
 
@@ -937,7 +939,7 @@ def plot_temperature(sim, idx, scen_txt, vel_txt):
     )
     gwe = sim.get_model("gwe-" + simname.split("-")[2])
 
-    with styles.USGSPlot() as fs:
+    with styles.USGSPlot():
         fig = plt.figure(figsize=figure_size)
         fig.tight_layout()
 
@@ -1030,6 +1032,7 @@ def plot_results(idx, sim_mf6gwf, sim_mf6gwe, silent=True):
 #
 # Define a function to run the example scenarios and plot results.
 
+
 # +
 def scenario(idx, silent=False):
     # Two different sets of values used among the 4 scenarios, but fastest to calculate them all at the same time
@@ -1072,11 +1075,14 @@ def scenario(idx, silent=False):
     # Run the transport model as a transient simulation, requires reading the
     # steady-state flow output saved in binary files.
     sim_mf6gwe = build_mf6_heat_model(key, scen_ext, **parameter_dict, silent=silent)
-    write_mf6_models(sim_mf6gwe, sim_mf6gwf=sim_mf6gwf, silent=silent)
-    if sim_mf6gwf is not None:
-        run_model(sim_mf6gwf, silent)
-    run_model(sim_mf6gwe, silent)
-    plot_results(idx, sim_mf6gwf, sim_mf6gwe)
+    if write:
+        write_mf6_models(sim_mf6gwe, sim_mf6gwf=sim_mf6gwf, silent=silent)
+    if run:
+        if sim_mf6gwf is not None:
+            run_model(sim_mf6gwf, silent)
+        run_model(sim_mf6gwe, silent)
+    if plot:
+        plot_results(idx, sim_mf6gwf, sim_mf6gwe)
 
 
 # -

--- a/scripts/ex-gwe-radial.py
+++ b/scripts/ex-gwe-radial.py
@@ -10,6 +10,7 @@
 import os
 import pathlib as pl
 import sys
+from pprint import pformat
 
 import flopy
 import numpy as np
@@ -824,9 +825,7 @@ def write_mf6_models(sim_mf6gwe, sim_mf6gwf=None, silent=True):
 def run_model(sim, silent=True):
     success = True
     success, buff = sim.run_simulation(silent=silent, report=True)
-    if not success:
-        print(buff)
-    return success
+    assert success, pformat(buff)
 # -
 
 # ### Plotting results
@@ -1073,19 +1072,11 @@ def scenario(idx, silent=False):
     # Run the transport model as a transient simulation, requires reading the
     # steady-state flow output saved in binary files.
     sim_mf6gwe = build_mf6_heat_model(key, scen_ext, **parameter_dict, silent=silent)
-
     write_mf6_models(sim_mf6gwe, sim_mf6gwf=sim_mf6gwf, silent=silent)
-
     if sim_mf6gwf is not None:
-        success = run_model(sim_mf6gwf, silent)
-    else:
-        success = True
-
-    if success:  # Ensure that flow model ran OK
-        success = run_model(sim_mf6gwe, silent)
-
-    if success:
-        plot_results(idx, sim_mf6gwf, sim_mf6gwe)
+        run_model(sim_mf6gwf, silent)
+    run_model(sim_mf6gwe, silent)
+    plot_results(idx, sim_mf6gwf, sim_mf6gwe)
 
 
 # -

--- a/scripts/ex-gwf-bump.py
+++ b/scripts/ex-gwf-bump.py
@@ -4,8 +4,6 @@
 
 # ### Initial setup
 #
-# ### Initial setup
-#
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +


### PR DESCRIPTION
* new GWE example was excluded from docs site &mdash; update description/notebook order on RTD as specified in `body.tex` rather than grouped by model type, so no more need to update `conf.py` or `ci_create_examples_rst.py` when a new model type is added
* download data files  from develop for now in `ex-gwe-radial.py`, until merged to master with next release
* update leading comment format in `ex-gwe-radial.py` for notebook rendering
* update some `pandas` syntax to avoid warnings
* add `**.ipynb` to `.gitignore`