### PR TITLE
fix(ex-prt-mp7-*): suppress output in notebooks

### DIFF
--- a/scripts/ex-prt-mp7-p01.py
+++ b/scripts/ex-prt-mp7-p01.py
@@ -995,4 +995,4 @@ def scenario(silent=False):
 
 
 # We are now ready to run the example problem. Subproblems 1A and 1B are solved by a single MODFLOW 6 run and a single MODPATH 7 run, so they are included under one "scenario". Each of the two subproblems is represented by its own particle release package (for MODFLOW 6) or particle group (for MODPATH 7).
-scenario(silent=False)
+scenario(silent=True)

--- a/scripts/ex-prt-mp7-p03.py
+++ b/scripts/ex-prt-mp7-p03.py
@@ -952,4 +952,4 @@ def scenario(silent=False):
 
 # Run the MODPATH 7 example problem 3 scenario.
 
-scenario(silent=False)
+scenario(silent=True)


### PR DESCRIPTION
Following up on #210 as the convention seems to be silencing output.