### PR TITLE
fix(ex-prt-mp7-p03): only run model if necessary

### DIFF
--- a/scripts/ex-prt-mp7-p03.py
+++ b/scripts/ex-prt-mp7-p03.py
@@ -943,8 +943,10 @@ def plot_all(gwfsim):
 
 def scenario(silent=False):
     gwfsim, prtsim, mp7sim = build_models()
-    run_models(gwfsim, prtsim, mp7sim, silent=silent)
-    plot_all(gwfsim)
+    if run:
+        run_models(gwfsim, prtsim, mp7sim, silent=silent)
+    if plot:
+        plot_all(gwfsim)
 
 
 # Run the MODPATH 7 example problem 3 scenario.


### PR DESCRIPTION
Build models for this example was also running the model.  Need to only run if run_model is True.