### PR TITLE
fix(naming): use consistent notebook and description names

### DIFF
--- a/doc/sections/ex-gwf-advtidal.tex
+++ b/doc/sections/ex-gwf-advtidal.tex
@@ -1,4 +1,4 @@
-\section{Tidal}
+\section{Tidal Model}
 
 % Describe source of problem
 This example demonstrates use of \mf observations and time series and the capability to use multiple stress packages of the same type in a single groundwater flow model.  This is a synthetic example problem that has not been documented elsewhere.

--- a/doc/sections/ex-gwf-bcf2ss.tex
+++ b/doc/sections/ex-gwf-bcf2ss.tex
@@ -1,4 +1,4 @@
-\section{BCF2SS}
+\section{BCF2SS Model}
 
 % Describe source of problem
 In an aquifer system where two aquifers are separated by a confining bed, large pumpage withdrawals from the bottom aquifer can desaturate parts of the upper aquifer. If pumpage is discontinued, resaturation of the upper aquifer can occur. This problem demonstrates the capability of the Node Property Flow (NPF) Package to successfully simulate this common hydrologic situation which is difficult or impossible to simulate without use of the rewetting option and the Standard Formulation or the Newton-Raphson Formulation.

--- a/doc/sections/ex-gwf-csub-p01.tex
+++ b/doc/sections/ex-gwf-csub-p01.tex
@@ -1,4 +1,4 @@
-\section{CSUB Package Problem 1}
+\section{Elastic Aquifer Loading}
 This problem simulates elastic compaction of aquifer materials in response to the loading of an aquifer by a passing train. Water-level responses were simulated for an eastbound train leaving the Smithtown Station in Long Island, New York at 13:04 on April 23, 1937 \citep{jacob1939fluctuations}. 
 
 \subsection{Example Description}

--- a/doc/sections/ex-gwf-csub-p02.tex
+++ b/doc/sections/ex-gwf-csub-p02.tex
@@ -1,4 +1,4 @@
-\section{CSUB Package Problem 2}
+\section{Delay Interbed Drainage}
 This problem simulates the drainage of a thick interbed caused by a step decrease in hydraulic head in the aquifer and is based on sample problem 1 in \cite{hoffmann2003modflow}. 
 
 

--- a/doc/sections/ex-gwf-csub-p03.tex
+++ b/doc/sections/ex-gwf-csub-p03.tex
@@ -1,4 +1,4 @@
-\section{CSUB Package Problem 3}
+\section{One-Dimensional Compaction}
 
 A one-dimensional \mf model was developed by \cite{sneed2008} to simulate aquitard drainage, compaction and, land subsidence at the Holly site, located at the Edwards Air Force base, in response to effective stress changes caused by groundwater pumpage in the Antelope Valley in southern California (fig.~\ref{fig:ex-gwf-csub-p03-location}). Land subsidence resulting from groundwater level declines, has long been recognized as a problem in Antelope Valley, California. The original one-dimension compaction model was calibrated to extensometer data from the USGS Holly site (station name \href{https://waterdata.usgs.gov/ca/nwis/dv/?site_no=344835117531305}{008N010W01Q005S}) for the period from 1990 to 2006, and used a head based-formulation to represent compaction. The model of \cite{sneed2008} has been modified to use the effective stress formulation available in the CSUB package for \mf.
 

--- a/doc/sections/ex-gwf-csub-p04.tex
+++ b/doc/sections/ex-gwf-csub-p04.tex
@@ -1,4 +1,4 @@
-\section{CSUB Package Problem 4}
+\section{One-Dimensional Compaction in a Three-Dimensional Flow Field}
 
 This problem is based on the problem presented in the SUB-WT report \citep{leake2007modflow} and represent groundwater development in a hypothetical aquifer that includes some features typical of basin-fill aquifers in an arid or semi-arid environment. The problem of \cite{leake2007modflow} was modified to include compaction of coarse-grained aquifer materials and water compressibility. Specific stress packages were also modified but net inflows to the model domain are identical.
 

--- a/doc/sections/ex-gwf-drn-p01.tex
+++ b/doc/sections/ex-gwf-drn-p01.tex
@@ -1,4 +1,4 @@
-\section{Drain Package Drainage Discharge Scaling Option Problem 1}
+\section{Drainage Discharge Scaling}
 
 % Describe source of problem
 This example is a modified version of the Unsaturated Zone Flow (UZF) Package problem 2 described in \cite{UZF}. UZF Package problem 2 is based on the Green Valley problem (Streamflow Routing (SFR) Package problem 1) described in \cite{modflowsfr1pack}. The problem has been modified by converting all of the SFR reaches to use rectangular channels and to use the drain package drainage option to simulate groundwater discharge to the land surface.                               

--- a/doc/sections/ex-gwf-lgr.tex
+++ b/doc/sections/ex-gwf-lgr.tex
@@ -1,4 +1,4 @@
-\section{LGR2 Problem 3}
+\section{LGR with MVR and SFR}
 
 This example is based on LGR2 Problem 3 in \cite{mehl2013}, which includes two models arranged in a nested parent-child grid setup, where the parent model uses a coarse grid that surrounds the finely-gridded child model (Figure~\ref{fig:mvr_lgr_planview}).  Parent-child model setups limit grid refinement to localized regions of interest within large model domains to keep model runtimes to a minimum.  Owing to the relative ease of setup for this type of model arrangement in \mf, particularly when developing a model (i.e., simulation) with a support utility like flopy \citep{bakker2016}, the use of multi-model arrangements necessitates a generalized supporting package like MVR to transfer water among features within a simulation.  To demonstrate, this example uses MVR to cascade streamflow from an upstream SFR reach in the parent model to a downstream SFR reach in the child model.  Further downstream MVR again cascades streamflow from the last child model SFR reach to the appropriate SFR reach in the parent model.  
 

--- a/doc/sections/ex-gwf-maw-p01.tex
+++ b/doc/sections/ex-gwf-maw-p01.tex
@@ -1,4 +1,4 @@
-\section{Multi-Aquifer Well Package Problem 1}
+\section{Neville-Tonkin Multi-Aquifer Well Problem}
 
 % Describe source of problem
 This is the multi-aquifer well simulation described in \cite{nevilletonkin2004}. The example simulates an upper and lower aquifer separated by an impermeable confining unit but connected by a well that is open across both aquifers.                                

--- a/doc/sections/ex-gwf-maw-p02.tex
+++ b/doc/sections/ex-gwf-maw-p02.tex
@@ -1,4 +1,4 @@
-\section{Multi-Aquifer Well Package Problem 2}
+\section{Multi-Aquifer Well Problem, Flowing Well Option}
 
 % Describe source of problem
 This is a modified version of the multi-aquifer well simulation described in \cite{nevilletonkin2004}. The example simulates an upper and lower aquifer separated by an impermeable confining unit but connected by a well that is open across both aquifers. The multi-aquifer well uses the flowing well Multi-Aquifer Well (MAW) Package option to simulate discharge of water from the well at land surface.                               

--- a/doc/sections/ex-gwf-maw-p03.tex
+++ b/doc/sections/ex-gwf-maw-p03.tex
@@ -1,4 +1,4 @@
-\section{Multi-Aquifer Well Package Problem 3}
+\section{Reilly Multi-Aquifer Well Problem}
 
 % Describe source of problem
 This is the unstressed multi-aquifer well simulation described in \cite{reilly1989bias}. The example simulates a unconfined groundwater system that exhibits two-dimensional flow in vertical section and quantify the movement of water through a well under nonpumping conditions.                               

--- a/doc/sections/ex-gwf-sagehen.tex
+++ b/doc/sections/ex-gwf-sagehen.tex
@@ -1,4 +1,4 @@
-\section{Sagehen---UZF1 Package Problem 1}
+\section{Sagehen UZF1 Package Problem 1}
 
 The first test problem in \cite{UZF} presents a conceptual model of the Sagehen watershed that showcased the first version of the unsaturated-zone flow (UZF1) package. The Sagehen watershed is located on the eastern side of the northern Sierra Nevada, north of Lake Tahoe and the city of Truckee (see inset in figure~\ref{fig:sagehen}). The simulation spans the upper 27 $mi^2$ of the watershed.  The lowest land surface altitude of 1,928 $m$ above mean sea level occurs where Sagehen Creek exits the model.  The highest altitude of 2,649 $m$ above mean sea level occurs on the western-most crest of the watershed, resulting in roughly 720 $m$ of topographic relief across the watershed.  Figure~\ref{fig:sagehen} depicts the setting and topographic relief of the watershed. The geologic setting is primarily comprised of volcanic rocks overlain with a veneer of alluvium. Annual precipitation averages approximately 970 $mm$ which falls primarily in the form of snow.  
 

--- a/doc/sections/ex-gwt-gwtgwt-p10.tex
+++ b/doc/sections/ex-gwt-gwtgwt-p10.tex
@@ -1,4 +1,4 @@
-\section{MT3DMS Problem 10 Two Domains}
+\section{MT3DMS Problem 10, Two Domains}
 
 This example is based on problem 10 from the MT3DMS manual \citep{zheng1999mt3dms}. The goal in this example is not to compare the final results to the MT3DMS data presented there, but to show how to create an equivalent setup of that problem using a multi-model approach with the GWF-GWF and GWT-GWT Model Exchanges. To validate its outcome, we can compare the simulated concentration in the study area to the \mf results from the original example.
 

--- a/doc/sections/ex-prt-mp7-p01.tex
+++ b/doc/sections/ex-prt-mp7-p01.tex
@@ -1,4 +1,4 @@
-\section{Forward Tracking, Structured Grid, Steady-State Flow}
+\section{Forward Particle Tracking, Structured Grid, Steady-State Flow}
 
 This example demonstrates a MODFLOW 6 particle tracking (PRT) model by reproducing example problem 1 from the MODPATH 7 \citep{pollock2016modpath7} example problems document \citep{modpath7examples}. An equivalent MODPATH 7 model is constructed for comparison, though only PRT results are shown.
 

--- a/doc/sections/ex-prt-mp7-p02.tex
+++ b/doc/sections/ex-prt-mp7-p02.tex
@@ -1,4 +1,4 @@
-\section{Backward Tracking, Quad-Refined Grid, Steady-State Flow}
+\section{Backward Particle Tracking, Quad-Refined Grid, Steady-State Flow}
 
 This example demonstrates a MODFLOW 6 particle tracking (PRT) model by reproducing example problem 2 from the MODPATH 7 \citep{pollock2016modpath7} example problems document \citep{modpath7examples}. An equivalent MODPATH 7 model is constructed for comparison, though only PRT results are shown.
 

--- a/doc/sections/ex-prt-mp7-p03.tex
+++ b/doc/sections/ex-prt-mp7-p03.tex
@@ -1,4 +1,4 @@
-\section{Forward Tracking, Structured Grid, Transient Flow}
+\section{Forward Particle Tracking, Structured Grid, Transient Flow}
 
 This example demonstrates a MODFLOW 6 particle tracking (PRT) model by reproducing example problem 3 from the MODPATH 7 \citep{pollock2016modpath7} example problems document \citep{modpath7examples}. An equivalent MODPATH 7 model is constructed for comparison, though only PRT results are shown.
 

--- a/doc/sections/ex-prt-mp7-p04.tex
+++ b/doc/sections/ex-prt-mp7-p04.tex
@@ -1,4 +1,4 @@
-\section{Backward Tracking, Refined Grid, Lateral Flow Boundaries}
+\section{Backward Particle Tracking, Refined Grid, Lateral Flow Boundaries}
 
 This example demonstrates a MODFLOW 6 particle tracking (PRT) model by reproducing example problem 4 from the MODPATH 7 \citep{pollock2016modpath7} example problems document \citep{modpath7examples}. An equivalent MODPATH 7 model is constructed for comparison, though only PRT results are shown.
 

--- a/scripts/ex-gwf-advtidal.py
+++ b/scripts/ex-gwf-advtidal.py
@@ -1,4 +1,4 @@
-# ## Advgwtidal example
+# ## Tidal Model
 #
 # This model represents highlands bordered by a tidal estuary.  The model
 # has 3 layers representing an upper aquifer, confining bed, and lower aquifer.

--- a/scripts/ex-gwf-bcf2ss.py
+++ b/scripts/ex-gwf-bcf2ss.py
@@ -1,4 +1,4 @@
-# ## BCF2SS example
+# ## BCF2SS Model
 #
 # This problem is described in McDonald and Harbaugh (1988) and duplicated
 # in Harbaugh and McDonald (1996). This problem is also is distributed with

--- a/scripts/ex-gwf-csub-p01.py
+++ b/scripts/ex-gwf-csub-p01.py
@@ -1,9 +1,9 @@
-# ## Jacob (1939) Elastic Aquifer Loading
+# ## Elastic Aquifer Loading
 #
 # This problem simulates elastic compaction of aquifer materials in response to the
 # loading of an aquifer by a passing train. Water-level responses were simulated for
 # an eastbound train leaving the Smithtown Station in Long Island, New York at 13:04
-# on April 23, 1937
+# on April 23, 1937.
 
 # ### Initial setup
 #

--- a/scripts/ex-gwf-disvmesh.py
+++ b/scripts/ex-gwf-disvmesh.py
@@ -1,4 +1,4 @@
-# ## USG1DISV example
+# ## Circular Island with Triangular Mesh
 #
 # Demonstration of a triangular mesh with the DISV Package to discretize a
 # circular island with a radius of 1500 meters.  The model has 2 layers and

--- a/scripts/ex-gwf-drn-p01.py
+++ b/scripts/ex-gwf-drn-p01.py
@@ -1,4 +1,4 @@
-# ## Unsaturated Zone Flow (UZF) Package example 2
+# ## Drainage Discharge Scaling
 #
 # This is the unsaturated zone package example problem (test 2) from the
 # Unsaturated Zone Flow Package documentation (Niswonger and others, 2006).

--- a/scripts/ex-gwf-fhb.py
+++ b/scripts/ex-gwf-fhb.py
@@ -1,4 +1,4 @@
-# ## FHB example
+# ## Flow and Head Boundary (FHB) Package Replication
 #
 # This example shows how the time series capability in MODFLOW 6 can be
 # combined with the constant head and well packages to replicate the

--- a/scripts/ex-gwf-hani.py
+++ b/scripts/ex-gwf-hani.py
@@ -1,4 +1,4 @@
-# ## Hani example
+# ## Hani Problem
 #
 # Simple steady state model using a regular MODFLOW grid to simulate the
 # response of an anisotropic confined aquifer to a pumping well. A

--- a/scripts/ex-gwf-lak-p01.py
+++ b/scripts/ex-gwf-lak-p01.py
@@ -1,4 +1,4 @@
-# ## Lake package (LAK) example 1
+# ## Lake Package Problem 1
 #
 # This is the lake package example problem (test 1) from the
 # Lake Package documentation (Merritt and Konikow, 2000).

--- a/scripts/ex-gwf-lak-p02.py
+++ b/scripts/ex-gwf-lak-p02.py
@@ -1,4 +1,4 @@
-# ## Lake package (LAK) Package problem 2
+# ## Lake Package Problem 2
 #
 # This is the lake package example problem (test 2) from the
 # Lake Package documentation (Merritt and Konikow, 2000).

--- a/scripts/ex-gwf-lgr.py
+++ b/scripts/ex-gwf-lgr.py
@@ -1,4 +1,4 @@
-# ## LGR example with MVR for SFR between two models
+# ## LGR with MVR and SFR
 #
 # This script reproduces the model in Mehl and Hill (2013).
 

--- a/scripts/ex-gwf-lgrv.py
+++ b/scripts/ex-gwf-lgrv.py
@@ -1,4 +1,4 @@
-# ## LGRV example
+# ## Vilhelmsen LGR
 #
 # These are the models described in Vilhelmsen et al. (2012).  The parent
 # model is 9 layers, the child model is 25 layers.

--- a/scripts/ex-gwf-maw-p01.py
+++ b/scripts/ex-gwf-maw-p01.py
@@ -1,4 +1,4 @@
-# ## Neville-Tonkin Multi-Aquifer Well Problem,
+# ## Neville-Tonkin Multi-Aquifer Well Problem
 #
 # This is the Neville-Tonkin Multi-Aquifer Well from the
 # Lake Package documentation (Neville and Tonkin, 2004).

--- a/scripts/ex-gwf-maw-p02.py
+++ b/scripts/ex-gwf-maw-p02.py
@@ -1,4 +1,4 @@
-# ## Flowing well Multi-Aquifer Well Problem,
+# ## Multi-Aquifer Well Problem, Flowing Well Option
 #
 # This is a modified version of the Neville-Tonkin Multi-Aquifer Well problem
 # from Neville and Tonkin, 2004 that uses the flowing well option.

--- a/scripts/ex-gwf-maw-p03.py
+++ b/scripts/ex-gwf-maw-p03.py
@@ -1,4 +1,4 @@
-# ## Reilly multi-aquifer well example
+# ## Reilly Multi-Aquifer Well Problem
 #
 # This is the multi-aquifer well example from Reilly and others (1989).
 

--- a/scripts/ex-gwf-nwt-p02.py
+++ b/scripts/ex-gwf-nwt-p02.py
@@ -1,4 +1,4 @@
-# ## Flow diversion example
+# ## MODFLOW-NWT Problem 2
 #
 # This example is based on problem 2 in Niswonger et al 2011, which
 # used the Newton-Raphson formulation to simulate dry cells under a

--- a/scripts/ex-gwf-nwt-p03.py
+++ b/scripts/ex-gwf-nwt-p03.py
@@ -1,4 +1,4 @@
-# ## MODFLOW-NWT Problem 3 example
+# ## MODFLOW-NWT Problem 3
 #
 # This example is based on problem 3 in Niswonder et al 2011, which used
 # the Newton-Raphson formulation to simulate water levels in a rectangular,

--- a/scripts/ex-gwf-sfr-p01.py
+++ b/scripts/ex-gwf-sfr-p01.py
@@ -1,4 +1,4 @@
-# ## Streamflow Routing (SFR) Package Problem 1
+# ## Streamflow Routing Package Problem 1
 #
 # This is the stream-aquifer interaction example problem (test 1) from the
 # Streamflow Routing Package documentation (Prudic, 1989). All reaches have

--- a/scripts/ex-gwf-sfr-p01b.py
+++ b/scripts/ex-gwf-sfr-p01b.py
@@ -1,4 +1,4 @@
-# ## Streamflow Routing (SFR) Package problem 1 with MVR applied among advanced packages
+# ## Advanced Packages with MVR
 #
 # This is the stream-aquifer interaction example problem (test 1) from the
 # Streamflow Routing Package documentation (Prudic, 1989) with a couple of

--- a/scripts/ex-gwt-gwtgwt-p10.py
+++ b/scripts/ex-gwt-gwtgwt-p10.py
@@ -1,4 +1,4 @@
-# ## MT3DMS Problem 10 Two Domains
+# ## MT3DMS Problem 10, Two Domains
 #
 # The purpose of this example is to demonstrate the model setup for
 # a coupled GWF-GWT simulation with submodels. It replicates the

--- a/scripts/ex-prt-mp7-p01.py
+++ b/scripts/ex-prt-mp7-p01.py
@@ -1,4 +1,4 @@
-# ## Forward Tracking, Structured Grid, Steady-State Flow
+# ## Forward Particle Tracking, Structured Grid, Steady-State Flow
 #
 # Application of a MODFLOW 6 particle-tracking (PRT) model
 # and a MODPATH 7 (MP7) model to solve example 1 from the

--- a/scripts/ex-prt-mp7-p02.py
+++ b/scripts/ex-prt-mp7-p02.py
@@ -1,4 +1,4 @@
-# ## Backward Tracking, Quad-Refined Grid, Steady-State Flow
+# ## Backward Particle Tracking, Quad-Refined Grid, Steady-State Flow
 #
 # Application of a MODFLOW 6 particle-tracking (PRT) model
 # and a MODPATH 7 (MP7) model to solve example 2 from the

--- a/scripts/ex-prt-mp7-p03.py
+++ b/scripts/ex-prt-mp7-p03.py
@@ -1,4 +1,4 @@
-# ## Forward Tracking, Structured Grid, Transient Flow
+# ## Forward Particle Tracking, Structured Grid, Transient Flow
 #
 # Application of a MODFLOW 6 particle-tracking (PRT)
 # model and a MODPATH 7 (MP7) model to solve example

--- a/scripts/ex-prt-mp7-p04.py
+++ b/scripts/ex-prt-mp7-p04.py
@@ -1,4 +1,4 @@
-# ## Backward Tracking, Refined Grid, Lateral Flow Boundaries
+# ## Backward Particle Tracking, Refined Grid, Lateral Flow Boundaries
 #
 # Application of a MODFLOW 6 particle-tracking (PRT) model
 # to solve example 4 from the MODPATH 7 documentation.


### PR DESCRIPTION
* followup to #183 which started but did not finish the job
* also "Forward/Backward Tracking..." -> "Forward/Backward Particle Tracking..." in PRT names