### PR TITLE
fix(gwe-examples): reduce bloat

### DIFF
--- a/scripts/ex-gwe-geotherm.py
+++ b/scripts/ex-gwe-geotherm.py
@@ -1012,4 +1012,4 @@ def scenario(idx, silent=False):
 # -
 
 # Run the scenario
-scenario(0)
+scenario(0, silent=True)

--- a/scripts/ex-gwe-radial.py
+++ b/scripts/ex-gwe-radial.py
@@ -1101,4 +1101,4 @@ def scenario(idx, silent=False):
 
 # Run the scenario.
 
-scenario(0)
+scenario(0, silent=True)


### PR DESCRIPTION
MF6 runtime output written to the cmd prompt was showing up in the notebooks published online; it shouldn't be