### PR TITLE
fix(ex-gwe-ates, ex-gwe-vsc): suppress output in notebooks

### DIFF
--- a/scripts/ex-gwe-ates.py
+++ b/scripts/ex-gwe-ates.py
@@ -985,5 +985,5 @@ def scenario(idx, silent=True):
 
 # +
 # Initiate model construction, write, run, and plot sequence
-scenario(0, silent=False)
+scenario(0, silent=True)
 # -

--- a/scripts/ex-gwe-vsc.py
+++ b/scripts/ex-gwe-vsc.py
@@ -782,11 +782,9 @@ def scenario(idx, silent=True):
 # +
 # Compares the solute plume with and without accounting for viscosity in a
 # 30 deg C temperature gradient (4 deg C top, 34 deg C bottom)
-scenario(0, silent=False)
+scenario(0, silent=True)
 
 # Compares the solute plume with and without accounting for viscosity in a
 # 90 deg C temperature gradient (4 deg C top, 94 deg C bottom)
-scenario(1, silent=False)
-# -
-
+scenario(1, silent=True)
 # -


### PR DESCRIPTION
- new gwe notebooks auto-generated from corresponding scripts (#206 & #209) include unnecessary FloPy and MODFLOW 6 output.  Need to toggle output flag (`silent=True`)
- ran ruff