### PR TITLE
ci: build mf6 instead of installing nightly build

### DIFF
--- a/.github/workflows/ex-rtd.yml
+++ b/.github/workflows/ex-rtd.yml
@@ -87,9 +87,10 @@ jobs:
       - name: Build MODFLOW 6
         working-directory: modflow6
         run: |
-          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=$(dirname $(which mf6))
+          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
           meson install -C builddir
           meson test --verbose --no-rebuild -C builddir
+          cp bin/* ~/.local/bin/modflow/
       
       - name: Create notebooks and run models
         working-directory: modflow6-examples/autotest

--- a/.github/workflows/ex-rtd.yml
+++ b/.github/workflows/ex-rtd.yml
@@ -28,6 +28,14 @@ jobs:
 
       - name: Checkout MODFLOW6 examples repo
         uses: actions/checkout@v4
+        with:
+          path: modflow6-examples
+
+      - name: Checkout MODFLOW 6
+        uses: actions/checkout@v4
+        with:
+          repository: MODFLOW-USGS/modflow6
+          path: modflow6
 
       - name: Output repo information
         run: |
@@ -60,7 +68,7 @@ jobs:
         uses: pyvista/setup-headless-display-action@v2
 
       - name: Install Python packages
-        working-directory: etc
+        working-directory: modflow6-examples/etc
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install -r requirements.pip.txt
@@ -73,30 +81,35 @@ jobs:
       - name: Install MODFLOW executables release
         uses: modflowpy/install-modflow-action@v1
 
-      - name: Install MODFLOW 6 development build
-        uses: modflowpy/install-modflow-action@v1
-        with:
-          repo: modflow6-nightly-build
+      - name: Build MODFLOW 6
+        working-directory: modflow6
+        run: |
+          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
+          meson install -C builddir
+          meson test --verbose --no-rebuild -C builddir
       
       - name: Create notebooks and run models
-        working-directory: autotest
+        working-directory: modflow6-examples/autotest
         run: pytest -v -n=auto --durations=0 test_notebooks.py --plot
 
       - name: Run processing script
-        working-directory: scripts
+        working-directory: modflow6-examples/scripts
         run: python process-scripts.py
 
       - name: Create package tables and examples.rst for ReadtheDocs
-        working-directory: etc
+        working-directory: modflow6-examples/etc
         run: python ci_create_examples_rst.py
 
       - name: List example rst files for ReadtheDocs
+        working-directory: modflow6-examples
         run: ls -R .doc/_examples/
 
       - name: List example image files for ReadtheDocs
+        working-directory: modflow6-examples
         run: ls -R .doc/_images/
 
       - name: List example notebook files for ReadtheDocs
+        working-directory: modflow6-examples
         run: ls -R .doc/_notebooks/
 
       - name: Upload completed jupyter notebooks as an artifact for ReadtheDocs
@@ -104,11 +117,11 @@ jobs:
         with:
           name: rtd-files-for-${{ github.sha }}
           path: |
-            .doc/introduction.md
-            .doc/examples.rst
-            .doc/_examples
-            .doc/_images
-            .doc/_notebooks
+            modflow6-examples/.doc/introduction.md
+            modflow6-examples/.doc/examples.rst
+            modflow6-examples/.doc/_examples
+            modflow6-examples/.doc/_images
+            modflow6-examples/.doc/_notebooks
 
   # trigger rtd if "rtd_build" job was successful
   rtd_trigger:

--- a/.github/workflows/ex-rtd.yml
+++ b/.github/workflows/ex-rtd.yml
@@ -81,9 +81,6 @@ jobs:
       - name: Install MODFLOW executables release
         uses: modflowpy/install-modflow-action@v1
 
-      # - name: Setup tmate session
-      #   uses: mxschmitt/action-tmate@v3
-
       - name: Build MODFLOW 6
         working-directory: modflow6
         run: |

--- a/.github/workflows/ex-rtd.yml
+++ b/.github/workflows/ex-rtd.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Build MODFLOW 6
         working-directory: modflow6
         run: |
-          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
+          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=$(dirname $(which mf6))
           meson install -C builddir
           meson test --verbose --no-rebuild -C builddir
       

--- a/.github/workflows/ex-rtd.yml
+++ b/.github/workflows/ex-rtd.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Install MODFLOW executables release
         uses: modflowpy/install-modflow-action@v1
 
+      # - name: Setup tmate session
+      #   uses: mxschmitt/action-tmate@v3
+
       - name: Build MODFLOW 6
         working-directory: modflow6
         run: |

--- a/.github/workflows/ex-workflow.yml
+++ b/.github/workflows/ex-workflow.yml
@@ -79,12 +79,13 @@ jobs:
       - name: Install MODFLOW executables release
         uses: modflowpy/install-modflow-action@v1
 
-      - name: Build MODFLOW 6
+      - name: Build and copy MODFLOW 6
         working-directory: modflow6
         run: |
-          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=$(dirname $(which mf6))
+          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
           meson install -C builddir
           meson test --verbose --no-rebuild -C builddir
+          cp bin/* ~/.local/bin/modflow/
 
       - name: Create model
         working-directory: modflow6-examples/autotest
@@ -165,12 +166,13 @@ jobs:
       - name: Install MODFLOW executables release
         uses: modflowpy/install-modflow-action@v1
 
-      - name: Build MODFLOW 6
+      - name: Build and copy MODFLOW 6
         working-directory: modflow6
         run: |
-          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=$(dirname $(which mf6))
+          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
           meson install -C builddir
           meson test --verbose --no-rebuild -C builddir
+          cp bin/* ~/.local/bin/modflow/
 
       - name: Test example scripts and create input files
         working-directory: modflow6-examples/autotest

--- a/.github/workflows/ex-workflow.yml
+++ b/.github/workflows/ex-workflow.yml
@@ -50,6 +50,14 @@ jobs:
     steps:
       - name: Checkout MODFLOW6 examples repo
         uses: actions/checkout@v4
+        with:
+          path: modflow6-examples
+
+      - name: Checkout MODFLOW 6 repo
+        uses: actions/checkout@v4
+        with:
+          repository: MODFLOW-USGS/modflow6
+          path: modflow6
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -57,7 +65,7 @@ jobs:
           python-version: 3.9
 
       - name: Install Python packages
-        working-directory: etc
+        working-directory: modflow6-examples/etc
         run: |
           python --version
           python -m pip install --upgrade pip setuptools wheel
@@ -68,20 +76,20 @@ jobs:
       - name: Update flopy MODFLOW 6 classes
         run: python -m flopy.mf6.utils.generate_classes --ref develop --no-backup
 
-      - name: Install MODFLOW executables release
-        uses: modflowpy/install-modflow-action@v1
-
-      - name: Install MODFLOW 6 development build
-        uses: modflowpy/install-modflow-action@v1
-        with:
-          repo: modflow6-nightly-build
+      - name: Build MODFLOW 6
+        working-directory: modflow6
+        run: |
+          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
+          meson install -C builddir
+          meson test --verbose --no-rebuild -C builddir
 
       - name: Create model
-        working-directory: autotest
+        working-directory: modflow6-examples/autotest
         # run the scripts via pytest without running the models, just build input files
         run: pytest -v -n=auto --durations=0 test_scripts.py --init
 
       - name: zip input files
+        working-directory: modflow6-examples
         run: |
           import shutil
           shutil.make_archive("modflow6-examples", "zip", "examples")
@@ -91,7 +99,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: zip_files
-          path: ./modflow6-examples.zip
+          path: ./modflow6-examples/modflow6-examples.zip
 
   build:
     name: current-build

--- a/.github/workflows/ex-workflow.yml
+++ b/.github/workflows/ex-workflow.yml
@@ -119,6 +119,14 @@ jobs:
     steps:
       - name: Checkout MODFLOW6 examples repo
         uses: actions/checkout@v4
+        with:
+          path: modflow6-examples
+
+      - name: Checkout MODFLOW 6 repo
+        uses: actions/checkout@v4
+        with:
+          repository: MODFLOW-USGS/modflow6
+          path: modflow6
 
       - name: Install TeX Live and additional TrueType fonts
         run: |
@@ -144,7 +152,7 @@ jobs:
         uses: pyvista/setup-headless-display-action@v2
 
       - name: Install Python packages
-        working-directory: etc
+        working-directory: modflow6-examples/etc
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install -r requirements.pip.txt
@@ -157,26 +165,29 @@ jobs:
       - name: Install MODFLOW executables release
         uses: modflowpy/install-modflow-action@v1
 
-      - name: Install MODFLOW 6 development build
-        uses: modflowpy/install-modflow-action@v1
-        with:
-          repo: modflow6-nightly-build
+      - name: Build MODFLOW 6
+        working-directory: modflow6
+        run: |
+          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=$(dirname $(which mf6))
+          meson install -C builddir
+          meson test --verbose --no-rebuild -C builddir
 
       - name: Test example scripts and create input files
-        working-directory: autotest
+        working-directory: modflow6-examples/autotest
         run: pytest -v -n=auto --durations=0 test_scripts.py --plot
 
       - name: Run processing script
-        working-directory: scripts
+        working-directory: modflow6-examples/scripts
         if: matrix.python == '3.9'
         run: python process-scripts.py
 
       - name: Build mf6examples LaTeX document
-        working-directory: doc
+        working-directory: modflow6-examples/doc
         if: matrix.python == '3.9'
         run: ./build-pdf.sh
 
       - name: Rename and move the LaTeX document
+        working-directory: modflow6-examples
         if: matrix.python == '3.9'
         run: |
           ls -l ./doc/
@@ -188,7 +199,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: current
-          path: mf6examples.pdf
+          path: modflow6-examples/mf6examples.pdf
 
   # make the release if the "build" job was successful
   release:

--- a/.github/workflows/ex-workflow.yml
+++ b/.github/workflows/ex-workflow.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Build MODFLOW 6
         working-directory: modflow6
         run: |
-          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
+          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=$(dirname $(which mf6))
           meson install -C builddir
           meson test --verbose --no-rebuild -C builddir
 

--- a/.github/workflows/ex-workflow.yml
+++ b/.github/workflows/ex-workflow.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Update flopy MODFLOW 6 classes
         run: python -m flopy.mf6.utils.generate_classes --ref develop --no-backup
 
+      - name: Install MODFLOW executables release
+        uses: modflowpy/install-modflow-action@v1
+
       - name: Build MODFLOW 6
         working-directory: modflow6
         run: |

--- a/autotest/pytest.ini
+++ b/autotest/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = --color=yes
+python_files =
+    test_*.py

--- a/etc/requirements.pip.txt
+++ b/etc/requirements.pip.txt
@@ -23,3 +23,5 @@ pooch
 GitPython
 pyvista
 ruff
+meson
+ninja

--- a/scripts/ex-gwe-prt.py
+++ b/scripts/ex-gwe-prt.py
@@ -382,7 +382,6 @@ def build_prt_sim(name):
         pname="oc",
         track_filerecord=[prt_track_file],
         trackcsv_filerecord=[prt_track_csv_file],
-        track_all=True,
     )
 
     pd = [

--- a/scripts/ex-prt-mp7-p01.py
+++ b/scripts/ex-prt-mp7-p01.py
@@ -362,7 +362,6 @@ def build_models(example_name):
         budget_filerecord=budget_record,
         track_filerecord=track_record,
         trackcsv_filerecord=trackcsv_record,
-        track_all=True,
         track_timesrecord=tracktimes,
         saverecord=[("BUDGET", "ALL")],
     )

--- a/scripts/ex-prt-mp7-p02.py
+++ b/scripts/ex-prt-mp7-p02.py
@@ -455,7 +455,6 @@ def build_prt_sim():
         budget_filerecord=budget_record,
         track_filerecord=track_record,
         trackcsv_filerecord=trackcsv_record,
-        track_all=False,
         track_timesrecord=tracktimes,
         saverecord=[("BUDGET", "ALL")],
     )


### PR DESCRIPTION
allow more synchronized development, previously we needed to wait for the nightly build