### PR TITLE
fix: use relative paths in fmi input files

### DIFF
--- a/scripts/ex-gwe-prt.py
+++ b/scripts/ex-gwe-prt.py
@@ -385,8 +385,16 @@ def build_prt_sim(name):
     )
 
     pd = [
-        ("GWFHEAD", gwf_ws / f"{gwf_name}.hds", None),
-        ("GWFBUDGET", gwf_ws / f"{gwf_name}.cbc", None),
+        (
+            "GWFHEAD",
+            (gwf_ws / f"{gwf_name}.hds").relative_to(prt_ws, walk_up=True),
+            None,
+        ),
+        (
+            "GWFBUDGET",
+            (gwf_ws / f"{gwf_name}.cbc").relative_to(prt_ws, walk_up=True),
+            None,
+        ),
     ]
 
     flopy.mf6.ModflowPrtfmi(

--- a/scripts/ex-gwe-prt.py
+++ b/scripts/ex-gwe-prt.py
@@ -387,12 +387,12 @@ def build_prt_sim(name):
     pd = [
         (
             "GWFHEAD",
-            (gwf_ws / f"{gwf_name}.hds").relative_to(prt_ws, walk_up=True),
+            pl.Path(f"../{gwf_ws.name}/{gwf_name}.hds"),
             None,
         ),
         (
             "GWFBUDGET",
-            (gwf_ws / f"{gwf_name}.cbc").relative_to(prt_ws, walk_up=True),
+            pl.Path(f"../{gwf_ws.name}/{gwf_name}.cbc"),
             None,
         ),
     ]

--- a/scripts/ex-prt-mp7-p01.py
+++ b/scripts/ex-prt-mp7-p01.py
@@ -367,8 +367,8 @@ def build_models(example_name):
 
     # Instantiate the MODFLOW 6 prt flow model interface
     pd = [
-        ("GWFHEAD", gwf_ws / headfile),
-        ("GWFBUDGET", gwf_ws / budgetfile),
+        ("GWFHEAD", (gwf_ws / headfile).relative_to(prt_ws, walk_up=True)),
+        ("GWFBUDGET", (gwf_ws / budgetfile).relative_to(prt_ws, walk_up=True)),
     ]
     flopy.mf6.ModflowPrtfmi(prt, packagedata=pd)
 

--- a/scripts/ex-prt-mp7-p01.py
+++ b/scripts/ex-prt-mp7-p01.py
@@ -367,8 +367,8 @@ def build_models(example_name):
 
     # Instantiate the MODFLOW 6 prt flow model interface
     pd = [
-        ("GWFHEAD", (gwf_ws / headfile).relative_to(prt_ws, walk_up=True)),
-        ("GWFBUDGET", (gwf_ws / budgetfile).relative_to(prt_ws, walk_up=True)),
+        ("GWFHEAD", pl.Path(f"../{gwf_ws.name}/{headfile}")),
+        ("GWFBUDGET", pl.Path(f"../{gwf_ws.name}/{budgetfile}")),
     ]
     flopy.mf6.ModflowPrtfmi(prt, packagedata=pd)
 

--- a/scripts/ex-prt-mp7-p02.py
+++ b/scripts/ex-prt-mp7-p02.py
@@ -462,8 +462,8 @@ def build_prt_sim():
     # Instantiate the MODFLOW 6 prt flow model interface
     # using "time-reversed" budget and head files
     pd = [
-        ("GWFHEAD", headfile_bkwd),
-        ("GWFBUDGET", budgetfile_bkwd),
+        ("GWFHEAD", (gwf_ws / headfile_bkwd).relative_to(prt_ws, walk_up=True)),
+        ("GWFBUDGET", (gwf_ws / budgetfile_bkwd).relative_to(prt_ws, walk_up=True)),
     ]
     flopy.mf6.ModflowPrtfmi(prt, packagedata=pd)
 
@@ -546,8 +546,8 @@ def run_models(*sims, silent=False):
 
         if "gwf" in sim.name:
             # Reverse budget and head files for backward tracking
-            reverse_budgetfile(gwf_ws / budgetfile, prt_ws / budgetfile_bkwd, sim.tdis)
-            reverse_headfile(gwf_ws / headfile, prt_ws / headfile_bkwd, sim.tdis)
+            reverse_budgetfile(gwf_ws / budgetfile, gwf_ws / budgetfile_bkwd, sim.tdis)
+            reverse_headfile(gwf_ws / headfile, gwf_ws / headfile_bkwd, sim.tdis)
 
 
 # -

--- a/scripts/ex-prt-mp7-p02.py
+++ b/scripts/ex-prt-mp7-p02.py
@@ -462,8 +462,8 @@ def build_prt_sim():
     # Instantiate the MODFLOW 6 prt flow model interface
     # using "time-reversed" budget and head files
     pd = [
-        ("GWFHEAD", (gwf_ws / headfile_bkwd).relative_to(prt_ws, walk_up=True)),
-        ("GWFBUDGET", (gwf_ws / budgetfile_bkwd).relative_to(prt_ws, walk_up=True)),
+        ("GWFHEAD", pl.Path(f"../{gwf_ws.name}/{headfile_bkwd}")),
+        ("GWFBUDGET", pl.Path(f"../{gwf_ws.name}/{budgetfile_bkwd}")),
     ]
     flopy.mf6.ModflowPrtfmi(prt, packagedata=pd)
 

--- a/scripts/ex-prt-mp7-p03.py
+++ b/scripts/ex-prt-mp7-p03.py
@@ -431,8 +431,8 @@ def build_prt_model():
     flopy.mf6.ModflowPrtfmi(
         prt,
         packagedata=[
-            ("GWFHEAD", gwf_ws / headfile),
-            ("GWFBUDGET", gwf_ws / budgetfile),
+            ("GWFHEAD", (gwf_ws / headfile).relative_to(prt_ws, walk_up=True)),
+            ("GWFBUDGET", (gwf_ws / budgetfile).relative_to(prt_ws, walk_up=True)),
         ],
     )
 

--- a/scripts/ex-prt-mp7-p03.py
+++ b/scripts/ex-prt-mp7-p03.py
@@ -431,8 +431,8 @@ def build_prt_model():
     flopy.mf6.ModflowPrtfmi(
         prt,
         packagedata=[
-            ("GWFHEAD", (gwf_ws / headfile).relative_to(prt_ws, walk_up=True)),
-            ("GWFBUDGET", (gwf_ws / budgetfile).relative_to(prt_ws, walk_up=True)),
+            ("GWFHEAD", pl.Path(f"../{gwf_ws.name}/{headfile}")),
+            ("GWFBUDGET", pl.Path(f"../{gwf_ws.name}/{budgetfile}")),
         ],
     )
 

--- a/scripts/ex-prt-mp7-p04.py
+++ b/scripts/ex-prt-mp7-p04.py
@@ -609,8 +609,8 @@ def build_prt():
     flopy.mf6.ModflowPrtfmi(
         prt,
         packagedata=[
-            ("GWFHEAD", headfile_bkwd),
-            ("GWFBUDGET", budgetfile_bkwd),
+            ("GWFHEAD", (gwf_ws / headfile_bkwd).relative_to(prt_ws, walk_up=True)),
+            ("GWFBUDGET", (gwf_ws / budgetfile_bkwd).relative_to(prt_ws, walk_up=True)),
         ],
     )
 
@@ -690,8 +690,8 @@ def run_models(*sims, silent=False):
 
         if "gwf" in sim.name:
             # Reverse budget and head files for backward tracking
-            reverse_budgetfile(gwf_ws / budgetfile, prt_ws / budgetfile_bkwd, sim.tdis)
-            reverse_headfile(gwf_ws / headfile, prt_ws / headfile_bkwd, sim.tdis)
+            reverse_budgetfile(gwf_ws / budgetfile, gwf_ws / budgetfile_bkwd, sim.tdis)
+            reverse_headfile(gwf_ws / headfile, gwf_ws / headfile_bkwd, sim.tdis)
 
 
 # -

--- a/scripts/ex-prt-mp7-p04.py
+++ b/scripts/ex-prt-mp7-p04.py
@@ -609,8 +609,8 @@ def build_prt():
     flopy.mf6.ModflowPrtfmi(
         prt,
         packagedata=[
-            ("GWFHEAD", (gwf_ws / headfile_bkwd).relative_to(prt_ws, walk_up=True)),
-            ("GWFBUDGET", (gwf_ws / budgetfile_bkwd).relative_to(prt_ws, walk_up=True)),
+            ("GWFHEAD", pl.Path(f"../{gwf_ws.name}/{headfile_bkwd}")),
+            ("GWFBUDGET", pl.Path(f"../{gwf_ws.name}/{budgetfile_bkwd}")),
         ],
     )
 


### PR DESCRIPTION
Absolute paths were written to `.fmi` files, make them relative