### PR TITLE
fix(ex-gwf-curvilinear): change title to match latex section title

### DIFF
--- a/scripts/ex-gwf-curvilinear-90.py
+++ b/scripts/ex-gwf-curvilinear-90.py
@@ -1,7 +1,7 @@
-# ## Curvilinear example
+# ## Curvilinear Groundwater Flow Model
 #
-# This example, ex-gwf-curvilinear, shows how the MODFLOW 6 DISV Package
-# can be used to simulate a curvilinear models.
+# This example, ex-gwf-curvilinear-90, shows how the MODFLOW 6 DISV Package
+# can be used to simulate a curvilinear models with a 90 degree rotation.
 #
 # The example corresponds to Figure 3d (lower-right) in:
 #    Romero, D. M., & Silver, S. E. (2006).
@@ -14,8 +14,6 @@
 #    Oxford. England: Clarendon.
 # The equation is transformed here to use head instead of concentration
 
-# ### Initial setup
-#
 # ### Initial setup
 #
 # Import dependencies, define the example name and workspace, and read settings from environment variables.

--- a/scripts/ex-gwf-curvilinear.py
+++ b/scripts/ex-gwf-curvilinear.py
@@ -1,4 +1,4 @@
-# ## Curvilinear example
+# ## Multipart Curvilinear Groundwater Flow Model
 #
 # This example, ex-gwf-curvilinear, shows how the MODFLOW 6 DISV Package
 # can be used to simulate a multipart curvilinear models.
@@ -14,8 +14,6 @@
 #    3) 90 to 0 degree curvilinear grid
 # that are merged, as 1-2-3, to make the final multipart curvilinear grid.
 
-# ### Initial setup
-#
 # ### Initial setup
 #
 # Import dependencies, define the example name and workspace, and read settings from environment variables.


### PR DESCRIPTION
@langevin-usgs  @wpbonelli 

This fixes the python files syntax that is parsed as markdown to have the same title title as the latex files. Now the title should match the ones defined in `doc/sections/ex-gwf-curvilinear-90.tex` and `doc/sections/ex-gwf-curvilinear.tex`

I also noticed that I had a markdown header dublicated, so I removed the  second occurrence of:
"# ### Initial setup"