### PR TITLE
chore(formatting): introduce ruff, apply minimal reformatting

### DIFF
--- a/.doc/conf.py
+++ b/.doc/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import re
+
 from modflow_devtools.misc import get_env
 
 # -- set boolean indicating if running on readthedocs server -----------------
@@ -149,13 +150,9 @@ html_theme = "sphinx_rtd_theme"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
-html_css_files = [
-    'custom.css',
-    'theme_overrides.css'
-]
+html_css_files = ["custom.css", "theme_overrides.css"]
 
 html_context = {
-    "github_repo": "https://github.com/MODFLOW-USGS/modflow6-examples",  # assuming an exact match
     "display_github": False,
     "github_user": "modflow6-examples",
     "github_repo": "modflow6-examples",
@@ -241,4 +238,3 @@ nbsphinx_prolog = (
 
 # Import Matplotlib to avoid this message in notebooks:
 # "Matplotlib is building the font cache; this may take a moment."
-import matplotlib.pyplot

--- a/.github/workflows/ex-workflow.yml
+++ b/.github/workflows/ex-workflow.yml
@@ -16,9 +16,36 @@ on:
       - 'DEVELOPER.md'
 
 jobs:
+  lint:
+    name: lint python files
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout MODFLOW6 examples repo
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+
+      - name: Install Python packages
+        working-directory: etc
+        run: |
+          python --version
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r requirements.pip.txt
+
+      - name: Lint
+        run: ruff check .
+
+      - name: Check format
+        run: ruff format . --check
+
   zip_files:
     name: zip input files
     runs-on: ubuntu-latest
+    needs: lint
 
     steps:
       - name: Checkout MODFLOW6 examples repo
@@ -69,6 +96,7 @@ jobs:
   build:
     name: current-build
     runs-on: ubuntu-latest
+    needs: lint
     strategy:
       fail-fast: false
       matrix:

--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -19,7 +19,9 @@ def write(request) -> bool:
 
 @pytest.fixture(scope="session")
 def run(request) -> bool:
-    return not (request.config.getoption("--init") or request.config.getoption("--no-run"))
+    return not (
+        request.config.getoption("--init") or request.config.getoption("--no-run")
+    )
 
 
 @pytest.fixture(scope="session")
@@ -50,7 +52,10 @@ def pytest_addoption(parser):
         help="Just build and write model input files",
     )
     parser.addoption(
-        "--no-write", action="store_true", default=False, help="Disable model build/write"
+        "--no-write",
+        action="store_true",
+        default=False,
+        help="Disable model build/write",
     )
     parser.addoption(
         "--no-run", action="store_true", default=False, help="Disable model runs"

--- a/autotest/test_notebooks.py
+++ b/autotest/test_notebooks.py
@@ -2,10 +2,9 @@
 
 from os import environ
 
+from conftest import NOTEBOOKS_PATH
 from modflow_devtools.markers import requires_exe
 from modflow_devtools.misc import run_cmd, set_env
-
-from conftest import NOTEBOOKS_PATH
 
 
 @requires_exe("jupytext")

--- a/etc/ci_create_examples_rst.py
+++ b/etc/ci_create_examples_rst.py
@@ -116,7 +116,7 @@ for ex in examples:
 
     # read restructured text file as a string
     print(f"reading...'{dst}'")
-    with open(dst, 'r', encoding="utf-8") as file:
+    with open(dst, "r", encoding="utf-8") as file:
         lines = file.read()
 
     # find equation labels in lines
@@ -142,7 +142,7 @@ for ex in examples:
 
     # read restructured text file for example
     print(f"reading...'{dst}'")
-    with open(dst, 'r', encoding="utf-8") as f:
+    with open(dst, "r", encoding="utf-8") as f:
         lines = f.readlines()
 
     # editing restructured text file for example

--- a/etc/requirements.pip.txt
+++ b/etc/requirements.pip.txt
@@ -22,3 +22,4 @@ jupytext
 pooch
 GitPython
 pyvista
+ruff

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,19 @@
+target-version = "py39"
+include = [
+    "autotest/**/*.py",
+    "scripts/**/*.py",
+    "etc/**/*.py",
+    ".doc/**/*.py",
+]
+extend-include = [
+    ".doc/**/*.ipynb"
+]
+
+[lint]
+select = ["F", "E", "I001"]
+ignore = [
+    "E501", # line too long TODO FIXME
+    "E722", # do not use bare `except`
+    "E741", # ambiguous variable name
+    "F841", # local variable assigned but never used
+]

--- a/scripts/ex-gwe-radial.py
+++ b/scripts/ex-gwe-radial.py
@@ -182,6 +182,7 @@ def create_outer_ring_of_ctrl_vols(outer_v, verts, iverts, xc, yc, ivt, idx):
     # Starts at 9 o'clock and proceeds counter-clockwise
     # As such, 'pt3' will be used by the subsequent iverts
     # However, 'pt4' will be re-used by each subseqeuent ivert
+    pt3_id = pt3_rad = pt3_ang = None
     for ii in np.arange(len(outer_v) - 1):
         # Create all the points involved
         pt1 = outer_v.iloc[ii]
@@ -198,6 +199,9 @@ def create_outer_ring_of_ctrl_vols(outer_v, verts, iverts, xc, yc, ivt, idx):
             finish_ang = pt4_ang
 
         else:
+            assert pt3_id is not None
+            assert pt3_rad is not None
+            assert pt3_ang is not None
             pt4_id = pt3_id
             pt4_rad = pt3_rad
             pt4_ang = pt3_ang

--- a/scripts/ex-gwf-curvilinear-90.py
+++ b/scripts/ex-gwf-curvilinear-90.py
@@ -1528,7 +1528,10 @@ class DisvGridMerger:
                     self.force_snap_cellid.add(ic_new)
 
         if len(self.force_snap_cellid) > 0:
-            dist = lambda v1, v2: sqrt((v2[1] - v1[1]) ** 2 + (v2[2] - v1[2]) ** 2)
+
+            def dist(v1, v2):
+                return sqrt((v2[1] - v1[1]) ** 2 + (v2[2] - v1[2]) ** 2)
+
             mg = self.merged
             vert_xy = np.array([(x, y) for _, x, y in mg.vertices])
             for ic in self.force_snap_cellid:
@@ -1542,7 +1545,7 @@ class DisvGridMerger:
                     mg.cell2d[ic] = tmp[:4] + vert
                 # check if vertices are within cell.
                 cell = [mg.vertices[iv][1:] for iv in vert]
-                path = mpltPath.Path(cell)
+                path = mpltPath.Path(cell)  # noqa: F821
                 contain = np.where(path.contains_points(vert_xy))[0]
                 for iv in contain:
                     # find closest polyline

--- a/scripts/ex-gwf-curvilinear.py
+++ b/scripts/ex-gwf-curvilinear.py
@@ -25,6 +25,7 @@ import copy
 import os
 import pathlib as pl
 from itertools import cycle
+from math import sqrt
 from typing import Dict, List
 
 import flopy
@@ -1527,7 +1528,10 @@ class DisvGridMerger:
                     self.force_snap_cellid.add(ic_new)
 
         if len(self.force_snap_cellid) > 0:
-            dist = lambda v1, v2: sqrt((v2[1] - v1[1]) ** 2 + (v2[2] - v1[2]) ** 2)
+
+            def dist(v1, v2):
+                return sqrt((v2[1] - v1[1]) ** 2 + (v2[2] - v1[2]) ** 2)
+
             mg = self.merged
             vert_xy = np.array([(x, y) for _, x, y in mg.vertices])
             for ic in self.force_snap_cellid:
@@ -1541,7 +1545,7 @@ class DisvGridMerger:
                     mg.cell2d[ic] = tmp[:4] + vert
                 # check if vertices are within cell.
                 cell = [mg.vertices[iv][1:] for iv in vert]
-                path = mpltPath.Path(cell)
+                path = mpltPath.Path(cell)  # noqa: F821
                 contain = np.where(path.contains_points(vert_xy))[0]
                 for iv in contain:
                     # find closest polyline

--- a/scripts/ex-gwf-lgrv.py
+++ b/scripts/ex-gwf-lgrv.py
@@ -51,9 +51,9 @@ time_units = "seconds"
 
 # Scenario-specific parameters
 parameters = {
-    f"ex-gwf-lgrv-gr": {"configuration": "Refined"},
-    f"ex-gwf-lgrv-gc": {"configuration": "Coarse"},
-    f"ex-gwf-lgrv-lgr": {"configuration": "LGR"},
+    "ex-gwf-lgrv-gr": {"configuration": "Refined"},
+    "ex-gwf-lgrv-gc": {"configuration": "Coarse"},
+    "ex-gwf-lgrv-lgr": {"configuration": "LGR"},
 }
 
 # Model parameters

--- a/scripts/ex-gwf-radial.py
+++ b/scripts/ex-gwf-radial.py
@@ -407,8 +407,8 @@ class RadialUnconfinedDrawdown:
             raise RuntimeError(
                 "RadialUnconfinedDrawdown: "
                 + "well_screen_elevation_top <= well_screen_elevation_bottom\n"
-                + f"That is: {well_screen_elevation_top} <= "
-                + f"{well_screen_elevation_bottom}"
+                + f"That is: {self.well_top} <= "
+                + f"{self.well_bot}"
             )
 
     def drawdown(
@@ -722,7 +722,7 @@ class RadialUnconfinedDrawdown:
             root = j0_roots[-1]
             bad_times = "\n".join([str(times[it]) for it in bessel_root_limit_reached])
             warnings.warn(
-                f"\n\nRadialUnconfinedDrawdown.drawdown_times failed to "
+                "\n\nRadialUnconfinedDrawdown.drawdown_times failed to "
                 + f"meet convergence sumrtol = {sumrtol}"
                 + "\nwithin the precalculated Bessel root solutions "
                 + "(convergence is evaluated at every second Bessel root).\n\n"

--- a/scripts/ex-gwt-hecht-mendez.py
+++ b/scripts/ex-gwt-hecht-mendez.py
@@ -383,7 +383,7 @@ def build_mf2k5_flow_model(
 
     # Instantiate the MODFLOW model
     mf = flopy.modflow.Modflow(
-        modelname=modelname_mf, model_ws=mt3d_ws, exe_name=exe_name_mf
+        modelname=modelname_mf, model_ws=mt3d_ws, exe_name="mf2005"
     )
 
     # Instantiate discretization package
@@ -575,7 +575,7 @@ def build_mt3d_transport_model(
     mt = flopy.mt3d.Mt3dms(
         modelname=modelname_mt,
         model_ws=mt3d_ws,
-        exe_name=exe_name_mt,
+        exe_name="mt3dms",
         modflowmodel=mf,
     )
 

--- a/scripts/ex-gwt-keating.py
+++ b/scripts/ex-gwt-keating.py
@@ -246,7 +246,7 @@ def build_mf6gwt():
         gwt, xt3d_off=True, alh=alpha_l, ath1=alpha_th, atv=alpha_tv
     )
     pd = [
-        ("GWFHEAD", f"../mf6gwf/flow.hds", None),
+        ("GWFHEAD", "../mf6gwf/flow.hds", None),
         ("GWFBUDGET", "../mf6gwf/flow.bud", None),
     ]
     flopy.mf6.ModflowGwtfmi(gwt, flow_imbalance_correction=True, packagedata=pd)

--- a/scripts/ex-gwt-moc3d-p01.py
+++ b/scripts/ex-gwt-moc3d-p01.py
@@ -171,6 +171,7 @@ class Wexler1d:
     def analytical(self, x, t, v, l, d, tol=1.0e-20, nval=5000):
         sigma = 0.0
         betalist = self.root3(d, v, l, nval=nval)
+        concold = None
         for i, bi in enumerate(betalist):
             denom = bi**2 + (v * l / 2.0 / d) ** 2 + v * l / d
             x1 = (
@@ -186,6 +187,7 @@ class Wexler1d:
             term1 = 2.0 * v * l / d * np.exp(v * x / 2.0 / d - v**2 * t / 4.0 / d)
             conc = 1.0 - term1 * sigma
             if i > 0:
+                assert concold is not None
                 diff = abs(conc - concold)
                 if np.all(diff < tol):
                     break
@@ -231,6 +233,7 @@ class Wexler1d:
         term1 = term1 / denom
         term2 = 2.0 * v * l / d * np.exp(v * x / 2.0 / d - v**2 * t / 4.0 / d - e * t)
         betalist = self.root3(d, v, l, nval=nval)
+        concold = None
         for i, bi in enumerate(betalist):
             denom = bi**2 + (v * l / 2.0 / d) ** 2 + v * l / d
             x1 = (
@@ -246,6 +249,7 @@ class Wexler1d:
 
             conc = term1 - term2 * sigma
             if i > 0:
+                assert concold is not None
                 diff = abs(conc - concold)
                 if np.all(diff < tol):
                     break
@@ -376,7 +380,7 @@ def build_mf6gwt(sim_folder, longitudinal_dispersivity, retardation_factor, deca
         ath1=longitudinal_dispersivity,
     )
     pd = [
-        ("GWFHEAD", f"../mf6gwf/flow.hds", None),
+        ("GWFHEAD", "../mf6gwf/flow.hds", None),
         ("GWFBUDGET", "../mf6gwf/flow.bud", None),
     ]
     flopy.mf6.ModflowGwtfmi(gwt, packagedata=pd)

--- a/scripts/ex-gwt-moc3d-p02.py
+++ b/scripts/ex-gwt-moc3d-p02.py
@@ -210,7 +210,7 @@ def build_mf6gwt(sim_folder):
         ath2=alpha_tv,
     )
     pd = [
-        ("GWFHEAD", f"../mf6gwf/flow.hds", None),
+        ("GWFHEAD", "../mf6gwf/flow.hds", None),
         ("GWFBUDGET", "../mf6gwf/flow.bud", None),
     ]
     flopy.mf6.ModflowGwtfmi(gwt, packagedata=pd)

--- a/scripts/ex-gwt-moc3d-p02tg.py
+++ b/scripts/ex-gwt-moc3d-p02tg.py
@@ -299,7 +299,7 @@ def build_mf6gwt(sim_folder):
         ath2=alpha_tv,
     )
     pd = [
-        ("GWFHEAD", f"../mf6gwf/flow.hds", None),
+        ("GWFHEAD", "../mf6gwf/flow.hds", None),
         ("GWFBUDGET", "../mf6gwf/flow.bud", None),
     ]
     flopy.mf6.ModflowGwtfmi(gwt, packagedata=pd)

--- a/scripts/ex-gwt-mt3dms-p02.py
+++ b/scripts/ex-gwt-mt3dms-p02.py
@@ -249,7 +249,7 @@ def build_mf6gwt(
                 gwt, volfrac=volfracim, porosity=porosity_im, zetaim=beta
             )
     pd = [
-        ("GWFHEAD", f"../mf6gwf/flow.hds", None),
+        ("GWFHEAD", "../mf6gwf/flow.hds", None),
         ("GWFBUDGET", "../mf6gwf/flow.bud", None),
     ]
     flopy.mf6.ModflowGwtfmi(gwt, packagedata=pd)

--- a/scripts/ex-gwt-mt3dsupp631.py
+++ b/scripts/ex-gwt-mt3dsupp631.py
@@ -162,7 +162,7 @@ def build_mf6gwt(sim_folder):
         ath1=longitudinal_dispersivity,
     )
     pd = [
-        ("GWFHEAD", f"../mf6gwf/flow.hds", None),
+        ("GWFHEAD", "../mf6gwf/flow.hds", None),
         ("GWFBUDGET", "../mf6gwf/flow.bud", None),
     ]
     flopy.mf6.ModflowGwtfmi(gwt, packagedata=pd)

--- a/scripts/ex-gwt-mt3dsupp632.py
+++ b/scripts/ex-gwt-mt3dsupp632.py
@@ -228,7 +228,7 @@ def build_mf6gwt(sim_folder, distribution_coefficient, decay, decay_sorbed):
         ath1=longitudinal_dispersivity,
     )
     pd = [
-        ("GWFHEAD", f"../mf6gwf/flow.hds", None),
+        ("GWFHEAD", "../mf6gwf/flow.hds", None),
         ("GWFBUDGET", "../mf6gwf/flow.bud", None),
     ]
     flopy.mf6.ModflowGwtfmi(gwt, packagedata=pd)

--- a/scripts/ex-gwt-mt3dsupp82.py
+++ b/scripts/ex-gwt-mt3dsupp82.py
@@ -206,7 +206,7 @@ def build_mf6gwt(sim_folder):
     flopy.mf6.ModflowGwtadv(gwt, scheme="upstream")
     flopy.mf6.ModflowGwtdsp(gwt, alh=alpha_l, ath1=alpha_th, atv=alpha_tv)
     pd = [
-        ("GWFHEAD", f"../mf6gwf/flow.hds", None),
+        ("GWFHEAD", "../mf6gwf/flow.hds", None),
         ("GWFBUDGET", "../mf6gwf/flow.bud", None),
         ("GWFMOVER", "../mf6gwf/flow.mvr.bud", None),
         ("MAW-1", "../mf6gwf/flow.maw.bud", None),

--- a/scripts/ex-gwt-prudic2004t2.py
+++ b/scripts/ex-gwt-prudic2004t2.py
@@ -133,6 +133,7 @@ def get_stream_data():
     connectiondata = [[ireach] for ireach in range(streamdata.shape[0])]
     isegold = -1
     distance_along_segment = []
+    distance = 0
     for ireach, row in enumerate(streamdata):
         iseg = row["seg"] - 1
         if iseg == isegold:

--- a/scripts/ex-gwt-synthetic-valley.py
+++ b/scripts/ex-gwt-synthetic-valley.py
@@ -639,8 +639,8 @@ def build_mf6gwt(sim_folder):
         ],
     )
     pd = [
-        ("GWFHEAD", f"../mf6gwf/flow.hds", None),
-        ("GWFBUDGET", f"../mf6gwf/flow.cbc", None),
+        ("GWFHEAD", "../mf6gwf/flow.hds", None),
+        ("GWFBUDGET", "../mf6gwf/flow.cbc", None),
     ]
     fmi = flopy.mf6.ModflowGwtfmi(gwt, packagedata=pd)
     sourcerecarray = [

--- a/scripts/ex-gwt-uzt-2d.py
+++ b/scripts/ex-gwt-uzt-2d.py
@@ -129,7 +129,6 @@ parameters = {
 parameter_units = {
     "longitudinal_dispersivity": "$m$",
     "ratio_horizontal_to_longitudinal_dispersivity": "unitless",
-    "ratio_horizontal_to_longitudinal_dispersivity": "unitless",
 }
 
 # Model units


### PR DESCRIPTION
* add ruff to `etc/requirements.pip.txt`
* add `ruff.toml` config file, ignoring a few rules
  * E501, line too long &mdash; eventually we can fix this but fixing here would make the changeset much larger
  * E722, do not use bare `except` &mdash; probably also good to fix eventually
  * E741, ambiguous variable name &mdash; typically `l`, I don't think we need to enforce this
  * F841, local variable assigned but never used &mdash; we frequently assign variables which aren't used when creating models and packages, I don't think we need to enforce
*  ignore F821 (undefined var) inline in a few places in curvilinear examples, @ScottBoyce maybe you can have a look sometime? it doesn't fail the script though so not pressing