### PR TITLE
chore: consistent example names in scripts/descriptions

### DIFF
--- a/doc/sections/ex-gwe-danckwerts.tex
+++ b/doc/sections/ex-gwe-danckwerts.tex
@@ -1,4 +1,4 @@
-\section{Infiltrating Heat Flux}
+\section{Infiltrating Heat Front}
 
 % Describe source of problem
 An analytical solution used in chemical engineering for modeling concentration in packed-bed reactors , commonly referred to as a ``Danckwerts'' (or ``third-type'') boundary condition, is adapted here for confirming the accuracy of heat transport as solved by the UZE package in \mf.  The analytical solution has the following characteristics: (1) it solves for total energy flux (advection and conduction) along a 1-dimensional (1D) profile [i.e., there is no conduction (``thermal bleeding'') with the surrounding materials], (2) heat flux can only enter the active domain with the inflow (in this case, the infiltration) and it does not require the temperature at the boundary to be equal to the temperature of the infiltration, and (3) it solves for total heat flux (instead of temperature) throughout the 1D domain.

--- a/doc/sections/ex-gwe-prt.tex
+++ b/doc/sections/ex-gwe-prt.tex
@@ -1,4 +1,4 @@
-\section{Thermal profile along a particle path}
+\section{Thermal Profile along a Particle Path}
 
 % Describe source of problem
 This example demonstrates the simultaneous use of three different model types in \mf: (1) groundwater flow (GWF), (2) groundwater energy transport (GWE), and (3) particle transport (PRT).  Both GWF and GWE solve for steady flow and temperature conditions, respectively. PRT is used to route two particles through the steady flow and heat transport fields and once informed of the particle locations through time, each x-y location is mapped to a temperature that is then plotted.

--- a/doc/sections/ex-gwf-bump.tex
+++ b/doc/sections/ex-gwf-bump.tex
@@ -1,4 +1,4 @@
-\section{Flow Diversion Problem}
+\section{Flow Diversion}
 
 % Describe source of problem
 This problem simulates unconfined groundwater flow in an aquifer with a high bottom elevation in the center of the aquifer and groundwater flow around a high bottom elevation.

--- a/doc/sections/ex-gwf-spbc.tex
+++ b/doc/sections/ex-gwf-spbc.tex
@@ -1,4 +1,4 @@
-\section{Laattoe Periodic BC}
+\section{Laattoe Periodic Boundary Condition}
 
 % Describe source of problem
 This example shows how the exchange capability in \mf can be used to simulate spatial periodic boundary conditions (SPBC), such as the one described by \cite{laattoe2014spatial}.  A SPBC can be used to represent spatially repeating groundwater flow conditions, such as those that might form beneath repeating bedforms on the sea floor.  The example simulated here is equivalent to the first MODFLOW simulation reported by \cite{laattoe2014spatial}.  

--- a/doc/sections/ex-gwf-u1gwfgwf.tex
+++ b/doc/sections/ex-gwf-u1gwfgwf.tex
@@ -1,4 +1,4 @@
-\section{Nested Grid Problem - Two Domains}
+\section{Nested Grid Problem, Two Domains}
 
 % Describe source of problem
 This example reproduces the nested grid problem described in the MODFLOW-USG documentation \citep{modflowusg}. A single model setup with a grid based on the Discretization by Vertices (DISV) input is presented elsewhere in these examples. This problem is set up using two individual GWF models with a regular grid (DIS) that are coupled through a GWF Exchange. A plan view of the combined grid for the two models is shown in figure~\ref{fig:ex-gwf-u1gwfgwf-s1-grid}. The XT3D option in the NPF package can be applied to avoid inaccuracies at the cell refinement interface \citep{modflow6xt3d}, which is the model boundary in this example. However, for this coupled system it is not sufficient to enable XT3D for the models independently: the correct flow calculation around the model interface relies on information from both models.

--- a/scripts/ex-gwe-danckwerts.py
+++ b/scripts/ex-gwe-danckwerts.py
@@ -1,11 +1,13 @@
-# ## Infiltrating heat front
+# ## Infiltrating Heat Front
 #
-#  An example demonstrating that a specified energy flux boundary condition works as expected when compared to an analytical solution.
+# An example demonstrating that a specified energy flux boundary condition
+# works as expected when compared to an analytical solution.
 #
 
 # ### Initial Setup
 #
-# Import dependencies, define the example name and workspace, and read settings from environment variables.
+# Import dependencies, define the example name and workspace,
+# and read settings from environment variables.
 
 # +
 import math

--- a/scripts/ex-gwe-prt.py
+++ b/scripts/ex-gwe-prt.py
@@ -1,4 +1,4 @@
-# ## PRT with GWE example
+# ## Thermal Profile along a Particle Path
 
 # Using a Voronoi grid, this example demonstrates the combined use of GWF, GWE, and PRT.  A steady flow field is established, followed by the establishment of a steady-state temperature field.  Two particles are then routed through the model domain and the temperature of the particle is determined along the flow path.
 

--- a/scripts/ex-gwe-radial.py
+++ b/scripts/ex-gwe-radial.py
@@ -1,4 +1,4 @@
-# ## Radial heat transport example
+# ## Radial Heat Transport
 #
 # This example was originally published in Al-Khoury et al 2020. The original data by Al-Khoury et al. (2020) was for a radially symmetric finite-element mesh.  Where their mesh calculates values at mesh points, this setup uses those points as vertices in a DISV grid.
 

--- a/scripts/ex-gwf-bump.py
+++ b/scripts/ex-gwf-bump.py
@@ -1,4 +1,4 @@
-# ## Flow diversion example
+# ## Flow Diversion
 #
 # This example simulates unconfined groundwater flow in an aquifer with a high bottom elevation in the center of the aquifer and groundwater flow around a high bottom elevation.
 

--- a/scripts/ex-gwf-capture.py
+++ b/scripts/ex-gwf-capture.py
@@ -1,4 +1,4 @@
-# ## Capture fraction analysis
+# ## Capture Fraction Analysis
 #
 # This problem is an example of a capture fraction analysis based on
 # Leake and others (2010) using the model developed by Freyberg (1988) and

--- a/scripts/ex-gwf-csub-p01.py
+++ b/scripts/ex-gwf-csub-p01.py
@@ -1,4 +1,4 @@
-# ## Jacob (1939) elastic aquifer loading example
+# ## Jacob (1939) Elastic Aquifer Loading
 #
 # This problem simulates elastic compaction of aquifer materials in response to the
 # loading of an aquifer by a passing train. Water-level responses were simulated for

--- a/scripts/ex-gwf-csub-p02.py
+++ b/scripts/ex-gwf-csub-p02.py
@@ -1,4 +1,4 @@
-# ## Delay interbed drainage example
+# ## Delay Interbed Drainage
 #
 # This problem simulates the drainage of a thick interbed caused by a step
 # decrease in hydraulic head in the aquifer and is based on MODFLOW-2000 subsidence

--- a/scripts/ex-gwf-csub-p03.py
+++ b/scripts/ex-gwf-csub-p03.py
@@ -1,4 +1,4 @@
-# ## One-dimensional compaction example
+# ## One-Dimensional Compaction
 #
 # A one-dimensional MODFLOW 6 model was developed by Sneed (2008) to simulate
 # aquitard drainage, compaction and, land subsidence at the Holly site, located at

--- a/scripts/ex-gwf-csub-p04.py
+++ b/scripts/ex-gwf-csub-p04.py
@@ -1,4 +1,4 @@
-# ## One-dimensional compaction in a three-dimensional flow field example
+# ## One-Dimensional Compaction in a Three-Dimensional Flow Field
 #
 # This problem is based on the problem presented in the SUB-WT report
 # (Leake and Galloway, 2007) and represent groundwater development in a

--- a/scripts/ex-gwf-radial.py
+++ b/scripts/ex-gwf-radial.py
@@ -1,4 +1,4 @@
-# ## USG1DISU example
+# ## Radial Groundwater Flow Model
 #
 # This example, ex-gwf-radial, shows how the MODFLOW 6 DISU Package
 # can be used to simulate an axisymmetric radial model.

--- a/scripts/ex-gwf-sagehen.py
+++ b/scripts/ex-gwf-sagehen.py
@@ -1,4 +1,4 @@
-# ## Sagehen example with UZF, SFR, and MVR advanced packages activated
+# ## Sagehen UZF1 Package Problem 1
 #
 # This script reproduces example 1 in the UZF1 Techniques and Methods
 # (Niswonger et al., 2006).

--- a/scripts/ex-gwf-sfr-p01.py
+++ b/scripts/ex-gwf-sfr-p01.py
@@ -1,4 +1,4 @@
-# ## Streamflow Routing (SFR) Package problem 1
+# ## Streamflow Routing (SFR) Package Problem 1
 #
 # This is the stream-aquifer interaction example problem (test 1) from the
 # Streamflow Routing Package documentation (Prudic, 1989). All reaches have

--- a/scripts/ex-gwf-spbc.py
+++ b/scripts/ex-gwf-spbc.py
@@ -1,4 +1,4 @@
-# ## SPBC example
+# ## Laattoe Periodic Boundary Condition
 #
 # Periodic boundary condition problem is based on Laattoe and others (2014).
 # A MODFLOW 6 GWF-GWF Exchange is used to connect the left column with the

--- a/scripts/ex-gwf-twri.py
+++ b/scripts/ex-gwf-twri.py
@@ -1,4 +1,4 @@
-# ## Original TWRI MODFLOW example
+# ## TWRI
 #
 # This problem is described in McDonald and Harbaugh (1988) and duplicated in
 # Harbaugh and McDonald (1996). This problem is also is distributed with

--- a/scripts/ex-gwf-u1disv.py
+++ b/scripts/ex-gwf-u1disv.py
@@ -1,4 +1,4 @@
-# ## USG1DISV example
+# ## Nested Grid Problem
 #
 # This example shows how the MODFLOW 6 DISV Package can be used to simulate
 # a nested grid problem.  The example corresponds to the first example

--- a/scripts/ex-gwf-u1gwfgwf.py
+++ b/scripts/ex-gwf-u1gwfgwf.py
@@ -1,4 +1,4 @@
-# ## USG-ex1 with GWF-GWF Exchange and XT3D
+# ## Nested Grid Problem, Two Domains
 #
 # This example shows how the MODFLOW 6 GWF-GWF Exchange can be used to simulate
 # a nested grid problem. The example corresponds to the first example

--- a/scripts/ex-gwf-whirl.py
+++ b/scripts/ex-gwf-whirl.py
@@ -1,4 +1,4 @@
-# ## Whirl example
+# ## Groundwater Whirls
 #
 # This is a 10 layer steady-state problem involving anisotropic groundwater
 # flow.  The XT3D formulation is used to represent variable hydraulic

--- a/scripts/ex-gwf-zaidel.py
+++ b/scripts/ex-gwf-zaidel.py
@@ -1,4 +1,4 @@
-# ## Zaidel (2013) example
+# ## Zaidel Problem
 #
 # Described in Zaidel (2013), representing a discontinuous
 # water table configuration over a stairway impervious base.

--- a/scripts/ex-gwt-gwtgwt-p10.py
+++ b/scripts/ex-gwt-gwtgwt-p10.py
@@ -1,4 +1,4 @@
-# ## Comparing MODFLOW 6 GWT-GWT to the single model results from MT3DMS problem 10
+# ## MT3DMS Problem 10 Two Domains
 #
 # The purpose of this example is to demonstrate the model setup for
 # a coupled GWF-GWT simulation with submodels. It replicates the

--- a/scripts/ex-gwt-hecht-mendez.py
+++ b/scripts/ex-gwt-hecht-mendez.py
@@ -1,4 +1,4 @@
-# ## Three-dimensional heat transport example
+# ## Hecht-Mendez 3D Borehole Heat Exchanger Problem
 #
 # The purpose of this script is to (1) recreate the 3D heat transport example
 # first published in Groundwater in 2010 titled, "Evaluating MT3DMS for Heat

--- a/scripts/ex-gwt-moc3d-p01.py
+++ b/scripts/ex-gwt-moc3d-p01.py
@@ -1,4 +1,4 @@
-# ## One-dimensional steady flow with transport
+# ## MOC3D Problem 1
 #
 # This problem corresponds to the first problem presented in the MOC3D
 # report Konikow 1996, involving the transport of a dissolved constituent

--- a/scripts/ex-gwt-moc3d-p02.py
+++ b/scripts/ex-gwt-moc3d-p02.py
@@ -1,4 +1,4 @@
-# ## Three-dimensional steady flow with transport
+# ## MOC3D Problem 2
 #
 # This problem corresponds to the second problem presented in the MOC3D report
 # Konikow 1996, which involves the transport of a dissolved constituent in a

--- a/scripts/ex-gwt-moc3d-p02tg.py
+++ b/scripts/ex-gwt-moc3d-p02tg.py
@@ -1,4 +1,4 @@
-# ## Three-Dimensional Steady Flow with Transport
+# ## MOC3D Problem 2 with Triangular Grid
 #
 # This problem corresponds to the second problem presented in the MOC3D
 # report Konikow 1996, which involves the transport of a dissolved

--- a/scripts/ex-gwt-mt3dms-p01.py
+++ b/scripts/ex-gwt-mt3dms-p01.py
@@ -1,4 +1,4 @@
-# ## One-Dimensional Transport in a Uniform Flow Field Comparison of MODFLOW 6 transport with MT3DMS
+# ## MT3DMS Problem 1
 #
 # The purpose of this script is to (1) recreate the example problems that were first
 # described in the 1999 MT3DMS report, and (2) compare MODFLOW 6-GWT solutions to the

--- a/scripts/ex-gwt-mt3dms-p02.py
+++ b/scripts/ex-gwt-mt3dms-p02.py
@@ -1,4 +1,4 @@
-# ## One-dimensional steady flow with transport
+# ## MT3DMS Problem 2
 #
 # This is the second example problem presented in Zheng 1999, titled "One-dimensional transport
 # with nonlinear or nonequilibrium sorption. The purpose of this example is to demonstrate

--- a/scripts/ex-gwt-mt3dms-p03.py
+++ b/scripts/ex-gwt-mt3dms-p03.py
@@ -1,4 +1,4 @@
-# ## Two-Dimensional Transport in a Uniform Flow Field Comparison of MODFLOW 6 transport with MT3DMS
+# ## MT3DMS Problem 3
 #
 # The purpose of this script is to (1) recreate the example problems that were first
 # described in the 1999 MT3DMS report, and (2) compare MF6-GWT solutions to the

--- a/scripts/ex-gwt-mt3dms-p04.py
+++ b/scripts/ex-gwt-mt3dms-p04.py
@@ -1,4 +1,4 @@
-# ## Two-Dimensional Transport in a Uniform Flow Field Comparison of MODFLOW 6 transport with MT3DMS
+# ## MT3DMS Problem 4
 #
 # The purpose of this script is to (1) recreate the example problems that were first
 # described in the 1999 MT3DMS report, and (2) compare MF6-GWT solutions to the

--- a/scripts/ex-gwt-mt3dms-p05.py
+++ b/scripts/ex-gwt-mt3dms-p05.py
@@ -1,4 +1,4 @@
-# ## Two-Dimensional Transport in a Radial Flow Field Comparison of MODFLOW 6 transport with MT3DMS
+# ## MT3DMS Problem 5
 #
 # The purpose of this script is to (1) recreate the example problems that were first
 # described in the 1999 MT3DMS report, and (2) compare MF6-GWT solutions to the

--- a/scripts/ex-gwt-mt3dms-p06.py
+++ b/scripts/ex-gwt-mt3dms-p06.py
@@ -1,4 +1,4 @@
-# ## Concentration at an Injection/Extraction Well, Comparison of MODFLOW 6 transport with MT3DMS
+# ## MT3DMS Problem 6
 #
 # The purpose of this script is to (1) recreate the example problems that were first
 # described in the 1999 MT3DMS report, and (2) compare MF6-GWT solutions to the

--- a/scripts/ex-gwt-mt3dms-p07.py
+++ b/scripts/ex-gwt-mt3dms-p07.py
@@ -1,4 +1,4 @@
-# ## Three Dimensional Transport in a Uniform Flow Field, Comparison of MODFLOW 6 transport with MT3DMS
+# ## MT3DMS Problem 7
 #
 # The purpose of this script is to (1) recreate the example problems that were first
 # described in the 1999 MT3DMS report, and (2) compare MF6-GWT solutions to the

--- a/scripts/ex-gwt-mt3dms-p08.py
+++ b/scripts/ex-gwt-mt3dms-p08.py
@@ -1,4 +1,4 @@
-# ## Two Dimensional Vertical Transport in a Heterogeneous Aquifer, Comparison of MODFLOW 6 transport with MT3DMS
+# ## MT3DMS Problem 8
 #
 # The purpose of this script is to (1) recreate the example problems that were first
 # described in the 1999 MT3DMS report, and (2) compare MF6-GWT solutions to the

--- a/scripts/ex-gwt-mt3dms-p09.py
+++ b/scripts/ex-gwt-mt3dms-p09.py
@@ -1,4 +1,4 @@
-# ## Two Dimensional Application Example, Comparison of MODFLOW 6 Transport with MT3DMS
+# ## MT3DMS Problem 9
 #
 # The purpose of this script is to (1) recreate the example problems that were first
 # described in the 1999 MT3DMS report, and (2) compare MF6-GWT solutions to the

--- a/scripts/ex-gwt-mt3dms-p10.py
+++ b/scripts/ex-gwt-mt3dms-p10.py
@@ -1,4 +1,4 @@
-# ## Three-Dimensional Field Case Study, Comparison of MODFLOW 6 Transport with MT3DMS
+# ## MT3DMS Problem 10
 #
 # The purpose of this script is to (1) recreate the example problems that were first
 # described in the 1999 MT3DMS report, and (2) compare MF6-GWT solutions to the

--- a/scripts/ex-gwt-mt3dsupp631.py
+++ b/scripts/ex-gwt-mt3dsupp631.py
@@ -1,4 +1,4 @@
-# ## Zero-Order Growth in a Uniform Flow Field
+# ## MT3DMS Supplemental Guide Problem 6.3.1
 #
 # This example is for zero-order production in a uniform flow field.
 # It is based on example problem 6.3.1 described in Zheng 2010. The

--- a/scripts/ex-gwt-mt3dsupp632.py
+++ b/scripts/ex-gwt-mt3dsupp632.py
@@ -1,4 +1,4 @@
-# ## Zero-order production in a dual-domain system
+# ## MT3DMS Supplemental Guide Problem 6.3.2
 #
 # This example tests the capabilities of the GWT model to simulate
 # 0-order production in a dual-domain system with & without sorption.

--- a/scripts/ex-gwt-mt3dsupp82.py
+++ b/scripts/ex-gwt-mt3dsupp82.py
@@ -1,4 +1,4 @@
-# ## Simulating effect of recirculation well
+# ## MT3DMS Supplemental Guide Problem 8.2
 #
 # This example is for a recirculating well.  It is based on example problem 8.2
 # described in Zheng 2010. The problem consists of a two-dimensional, one-layer

--- a/scripts/ex-gwt-prudic2004t2.py
+++ b/scripts/ex-gwt-prudic2004t2.py
@@ -1,4 +1,4 @@
-# ## Stream-lake interaction with solute transport
+# ## SFR1 Manual Problem 2
 #
 # This problem is based on the stream-aquifer interaction problem
 # described as Test 2 by Prudic et al 2004, which modifies another

--- a/scripts/ex-gwt-rotate.py
+++ b/scripts/ex-gwt-rotate.py
@@ -1,4 +1,4 @@
-# ## Rotating interface example
+# ## Rotating Interface Problem
 #
 # This example demonstrates density-driven groundwater flow.
 

--- a/scripts/ex-gwt-uzt-2d.py
+++ b/scripts/ex-gwt-uzt-2d.py
@@ -1,4 +1,4 @@
-# ## Two-Dimensional Transport with the UZF and UZT packages active.
+# ## Two-Dimensional Test of Unsaturated-Saturated Transport
 #
 # This problem tests transport in the unsaturated zone.
 # This example originally appeared in Morway et al (2013).

--- a/scripts/ex-prt-mp7-p01.py
+++ b/scripts/ex-prt-mp7-p01.py
@@ -1,17 +1,3 @@
-# ---
-# jupyter:
-#   jupytext:
-#     text_representation:
-#       extension: .py
-#       format_name: light
-#       format_version: '1.5'
-#       jupytext_version: 1.16.1
-#   kernelspec:
-#     display_name: Python 3 (ipykernel)
-#     language: python
-#     name: python3
-# ---
-
 # ## Forward Tracking, Structured Grid, Steady-State Flow
 #
 # Application of a MODFLOW 6 particle-tracking (PRT) model

--- a/scripts/ex-prt-mp7-p02.py
+++ b/scripts/ex-prt-mp7-p02.py
@@ -1,17 +1,3 @@
-# ---
-# jupyter:
-#   jupytext:
-#     text_representation:
-#       extension: .py
-#       format_name: light
-#       format_version: '1.5'
-#       jupytext_version: 1.16.1
-#   kernelspec:
-#     display_name: Python 3 (ipykernel)
-#     language: python
-#     name: python3
-# ---
-
 # ## Backward Tracking, Quad-Refined Grid, Steady-State Flow
 #
 # Application of a MODFLOW 6 particle-tracking (PRT) model

--- a/scripts/ex-prt-mp7-p03.py
+++ b/scripts/ex-prt-mp7-p03.py
@@ -1,17 +1,3 @@
-# ---
-# jupyter:
-#   jupytext:
-#     text_representation:
-#       extension: .py
-#       format_name: light
-#       format_version: '1.5'
-#       jupytext_version: 1.14.7
-#   kernelspec:
-#     display_name: venv
-#     language: python
-#     name: python3
-# ---
-
 # ## Forward Tracking, Structured Grid, Transient Flow
 #
 # Application of a MODFLOW 6 particle-tracking (PRT)

--- a/scripts/ex-prt-mp7-p04.py
+++ b/scripts/ex-prt-mp7-p04.py
@@ -1,17 +1,3 @@
-# ---
-# jupyter:
-#   jupytext:
-#     text_representation:
-#       extension: .py
-#       format_name: light
-#       format_version: '1.5'
-#       jupytext_version: 1.14.6
-#   kernelspec:
-#     display_name: venv
-#     language: python
-#     name: python3
-# ---
-
 # ## Backward Tracking, Refined Grid, Lateral Flow Boundaries
 #
 # Application of a MODFLOW 6 particle-tracking (PRT) model


### PR DESCRIPTION
* use the same name in the latex file and example script/notebook
* use same case conventions throughout (title case)
* remove jupytext metadata from PRT scripts