### PR TITLE
fix(plots): fix 3D plots in MP7/PRT examples

### DIFF
--- a/.doc/introduction.md
+++ b/.doc/introduction.md
@@ -89,26 +89,3 @@ Examples have been included for the MODFLOW 6 components summarized in the table
 | [MVT](https://modflow6.readthedocs.io/en/latest/_mf6io/gwt-mvt.html) | [ex-gwt-mt3dsupp82](_examples/ex-gwt-mt3dsupp82.html), [ex-gwt-prudic2004t2](_examples/ex-gwt-prudic2004t2.html) |
 
 
-#### Groundwater Transport Model Internal Flow Packages
-
-| Package | Examples                                                           |
-|---------|--------------------------------------------------------------------|
-| [CND](https://modflow6.readthedocs.io/en/latest/_mf6io/gwt-cnd.html) | [ex-gwe-radial-slow](_examples/ex-gwe-radial.html), [ex-gwe-geotherm](_examples/ex-gwe-geotherm.html) |
-| [EST](https://modflow6.readthedocs.io/en/latest/_mf6io/gwe-est.html) | [ex-gwe-radial-slow](_examples/ex-gwe-radial.html), [ex-gwe-geotherm](_examples/ex-gwe-geotherm.html) |
-
-
-
-
-#### Groundwater Energy Transport Model Standard Boundary Packages
-
-| Package | Examples                                                           |
-|---------|--------------------------------------------------------------------|
-| [ESL](https://modflow6.readthedocs.io/en/latest/_mf6io/gwe-esl.html) | [ex-gwe-radial-slow](_examples/ex-gwe-radial.html), [ex-gwe-geotherm](_examples/ex-gwe-geotherm.html) |
-
-
-#### Groundwater Energy Transport Model Advanced Boundary Packages
-
-| Package | Examples                                                           |
-|---------|--------------------------------------------------------------------|
-
-

--- a/.doc/introduction.md
+++ b/.doc/introduction.md
@@ -89,3 +89,26 @@ Examples have been included for the MODFLOW 6 components summarized in the table
 | [MVT](https://modflow6.readthedocs.io/en/latest/_mf6io/gwt-mvt.html) | [ex-gwt-mt3dsupp82](_examples/ex-gwt-mt3dsupp82.html), [ex-gwt-prudic2004t2](_examples/ex-gwt-prudic2004t2.html) |
 
 
+#### Groundwater Transport Model Internal Flow Packages
+
+| Package | Examples                                                           |
+|---------|--------------------------------------------------------------------|
+| [CND](https://modflow6.readthedocs.io/en/latest/_mf6io/gwt-cnd.html) | [ex-gwe-radial-slow](_examples/ex-gwe-radial.html), [ex-gwe-geotherm](_examples/ex-gwe-geotherm.html) |
+| [EST](https://modflow6.readthedocs.io/en/latest/_mf6io/gwe-est.html) | [ex-gwe-radial-slow](_examples/ex-gwe-radial.html), [ex-gwe-geotherm](_examples/ex-gwe-geotherm.html) |
+
+
+
+
+#### Groundwater Energy Transport Model Standard Boundary Packages
+
+| Package | Examples                                                           |
+|---------|--------------------------------------------------------------------|
+| [ESL](https://modflow6.readthedocs.io/en/latest/_mf6io/gwe-esl.html) | [ex-gwe-radial-slow](_examples/ex-gwe-radial.html), [ex-gwe-geotherm](_examples/ex-gwe-geotherm.html) |
+
+
+#### Groundwater Energy Transport Model Advanced Boundary Packages
+
+| Package | Examples                                                           |
+|---------|--------------------------------------------------------------------|
+
+

--- a/.doc/requirements.rtd.txt
+++ b/.doc/requirements.rtd.txt
@@ -1,3 +1,4 @@
+nbconvert==7.16.3
 nbsphinx
 nbsphinx_link
 ipython

--- a/.github/workflows/ex-rtd.yml
+++ b/.github/workflows/ex-rtd.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           # referenced from https://github.com/pyvista/pyvista/blob/main/.github/workflows/vtk-pre-test.yml#L53
           pip uninstall -y vtk
-          pip install --extra-index-url https://wheels.vtk.org trame vtk-osmesa
+          pip install --extra-index-url https://wheels.vtk.org trame vtk-osmesa trame-vtk trame-components
 
       - name: Update flopy MODFLOW 6 classes
         run: python -m flopy.mf6.utils.generate_classes --ref develop --no-backup

--- a/.github/workflows/ex-rtd.yml
+++ b/.github/workflows/ex-rtd.yml
@@ -56,6 +56,9 @@ jobs:
         with:
           python-version: 3.9
 
+      - name: Set up headless display
+        uses: pyvista/setup-headless-display-action@v2
+
       - name: Install Python packages
         working-directory: etc
         run: |
@@ -63,14 +66,6 @@ jobs:
           pip install -r requirements.pip.txt
           pip install -r requirements.usgs.txt
           python -m ipykernel install --name python_kernel --user
-
-      # PyVista doesn't like the default vtk
-      - name: OpenGL workaround
-        if: runner.os == 'Linux'
-        run: |
-          # referenced from https://github.com/pyvista/pyvista/blob/main/.github/workflows/vtk-pre-test.yml#L53
-          pip uninstall -y vtk
-          pip install --extra-index-url https://wheels.vtk.org trame vtk-osmesa trame-vtk trame-components
 
       - name: Update flopy MODFLOW 6 classes
         run: python -m flopy.mf6.utils.generate_classes --ref develop --no-backup

--- a/.github/workflows/ex-workflow.yml
+++ b/.github/workflows/ex-workflow.yml
@@ -143,7 +143,7 @@ jobs:
         run: |
           # referenced from https://github.com/pyvista/pyvista/blob/main/.github/workflows/vtk-pre-test.yml#L53
           pip uninstall -y vtk
-          pip install --extra-index-url https://wheels.vtk.org trame vtk-osmesa
+          pip install --extra-index-url https://wheels.vtk.org trame vtk-osmesa trame-vtk trame-components
 
       - name: Update flopy MODFLOW 6 classes
         run: python -m flopy.mf6.utils.generate_classes --ref develop --no-backup

--- a/.github/workflows/ex-workflow.yml
+++ b/.github/workflows/ex-workflow.yml
@@ -129,6 +129,9 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      - name: Set up headless display
+        uses: pyvista/setup-headless-display-action@v2
+
       - name: Install Python packages
         working-directory: etc
         run: |
@@ -136,14 +139,6 @@ jobs:
           pip install -r requirements.pip.txt
           pip install -r requirements.usgs.txt
           python -m ipykernel install --name python_kernel --user
-
-      # PyVista doesn't like the default vtk
-      - name: OpenGL workaround
-        if: runner.os == 'Linux'
-        run: |
-          # referenced from https://github.com/pyvista/pyvista/blob/main/.github/workflows/vtk-pre-test.yml#L53
-          pip uninstall -y vtk
-          pip install --extra-index-url https://wheels.vtk.org trame vtk-osmesa trame-vtk trame-components
 
       - name: Update flopy MODFLOW 6 classes
         run: python -m flopy.mf6.utils.generate_classes --ref develop --no-backup

--- a/doc/sections/ex-prt-mp7-p02.tex
+++ b/doc/sections/ex-prt-mp7-p02.tex
@@ -27,7 +27,7 @@ Subproblem 2A pathlines and points on a 1000-day time interval are visualized in
 	Three-dimensional perspective of pathlines and 1000-day points for subproblem 2A, and recharge points for subproblem 2B. Points are colored by layer.
 }
 	{fig:ex-prt-mp7-p02-paths-3d}
-	{../figures/mp7-p02-paths-3d.pdf}
+	{../figures/mp7-p02-paths-3d.png}
 \end{StandardFigure}
 
 \begin{StandardFigure}{

--- a/doc/sections/ex-prt-mp7-p03.tex
+++ b/doc/sections/ex-prt-mp7-p03.tex
@@ -30,7 +30,7 @@ Path points on a 2000-day interval are visualized in plan view in fig~\ref{fig:e
 
 \begin{StandardFigure}{
     Three-dimensional perspective of pathlines and 2000-day points. Points are colored by destination.
-    }{fig:ex-prt-mp7-p03-paths-3d}{../figures/mp7-p03-paths-3d.pdf}
+    }{fig:ex-prt-mp7-p03-paths-3d}{../figures/mp7-p03-paths-3d.png}
 \end{StandardFigure}
 
 \begin{StandardFigure}{

--- a/etc/ci_create_examples_rst.py
+++ b/etc/ci_create_examples_rst.py
@@ -191,9 +191,7 @@ for ex in examples:
 
             tag = ".. figure:: ../figures/"
             if tag in line:
-                line = line.replace(tag, ".. figure:: ../_images/").replace(
-                    ".pdf", ".svg"
-                )
+                line = line.replace(tag, ".. figure:: ../_images/")
 
             tag = ".. figure:: ../images/"
             if tag in line:
@@ -312,11 +310,7 @@ for src_dir in src_dirs:
         file_name
         for file_name in os.listdir(src_dir)
         if os.path.isfile(os.path.join(src_dir, file_name))
-        and (
-            file_name.endswith(".png")
-            or file_name.endswith(".gif")
-            or file_name.endswith(".svg")
-        )
+        and (file_name.endswith(".png") or file_name.endswith(".gif"))
     ]
     for file_name in file_names:
         src = os.path.join(src_dir, file_name)

--- a/scripts/ex-gwe-prt.py
+++ b/scripts/ex-gwe-prt.py
@@ -639,7 +639,7 @@ def plot_results(gwf_sim, gwe_sim, prt_sim, silent=True):
         axes[1].set_xlim(0, 2000)
         xticks = np.arange(0, 2100, 250)
         axes[1].set_xticks(xticks)
-        axes[1].set_ylabel("Temperature, $^{\circ}C$")
+        axes[1].set_ylabel(r"Temperature, $^{\circ}C$")
         axes[1].set_ylim(40, 80.0)
         yticks = np.arange(40, 81, 10)
         axes[1].set_yticks(yticks)

--- a/scripts/ex-prt-mp7-p01.py
+++ b/scripts/ex-prt-mp7-p01.py
@@ -757,33 +757,45 @@ def plot_pathpoints_3d(gwf, pathlines, title):
     bed_mesh.rotate_y(-20, point=axes.origin, inplace=True)
     bed_mesh.rotate_x(20, point=axes.origin, inplace=True)
 
-    p = pv.Plotter(window_size=[500, 500])
-    p.enable_anti_aliasing()
-    p.add_title(title, font_size=7)
-    p.add_mesh(gwf_mesh, opacity=0.025, style="wireframe")
-    p.add_mesh(
-        prt_mesh,
-        scalars="k" if "k" in prt_mesh.point_data else "ilay",
-        cmap=["green", "gold", "red"],
-        point_size=4,
-        render_points_as_spheres=True,
-    )
-    p.add_mesh(riv_mesh, color="teal", opacity=0.2)
-    p.add_mesh(wel_mesh, color="red", opacity=0.3)
-    p.add_mesh(bed_mesh, color="tan", opacity=0.1)
-    p.remove_scalar_bar()
-    p.add_legend(
-        labels=[("Layer 1", "green"), ("Layer 2", "gold"), ("Layer 3", "red")],
-        bcolor="white",
-        face="r",
-        size=(0.15, 0.15),
-    )
+    def _plot(screenshot=False):
+        p = pv.Plotter(
+            window_size=[500, 500],
+            off_screen=screenshot,
+            notebook=False if screenshot else None,
+        )
+        p.enable_anti_aliasing()
+        p.add_title(title, font_size=7)
+        p.add_mesh(gwf_mesh, opacity=0.025, style="wireframe")
+        p.add_mesh(
+            prt_mesh,
+            scalars="k" if "k" in prt_mesh.point_data else "ilay",
+            cmap=["green", "gold", "red"],
+            point_size=4,
+            line_width=4,
+            render_points_as_spheres=True,
+            render_lines_as_tubes=True,
+            smooth_shading=True,
+        )
+        p.add_mesh(riv_mesh, color="teal", opacity=0.2)
+        p.add_mesh(wel_mesh, color="red", opacity=0.3)
+        p.add_mesh(bed_mesh, color="tan", opacity=0.1)
+        p.remove_scalar_bar()
+        p.add_legend(
+            labels=[("Layer 1", "green"), ("Layer 2", "gold"), ("Layer 3", "red")],
+            bcolor="white",
+            face="r",
+            size=(0.15, 0.15),
+        )
 
-    p.camera.zoom(1.7)
+        p.camera.zoom(1.7)
+        p.show()
+        if screenshot:
+            p.screenshot(figs_path / f"{sim_name}-paths-3d.png")
+
     if plot_show:
-        p.show(auto_close=False)
+        _plot()
     if plot_save:
-        p.show(screenshot=figs_path / f"{sim_name}-paths-3d.png")
+        _plot(screenshot=True)
 
 
 def plot_all_pathlines(gwf, mf6pl, title=None):

--- a/scripts/ex-prt-mp7-p01.py
+++ b/scripts/ex-prt-mp7-p01.py
@@ -476,7 +476,7 @@ def get_pathlines(mf6_path, mp7_path):
         .tt
     )
 
-    # determine which particles ended up in which capture area
+    # determine which particles ended up in which capture zone
     mf6pl["destzone"] = mf6pl[mf6pl.istatus > 1].izone
     mf6pl["dest"] = mf6pl.apply(
         lambda row: (
@@ -757,8 +757,9 @@ def plot_pathpoints_3d(gwf, pathlines, title):
     bed_mesh.rotate_y(-20, point=axes.origin, inplace=True)
     bed_mesh.rotate_x(20, point=axes.origin, inplace=True)
 
-    p = pv.Plotter(window_size=[500, 500])
-    p.add_title(title, font_size=5)
+    p = pv.Plotter(window_size=[700, 700])
+    p.enable_anti_aliasing()
+    p.add_title(title, font_size=7)
     p.add_mesh(gwf_mesh, opacity=0.025, style="wireframe")
     p.add_mesh(
         prt_mesh,
@@ -775,7 +776,7 @@ def plot_pathpoints_3d(gwf, pathlines, title):
         labels=[("Layer 1", "green"), ("Layer 2", "gold"), ("Layer 3", "red")],
         bcolor="white",
         face="r",
-        size=(0.1, 0.1),
+        size=(0.2, 0.2),
     )
 
     p.camera.zoom(1.7)

--- a/scripts/ex-prt-mp7-p01.py
+++ b/scripts/ex-prt-mp7-p01.py
@@ -757,7 +757,7 @@ def plot_pathpoints_3d(gwf, pathlines, title):
     bed_mesh.rotate_y(-20, point=axes.origin, inplace=True)
     bed_mesh.rotate_x(20, point=axes.origin, inplace=True)
 
-    p = pv.Plotter(window_size=[700, 700])
+    p = pv.Plotter(window_size=[500, 500])
     p.enable_anti_aliasing()
     p.add_title(title, font_size=7)
     p.add_mesh(gwf_mesh, opacity=0.025, style="wireframe")
@@ -765,7 +765,7 @@ def plot_pathpoints_3d(gwf, pathlines, title):
         prt_mesh,
         scalars="k" if "k" in prt_mesh.point_data else "ilay",
         cmap=["green", "gold", "red"],
-        point_size=2,
+        point_size=4,
         render_points_as_spheres=True,
     )
     p.add_mesh(riv_mesh, color="teal", opacity=0.2)
@@ -776,7 +776,7 @@ def plot_pathpoints_3d(gwf, pathlines, title):
         labels=[("Layer 1", "green"), ("Layer 2", "gold"), ("Layer 3", "red")],
         bcolor="white",
         face="r",
-        size=(0.2, 0.2),
+        size=(0.15, 0.15),
     )
 
     p.camera.zoom(1.7)

--- a/scripts/ex-prt-mp7-p01.py
+++ b/scripts/ex-prt-mp7-p01.py
@@ -778,12 +778,11 @@ def plot_pathpoints_3d(gwf, pathlines, title):
         size=(0.1, 0.1),
     )
 
-    if plot_save:
-        p.save_graphic(figs_path / f"{sim_name}-paths-3d.pdf")
-        p.save_graphic(figs_path / f"{sim_name}-paths-3d.svg")
+    p.camera.zoom(1.7)
     if plot_show:
-        p.camera.zoom(1.7)
-        p.show()
+        p.show(auto_close=False)
+    if plot_save:
+        p.show(screenshot=figs_path / f"{sim_name}-paths-3d.png")
 
 
 def plot_all_pathlines(gwf, mf6pl, title=None):

--- a/scripts/ex-prt-mp7-p02.py
+++ b/scripts/ex-prt-mp7-p02.py
@@ -1110,7 +1110,7 @@ def plot_3d(gwf, pathlines, endpoints=None, title=None):
             scalars="k" if "k" in prt_mesh.point_data else "ilay",
             cmap=["green", "gold", "red"],
             point_size=4,
-            line_width=4,
+            line_width=3,
             render_points_as_spheres=True,
             render_lines_as_tubes=True,
             smooth_shading=True,

--- a/scripts/ex-prt-mp7-p02.py
+++ b/scripts/ex-prt-mp7-p02.py
@@ -1085,7 +1085,7 @@ def plot_3d(gwf, pathlines, endpoints=None, title=None):
     bed_mesh.rotate_y(-10, point=axes.origin, inplace=True)
     bed_mesh.rotate_x(10, point=axes.origin, inplace=True)
 
-    p = pv.Plotter(window_size=[700, 700])
+    p = pv.Plotter(window_size=[500, 500])
     p.enable_anti_aliasing()
     if title is not None:
         p.add_title(title, font_size=7)
@@ -1108,7 +1108,7 @@ def plot_3d(gwf, pathlines, endpoints=None, title=None):
             eps_mesh,
             scalars=endpoints.k.ravel(),
             cmap=["green", "gold", "red"],
-            point_size=2,
+            point_size=4,
         )
         p.remove_scalar_bar()
     p.add_mesh(riv_mesh, color="teal", opacity=0.2)
@@ -1118,7 +1118,7 @@ def plot_3d(gwf, pathlines, endpoints=None, title=None):
         labels=[("Layer 1", "green"), ("Layer 2", "gold"), ("Layer 3", "red")],
         bcolor="white",
         face="r",
-        size=(0.2, 0.2),
+        size=(0.15, 0.15),
     )
 
     p.camera.zoom(2)

--- a/scripts/ex-prt-mp7-p02.py
+++ b/scripts/ex-prt-mp7-p02.py
@@ -1085,9 +1085,10 @@ def plot_3d(gwf, pathlines, endpoints=None, title=None):
     bed_mesh.rotate_y(-10, point=axes.origin, inplace=True)
     bed_mesh.rotate_x(10, point=axes.origin, inplace=True)
 
-    p = pv.Plotter(window_size=[500, 500])
+    p = pv.Plotter(window_size=[700, 700])
+    p.enable_anti_aliasing()
     if title is not None:
-        p.add_title(title, font_size=5)
+        p.add_title(title, font_size=7)
     p.add_mesh(gwf_mesh, opacity=0.025, style="wireframe")
     p.add_mesh(
         prt_mesh,
@@ -1117,7 +1118,7 @@ def plot_3d(gwf, pathlines, endpoints=None, title=None):
         labels=[("Layer 1", "green"), ("Layer 2", "gold"), ("Layer 3", "red")],
         bcolor="white",
         face="r",
-        size=(0.1, 0.1),
+        size=(0.2, 0.2),
     )
 
     p.camera.zoom(2)

--- a/scripts/ex-prt-mp7-p02.py
+++ b/scripts/ex-prt-mp7-p02.py
@@ -1120,12 +1120,11 @@ def plot_3d(gwf, pathlines, endpoints=None, title=None):
         size=(0.1, 0.1),
     )
 
-    if plot_save:
-        p.save_graphic(figs_path / f"{sim_name}-paths-3d.pdf")
-        p.save_graphic(figs_path / f"{sim_name}-paths-3d.svg")
+    p.camera.zoom(2)
     if plot_show:
-        p.camera.zoom(3.0)
-        p.show()
+        p.show(auto_close=False)
+    if plot_save:
+        p.show(screenshot=figs_path / f"{sim_name}-paths-3d.png")
 
 
 def load_head():

--- a/scripts/ex-prt-mp7-p03.py
+++ b/scripts/ex-prt-mp7-p03.py
@@ -779,40 +779,52 @@ def plot_pathpoints_3d(gwf, mf6pl, title=None):
     bed_mesh.rotate_y(-10, point=axes.origin, inplace=True)
     bed_mesh.rotate_x(10, point=axes.origin, inplace=True)
 
-    p = pv.Plotter(window_size=[500, 500])
-    p.enable_anti_aliasing()
-    if title is not None:
-        p.add_title(title, font_size=7)
-    p.add_mesh(gwf_mesh, opacity=0.025, style="wireframe")
-    p.add_mesh(
-        prt_mesh,
-        scalars="destzone",
-        cmap=["red", "red", "green", "blue"],
-        point_size=4,
-        render_points_as_spheres=True,
-    )
-    p.add_mesh(drn_mesh, color="green", opacity=0.2)
-    p.add_mesh(riv_mesh, color="teal", opacity=0.2)
-    p.add_mesh(wel_mesh, color="red", opacity=0.3)
-    p.add_mesh(wel2_mesh, color="red", opacity=0.2)
-    p.add_mesh(bed_mesh, color="tan", opacity=0.1)
-    p.remove_scalar_bar()
-    p.add_legend(
-        labels=[
-            ("Well (layer 3)", "red"),
-            ("Drain", "green"),
-            ("River", "blue"),
-        ],
-        bcolor="white",
-        face="r",
-        size=(0.2, 0.2),
-    )
+    def _plot(screenshot=False):
+        p = pv.Plotter(
+            window_size=[500, 500],
+            off_screen=screenshot,
+            notebook=False if screenshot else None,
+        )
+        p.enable_anti_aliasing()
+        if title is not None:
+            p.add_title(title, font_size=7)
+        p.add_mesh(gwf_mesh, opacity=0.025, style="wireframe")
+        p.add_mesh(
+            prt_mesh,
+            scalars="destzone",
+            cmap=["red", "red", "green", "blue"],
+            point_size=4,
+            line_width=4,
+            render_points_as_spheres=True,
+            render_lines_as_tubes=True,
+            smooth_shading=True,
+        )
+        p.add_mesh(drn_mesh, color="green", opacity=0.2)
+        p.add_mesh(riv_mesh, color="teal", opacity=0.2)
+        p.add_mesh(wel_mesh, color="red", opacity=0.3)
+        p.add_mesh(wel2_mesh, color="red", opacity=0.2)
+        p.add_mesh(bed_mesh, color="tan", opacity=0.1)
+        p.remove_scalar_bar()
+        p.add_legend(
+            labels=[
+                ("Well (layer 3)", "red"),
+                ("Drain", "green"),
+                ("River", "blue"),
+            ],
+            bcolor="white",
+            face="r",
+            size=(0.2, 0.2),
+        )
 
-    p.camera.zoom(2.2)
+        p.camera.zoom(2.2)
+        p.show()
+        if screenshot:
+            p.screenshot(figs_path / f"{sim_name}-paths-3d.png")
+
     if plot_show:
-        p.show(auto_close=False)
+        _plot()
     if plot_save:
-        p.show(screenshot=figs_path / f"{sim_name}-paths-3d.png")
+        _plot(screenshot=True)
 
 
 def plot_all_pathlines(gwf, mf6pl, title=None):

--- a/scripts/ex-prt-mp7-p03.py
+++ b/scripts/ex-prt-mp7-p03.py
@@ -794,7 +794,7 @@ def plot_pathpoints_3d(gwf, mf6pl, title=None):
             scalars="destzone",
             cmap=["red", "red", "green", "blue"],
             point_size=4,
-            line_width=4,
+            line_width=3,
             render_points_as_spheres=True,
             render_lines_as_tubes=True,
             smooth_shading=True,
@@ -936,7 +936,7 @@ def plot_all(gwfsim):
     plot_pathpoints_3d(
         gwf,
         mf6pathlines,
-        title="Pathlines and 2000-day points,\ncolored by destination",
+        title="Pathlines, 2000-day points,\ncolored by destination",
     )
     plot_endpoints(
         gwf,

--- a/scripts/ex-prt-mp7-p03.py
+++ b/scripts/ex-prt-mp7-p03.py
@@ -525,12 +525,18 @@ def get_mf6_pathlines(path):
     pl.set_index(["iprp", "irpt", "trelease"], drop=False, inplace=True)
 
     # determine which particles ended up in which capture zone
-    pl["czone"] = pl[pl.istatus > 1].izone
-    pl["cname"] = pl.apply(
+    pl["destzone"] = pl[pl.istatus > 1].izone
+    pl["dest"] = pl.apply(
         lambda row: (
             "well"
-            if (row.czone == 2 or row.czone == 3)
-            else ("drain" if row.czone == 4 else "river" if row.czone == 5 else pd.NA)
+            if (row.destzone == 2 or row.destzone == 3)
+            else (
+                "drain"
+                if row.destzone == 4
+                else "river"
+                if row.destzone == 5
+                else pd.NA
+            )
         ),
         axis=1,
     )
@@ -610,7 +616,7 @@ def plot_pathlines(ax, gwf, data, **kwargs):
             color = kwargs["color"]
         else:
             color = "grey"
-        d = data[data.cname == dest]
+        d = data[data.dest == dest]
         pl.plot_pathline(
             d, layer="all", colors=[color], label=label, linewidth=0.5, alpha=0.5
         )
@@ -625,7 +631,7 @@ def plot_points(fig, ax, gwf, data, colorbar=True, **kwargs):
         for dest in ["well", "river", "drain"]:
             color = kwargs["colordest"][dest]
             label = "Captured by " + dest
-            pdata = data[data.cname == dest]
+            pdata = data[data.dest == dest]
             pts.append(
                 ax.scatter(
                     pdata["x"],
@@ -773,13 +779,14 @@ def plot_pathpoints_3d(gwf, mf6pl, title=None):
     bed_mesh.rotate_y(-10, point=axes.origin, inplace=True)
     bed_mesh.rotate_x(10, point=axes.origin, inplace=True)
 
-    p = pv.Plotter(window_size=[500, 500])
+    p = pv.Plotter(window_size=[700, 700])
+    p.enable_anti_aliasing()
     if title is not None:
-        p.add_title(title, font_size=5)
+        p.add_title(title, font_size=7)
     p.add_mesh(gwf_mesh, opacity=0.025, style="wireframe")
     p.add_mesh(
         prt_mesh,
-        scalars="czone",
+        scalars="destzone",
         cmap=["red", "red", "green", "blue"],
         point_size=3,
         render_points_as_spheres=True,
@@ -798,10 +805,10 @@ def plot_pathpoints_3d(gwf, mf6pl, title=None):
         ],
         bcolor="white",
         face="r",
-        size=(0.1, 0.1),
+        size=(0.2, 0.2),
     )
 
-    p.camera.zoom(2.5)
+    p.camera.zoom(2.2)
     if plot_show:
         p.show(auto_close=False)
     if plot_save:
@@ -917,7 +924,7 @@ def plot_all(gwfsim):
     plot_pathpoints_3d(
         gwf,
         mf6pathlines,
-        title="Pathlines and 2000-day points,\ncolored by destination, 3D view",
+        title="Pathlines and 2000-day points,\ncolored by destination",
     )
     plot_endpoints(
         gwf,

--- a/scripts/ex-prt-mp7-p03.py
+++ b/scripts/ex-prt-mp7-p03.py
@@ -779,7 +779,7 @@ def plot_pathpoints_3d(gwf, mf6pl, title=None):
     bed_mesh.rotate_y(-10, point=axes.origin, inplace=True)
     bed_mesh.rotate_x(10, point=axes.origin, inplace=True)
 
-    p = pv.Plotter(window_size=[700, 700])
+    p = pv.Plotter(window_size=[500, 500])
     p.enable_anti_aliasing()
     if title is not None:
         p.add_title(title, font_size=7)
@@ -788,7 +788,7 @@ def plot_pathpoints_3d(gwf, mf6pl, title=None):
         prt_mesh,
         scalars="destzone",
         cmap=["red", "red", "green", "blue"],
-        point_size=3,
+        point_size=4,
         render_points_as_spheres=True,
     )
     p.add_mesh(drn_mesh, color="green", opacity=0.2)

--- a/scripts/ex-prt-mp7-p04.py
+++ b/scripts/ex-prt-mp7-p04.py
@@ -12,15 +12,24 @@
 #     name: python3
 # ---
 
-# ## Particle tracking through a steady-state system with lateral flow boundaries and a refined vertex grid.
+# ## Particle tracking: steady-state, refined vertex grid, lateral flow boundaries
 #
-# Application of a MODFLOW 6 particle-tracking (PRT) model to solve example 4 from the MODPATH 7 documentation.
+# Application of a MODFLOW 6 particle-tracking (PRT) model
+# to solve example 4 from the MODPATH 7 documentation.
 #
-# This notebook demonstrates a steady-state MODFLOW 6 simulation using a quadpatch DISV grid with an irregular domain and a large number of inactive cells. Particles are tracked backwards from terminating locations, including a pair of wells in a locally-refined region of the grid and constant-head cells along the grid's right side, to release locations along the left border of the grid's active region. Injection wells along the left-hand border are used to generate boundary flows.
+# This notebook demonstrates a steady-state MODFLOW 6 simulation
+# using a quadpatch DISV grid with an irregular domain and a large
+# number of inactive cells. Particles are tracked backwards from
+# terminating locations, including a pair of wells in a locally-
+# refined region of the grid and constant-head cells along the grid's
+# right side, to release locations along the left border of the grid's
+# active region. Injection wells along the left-hand border are used
+# to generate boundary flows.
 #
 # ### Initial setup
 #
-# Import dependencies, define the example name and workspace, and read settings from environment variables.
+# Import dependencies, define the example name and workspace,
+# and read settings from environment variables.
 
 # +
 import pathlib as pl
@@ -104,11 +113,14 @@ tdis_rc = [(10000, 1, 1.0)]
 # Bottom elevations
 botm = np.zeros((nlay, nrow, ncol), dtype=np.float32)
 
-# [GRIDGEN](https://www.usgs.gov/software/gridgen-program-generating-unstructured-finite-volume-grids) can be used to create a quadpatch grid with a refined region in the upper left quadrant.
+# [GRIDGEN](https://www.usgs.gov/software/gridgen-program-generating-unstructured-finite-volume-grids)
+# can be used to create a quadpatch grid with a refined region in the upper left quadrant.
 #
-# We will create a grid with 3 refinement levels, all nearly but not perfectly rectangular: a 500x500 area is carved out of the corners of the rectangle for each level. To form each region's polygon we combine 5 rectangles.
+# We will create a grid with 3 refinement levels, all nearly but not perfectly rectangular:
+# a 500x500 area is carved out of the corners of the rectangle for each level. To form each
+# refinement region's polygon we combine 5 rectangles.
 #
-# Create the top-level grid discretization.
+# First create the top-level grid discretization.
 
 # +
 ms = flopy.modflow.Modflow()
@@ -377,7 +389,8 @@ wells = [
 
 assert len(wells) == 68
 
-# Define particle release locations, initially in the representation for MODPATH 7 particle input style 1.
+# Define particle release locations, initially in the
+# representation for MODPATH 7 particle input style 1.
 particles = [
     # MODPATH 7 input style 1
     # (node number, localx, localy, localz)
@@ -435,7 +448,12 @@ particles = [
     (891, 0.875, 1.000, 0.500),
 ]
 
-# For vertex grids, the MODFLOW 6 PRT model's PRP (particle release point) package expects initial particle locations as tuples `(particle ID, (layer, cell ID), x coord, y coord, z coord)`. While MODPATH 7 input style 1 expects local coordinates, PRT expects global coordinates (the user must guarantee that each release point's coordinates fall within the cell with the given ID). FloPy's `ParticleData` class provides a `to_coords()` utility method to convert local coordinates to global coordinates for easier migration from MODPATH 7 to PRT.
+# For vertex grids, the MODFLOW 6 PRT model's PRP (particle release point) package expects initial
+# particle locations as tuples `(particle ID, (layer, cell ID), x coord, y coord, z coord)`. While
+# MODPATH 7 input style 1 expects local coordinates, PRT expects global coordinates (the user must
+# guarantee that each release point's coordinates fall within the cell with the given ID). FloPy's
+# `ParticleData` class provides a `to_coords()` utility method to convert local coordinates to
+# global coordinates for easier migration from MODPATH 7 to PRT.
 partdata = flopy.modpath.ParticleData(
     partlocs=[p[0] for p in particles],
     structured=False,
@@ -695,7 +713,10 @@ def run_models(*sims, silent=False):
 #
 # Define functions to plot the grid, boundary conditions, and model results.
 #
-# Below we highlight the vertices of well-containing cells which lie on the boundary between coarser- and finer-grained refinement regions (there are 7 of these). Note the disagreement between values of `IFLOWFACE` and `IFACE` for these cells. This is because the cells have 5 polygonal faces.
+# Below we highlight the vertices of well-containing cells which lie on the boundary between
+# coarser- and finer-grained refinement regions (there are 7 of these). Note the disagreement
+# between values of MODFLOW 6 PRT's `IFLOWFACE` and MODPATH 7's `IFACE` for these cells. This
+# is because the cells have 5 polygonal faces.
 
 
 # +


### PR DESCRIPTION
Reduce plot point color issues (rendering artifacts?) in P03 and other improvements

* use `vtk` with [`setup-headless-display-action`](https://github.com/pyvista/setup-headless-display-action) instead of `vtk-osmesa` 
* export 3D plots as PNG instead of PDF/SVG
* render lines as tubes
* improve zoom/legend font size
* wrap long comments in P04
* try pinning `nbconvert==7.16.3` to fix notebook thumbnail rendering
  * https://github.com/spatialaudio/nbsphinx/issues/796#issuecomment-2102618272

#### old
<img src="https://github.com/MODFLOW-USGS/modflow6-examples/assets/10502868/d204a2c6-34d4-4c65-833e-4607688247cc" width="500">

#### new
<img src="https://modflow6-examples.readthedocs.io/en/latest/_images/_notebooks_ex-prt-mp7-p03_15_9.png" width="500">
