### PR TITLE
fix: specify encoding when opening files in rst generator script

### DIFF
--- a/etc/ci_create_examples_rst.py
+++ b/etc/ci_create_examples_rst.py
@@ -116,7 +116,7 @@ for ex in examples:
 
     # read restructured text file as a string
     print(f"reading...'{dst}'")
-    with open(dst) as file:
+    with open(dst, 'r', encoding="utf-8") as file:
         lines = file.read()
 
     # find equation labels in lines
@@ -142,12 +142,12 @@ for ex in examples:
 
     # read restructured text file for example
     print(f"reading...'{dst}'")
-    with open(dst) as f:
+    with open(dst, 'r', encoding="utf-8") as f:
         lines = f.readlines()
 
     # editing restructured text file for example
     print(f"editing...'{dst}'")
-    with open(dst, "w") as f:
+    with open(dst, "w", encoding="utf-8") as f:
         write_line = True
         in_reference = False
         eq_no = 0


### PR DESCRIPTION
* necessary on Windows
* moved from #161