### PR TITLE
fix(ex-prt-mp7-p01): remove 3d plot from latex description

### DIFF
--- a/doc/sections/ex-prt-mp7-p01.tex
+++ b/doc/sections/ex-prt-mp7-p01.tex
@@ -24,16 +24,11 @@ In this example a MODFLOW 6 particle tracking (PRT) model runs in the same simul
 
 In subproblem 1A, a line of 21 particles is placed at the water table in layer 1 for column 3, rows 1 through 21. In subproblem 1B, a denser release configuration is used which places a 3 x 3 array of particles on the top face of every cell in layer 1. Both simulations track particles forward to their discharge points.
 
-Subproblem 1A path points on a 1000-day time interval are visualized in 2D~(fig~\ref{fig:ex-prt-mp7-p01-paths-layer}) and 3D~(fig~\ref{fig:ex-prt-mp7-p01-paths-3d}).
+Subproblem 1A path points on a 1000-day time interval are shown in fig~\ref{fig:ex-prt-mp7-p01-paths-layer}.
 
 \begin{StandardFigure}{
     Particle pathlines and 1000-day points for subproblem 1A. Points are colored by layer.
     }{fig:ex-prt-mp7-p01-paths-layer}{../figures/mp7-p01-paths-layer.png}
-\end{StandardFigure}
-
-\begin{StandardFigure}{
-    Three-dimensional perspective of pathlines and 1000-day points for subproblem 1A. Points are colored by layer.
-    }{fig:ex-prt-mp7-p01-paths-3d}{../figures/mp7-p01-paths-3d.pdf}
 \end{StandardFigure}
 
 To illustrate discharge points, pathlines are colored by discharge area (well or river) in fig~\ref{fig:ex-prt-mp7-p01-paths}. To show capture areas, starting locations of all particles are color-coded according to the zone value of the cells in which they terminate in fig~\ref{fig:ex-prt-mp7-p01-rel-destination}. Travel time analysis is also a common use case for particle tracking. Particle release points are colored by total travel time to capture in fig~\ref{fig:ex-prt-mp7-p01-rel-travel-time}.


### PR DESCRIPTION
* render fails on [RTD description page](https://modflow6-examples.readthedocs.io/en/latest/_examples/ex-prt-mp7-p01.html#fig-ex-prt-mp7-p01-paths-3d)