### PR TITLE
fix(ex-gwe-prt): fix figsize for embedding in pdf doc

### DIFF
--- a/scripts/ex-gwe-prt.py
+++ b/scripts/ex-gwe-prt.py
@@ -495,7 +495,7 @@ def plot_results(gwf_sim, gwe_sim, prt_sim, silent=True):
         fig, axes = plt.subplots(
             3,
             1,
-            figsize=(7, 9),
+            figsize=(6, 7),
             tight_layout=True,
             gridspec_kw={"height_ratios": [3, 1, 1]},
         )


### PR DESCRIPTION
This figure was getting cut off:

<img width="647" alt="Screenshot 2024-05-23 at 12 28 26 PM" src="https://github.com/MODFLOW-USGS/modflow6-examples/assets/10502868/180113ca-6257-4aac-906b-c44317b24213">

Fixed version with reduced `figsize`:

<img width="665" alt="Screenshot 2024-05-23 at 12 51 08 PM" src="https://github.com/MODFLOW-USGS/modflow6-examples/assets/10502868/bd9b9527-7f99-479c-b0bd-18ad27fbfefc">

I'm not sure why the legend moved as a result of re-scaling.

In the future I wonder if we could scale figures via latex instead of relying on the pre-existing size of the embedded figure.