### PR TITLE
Curvilinear Examples Title Cleanup

### DIFF
--- a/scripts/ex-gwf-curvilinear-90.py
+++ b/scripts/ex-gwf-curvilinear-90.py
@@ -1,4 +1,4 @@
-# ## Curvilinear example
+# ## Curvilinear 90 Degree Example
 #
 # This example, ex-gwf-curvilinear, shows how the MODFLOW 6 DISV Package
 # can be used to simulate a curvilinear models.

--- a/scripts/ex-gwf-curvilinear.py
+++ b/scripts/ex-gwf-curvilinear.py
@@ -1,4 +1,4 @@
-# ## Curvilinear example
+# ## Curvilinear Example
 #
 # This example, ex-gwf-curvilinear, shows how the MODFLOW 6 DISV Package
 # can be used to simulate a multipart curvilinear models.


### PR DESCRIPTION
Just some minor changes to the titles in the two curvilinear example problems. I realized they were not title case and the result for the readthedocs webpage has the same times. This should make it have a better presentation and look similar to the rest of the pages.