### PR TITLE
fix(PRT): multiple fixes/improvements after review

### DIFF
--- a/.doc/notebook_examples.rst
+++ b/.doc/notebook_examples.rst
@@ -5,7 +5,7 @@ The Jupyter Notebooks used to create the input files and figures for
 each of the MODFLOW 6 `examples <examples.html>`_.
 
 .. nbgallery::
-    :name: Examples gallery
+   :name: Examples gallery
 
    _notebooks/ex-gwf-twri
    _notebooks/ex-gwf-bcf2ss
@@ -73,4 +73,5 @@ each of the MODFLOW 6 `examples <examples.html>`_.
    _notebooks/ex-prt-mp7-p03
    _notebooks/ex-prt-mp7-p04
    _notebooks/ex-gwe-prt
+
 

--- a/doc/sections/ex-prt-mp7-p02.tex
+++ b/doc/sections/ex-prt-mp7-p02.tex
@@ -4,7 +4,7 @@ This example demonstrates a MODFLOW 6 particle tracking (PRT) model by reproduci
 
 \subsection{Example description}
 
-PRT/MP7 Example 2 modifies the flow system from PRT/MP7 Example 1 with a quad-refined unstructured grid. The region near the well is refined three levels. This example also employs a backwards tracking analysis, in which groundwater flows have been reversed before providing them to PRT to track particle trajectories in reverse. The system includes the same well and river boundary conditions as in example 1. Model parameters for this example are summarized in table~\ref{tab:ex-prt-mp7-p02-01}.
+PRT/MP7 Example 2 modifies the flow system from PRT/MP7 Example 1 with a quad-refined unstructured grid. The region near the well is refined three levels. This example also employs a backwards tracking analysis, in which groundwater flows are reversed with FloPy before providing them to PRT to track particle trajectories in reverse. The system includes the same well and river boundary conditions as in example 1. Model parameters for this example are summarized in table~\ref{tab:ex-prt-mp7-p02-01}.
 
 \input{../tables/ex-prt-mp7-p02-01.tex}
 

--- a/doc/sections/ex-prt-mp7-p03.tex
+++ b/doc/sections/ex-prt-mp7-p03.tex
@@ -16,9 +16,7 @@ Particles are released in batches from a 2x2-cell square (4 total cells) in the 
 
 In this example a MODFLOW 6 particle tracking (PRT) model runs in a separate simulation from the groundwater flow (GWF) model~(fig~\ref{fig:ex-prt-mp7-p01-head}). Intercell flows are read by the PRT model from the binary budget file written by the GWF model.
 
-Path points on a 2000-day interval are visualized in plan view in fig~\ref{fig:ex-prt-mp7-p03-paths-layer} and in 3D in fig~\ref{fig:ex-prt-mp7-p03-paths-3d}.
-
-Release and termination points are colored by destination in fig~\ref{fig:ex-prt-mp7-p03-rel-term}.
+Path points on a 2000-day interval are visualized in plan view in fig~\ref{fig:ex-prt-mp7-p03-paths-layer} and in 3D in fig~\ref{fig:ex-prt-mp7-p03-paths-3d}. Release and termination points are colored by destination in fig~\ref{fig:ex-prt-mp7-p03-rel-term}.
 
 \begin{StandardFigure}{
     Head simulated by the MODFLOW 6 groundwater flow (GWF) model.

--- a/doc/sections/ex-prt-mp7-p03.tex
+++ b/doc/sections/ex-prt-mp7-p03.tex
@@ -18,7 +18,7 @@ In this example a MODFLOW 6 particle tracking (PRT) model runs in a separate sim
 
 Path points on a 2000-day interval are visualized in plan view in fig~\ref{fig:ex-prt-mp7-p03-paths-layer} and in 3D in fig~\ref{fig:ex-prt-mp7-p03-paths-3d}.
 
-Release and termination points are colored by capture destination in fig~\ref{fig:ex-prt-mp7-p03-rel-term}.
+Release and termination points are colored by destination in fig~\ref{fig:ex-prt-mp7-p03-rel-term}.
 
 \begin{StandardFigure}{
     Head simulated by the MODFLOW 6 groundwater flow (GWF) model.
@@ -26,16 +26,16 @@ Release and termination points are colored by capture destination in fig~\ref{fi
 \end{StandardFigure}
 
 \begin{StandardFigure}{
-    2000-day particle path points. Points are colored by layer.
+    2000-day particle path points. Points are colored by travel time.
     }{fig:ex-prt-mp7-p03-paths-layer}{../figures/mp7-p03-paths-layer.png}
 \end{StandardFigure}
 
 \begin{StandardFigure}{
-    Three-dimensional perspective of pathlines and 2000-day points. Points are colored by layer.
+    Three-dimensional perspective of pathlines and 2000-day points. Points are colored by destination.
     }{fig:ex-prt-mp7-p03-paths-3d}{../figures/mp7-p03-paths-3d.pdf}
 \end{StandardFigure}
 
 \begin{StandardFigure}{
-    Particle release and termination points, colored by capture destination.
+    Particle release and termination points, colored by destination.
     }{fig:ex-prt-mp7-p03-rel-term}{../figures/mp7-p03-rel-term.png}
 \end{StandardFigure}

--- a/doc/sections/ex-prt-mp7-p04.tex
+++ b/doc/sections/ex-prt-mp7-p04.tex
@@ -4,7 +4,7 @@ This example demonstrates a MODFLOW 6 particle tracking (PRT) model by reproduci
 
 \subsection{Example description}
 
-PRT/MP7 Example 4 involves steady-state flow on an unstructured quad-refined grid. The grid has a large, irregular inactive region around its boundary. The left side of the active region is lined with injection wells to represent boundary flows. There is a quad-refined region in the upper left quadrant of the grid, in which two pumping wells are located. Particles are released from two areas: around the horizontal faces of both pumping well cells, and from the left faces of a constant head boundary along the active region on the right border of the grid. Particles are then tracked backwards to terminating locations along the left border of the grid. Model parameters for this example are summarized in table~\ref{tab:ex-prt-mp7-p04-01}.
+PRT/MP7 Example 4 involves steady-state flow on an unstructured quad-refined grid. The grid has a large, irregular inactive region around its boundary. The left side of the active region is lined with injection wells to represent boundary flows. There is a quad-refined region in the upper left quadrant of the grid, in which two pumping wells are located. Particles are released from two areas: around the horizontal faces of both pumping well cells, and from the left faces of a constant-head boundary along the active region on the right border of the grid. Particles are then tracked backwards to terminating locations along the left border of the grid. Like PRT/MP7 Example 2, groundwater flows are reversed with FloPy before providing them to PRT for backwards tracking. Model parameters for this example are summarized in table~\ref{tab:ex-prt-mp7-p04-01}.
 
 \input{../tables/ex-prt-mp7-p04-01.tex}
 

--- a/etc/ci_create_examples_rst.py
+++ b/etc/ci_create_examples_rst.py
@@ -191,7 +191,9 @@ for ex in examples:
 
             tag = ".. figure:: ../figures/"
             if tag in line:
-                line = line.replace(tag, ".. figure:: ../_images/")
+                line = line.replace(tag, ".. figure:: ../_images/").replace(
+                    ".pdf", ".svg"
+                )
 
             tag = ".. figure:: ../images/"
             if tag in line:
@@ -310,7 +312,11 @@ for src_dir in src_dirs:
         file_name
         for file_name in os.listdir(src_dir)
         if os.path.isfile(os.path.join(src_dir, file_name))
-        and (file_name.endswith(".png") or file_name.endswith(".gif"))
+        and (
+            file_name.endswith(".png")
+            or file_name.endswith(".gif")
+            or file_name.endswith(".svg")
+        )
     ]
     for file_name in file_names:
         src = os.path.join(src_dir, file_name)

--- a/scripts/ex-prt-mp7-p01.py
+++ b/scripts/ex-prt-mp7-p01.py
@@ -559,7 +559,7 @@ def get_pathlines(mf6_path, mp7_path):
 
 
 # +
-# Pathline and starting point colors by capture destination
+# Pathline and starting point colors by destination
 colordest = {"well": "red", "river": "blue"}
 
 
@@ -779,7 +779,8 @@ def plot_pathpoints_3d(gwf, pathlines, title):
     )
 
     if plot_save:
-        p.save_graphic(figs_path / f"{sim_name}-paths-3d.pdf", raster=False)
+        p.save_graphic(figs_path / f"{sim_name}-paths-3d.pdf")
+        p.save_graphic(figs_path / f"{sim_name}-paths-3d.svg")
     if plot_show:
         p.camera.zoom(1.7)
         p.show()

--- a/scripts/ex-prt-mp7-p02.py
+++ b/scripts/ex-prt-mp7-p02.py
@@ -1125,7 +1125,8 @@ def plot_3d(gwf, pathlines, endpoints=None, title=None):
     )
 
     if plot_save:
-        p.save_graphic(figs_path / f"{sim_name}-paths-3d.pdf", raster=False)
+        p.save_graphic(figs_path / f"{sim_name}-paths-3d.pdf")
+        p.save_graphic(figs_path / f"{sim_name}-paths-3d.svg")
     if plot_show:
         p.camera.zoom(3.0)
         p.show()

--- a/scripts/ex-prt-mp7-p02.py
+++ b/scripts/ex-prt-mp7-p02.py
@@ -126,10 +126,6 @@ kv = [float(value) for value in kv_str.split(",")]
 # Cell types by layer
 icelltype = [1, 0, 0]
 
-# Conductivities
-k = [50.0, 0.01, 200.0]
-k33 = [10.0, 0.01, 20.0]
-
 # Well
 wel_coords = [(4718.45, 5281.25)]
 wel_q = [-150000.0]
@@ -327,8 +323,8 @@ def build_gwf_sim():
         gwf,
         xt3doptions=[("xt3d")],
         icelltype=icelltype,
-        k=k,
-        k33=k33,
+        k=kh,
+        k33=kv,
         save_saturation=True,
         save_specific_discharge=True,
     )

--- a/scripts/ex-prt-mp7-p03.py
+++ b/scripts/ex-prt-mp7-p03.py
@@ -601,7 +601,7 @@ def get_mp7_pathlines(timeseriesfile_path, endpointfile_path, gwf):
 
 
 # +
-# Pathline and starting point colors by capture destination
+# Pathline and starting point colors by destination
 colordest = {"well": "red", "drain": "green", "river": "blue"}
 
 
@@ -814,7 +814,8 @@ def plot_pathpoints_3d(gwf, mf6pl, title=None):
     )
 
     if plot_save:
-        p.save_graphic(figs_path / f"{sim_name}-paths-3d.pdf", raster=False)
+        p.save_graphic(figs_path / f"{sim_name}-paths-3d.pdf")
+        p.save_graphic(figs_path / f"{sim_name}-paths-3d.svg")
     if plot_show:
         p.camera.zoom(3.8)
         p.show()

--- a/scripts/ex-prt-mp7-p04.py
+++ b/scripts/ex-prt-mp7-p04.py
@@ -94,13 +94,14 @@ ncol = 26  # Number of columns
 delr = 500.0  # Column width ($ft$)
 delc = 500.0  # Row width ($ft$)
 top = 100.0  # Top of the model ($ft$)
-botm_str = "0.0, 0.0, 0.0"  # Layer bottom elevations ($ft$)
+botm = 0.0  # Layer bottom elevations ($ft$)
+kh = 50.0  # Horizontal hydraulic conductivity ($ft/d$)
 porosity = 0.1  # Porosity (unitless)
 
 # Time discretization
 tdis_rc = [(10000, 1, 1.0)]
 
-# Parse bottom elevations
+# Bottom elevations
 botm = np.zeros((nlay, nrow, ncol), dtype=np.float32)
 
 # [GRIDGEN](https://www.usgs.gov/software/gridgen-program-generating-unstructured-finite-volume-grids) can be used to create a quadpatch grid with a refined region in the upper left quadrant.
@@ -518,7 +519,7 @@ def build_gwf():
         save_specific_discharge=True,
         save_saturation=True,
         icelltype=[0],
-        k=[50],
+        k=[kh],
     )
 
     # constant head boundary (period, node number, head)
@@ -813,7 +814,6 @@ def plot_inset(ax, gwf):
 
     # plot grid features
     plot_map_view(axins, gwf)
-    # plot_well_cell_ids(axins)
     plot_well_ifaces(axins)
     plot_well_vertices_on_refinement_boundary(axins)
 
@@ -823,7 +823,13 @@ def plot_inset(ax, gwf):
 
     # add legend
     legend_elements = [
-        mpl.lines.Line2D([0], [0], color="red", lw=4, label="Well IFACEs"),
+        mpl.lines.Line2D(
+            [0],
+            [0],
+            color="red",
+            lw=4,
+            label="Well cell faces assigned flow (IFLOWFACE)",
+        ),
         mpl.lines.Line2D(
             [0],
             [0],
@@ -856,8 +862,8 @@ def plot_grid(gwf, title=None):
         # add legend
         ax.legend(
             handles=[
-                mpl.patches.Patch(color="red", label="Wells"),
-                mpl.patches.Patch(color="blue", label="Constant head boundary"),
+                mpl.patches.Patch(color="red", label="Wells", alpha=0.3),
+                mpl.patches.Patch(color="blue", label="Constant-head boundary"),
             ],
             bbox_to_anchor=(-1.1, 0, 0.8, 0.1),
         )


### PR DESCRIPTION
* regenerate `notebook_examples.rst`
* mention head/budget reversal for backwards tracking is accomplished with FloPy
* use SVG for 3D plots on ReadTheDocs example description pages, PDFs don't render
* fix some incorrect figure labels ("colored by layer" -> "travel time" or "destination") and legends