### PR TITLE
fix(ex-gwe-*): update est package input after dropping PACKAGEDATA block

### DIFF
--- a/scripts/ex-gwe-ates.py
+++ b/scripts/ex-gwe-ates.py
@@ -1,4 +1,4 @@
-# ## Aquifer thermal energy storage (ATES) example
+# ## Aquifer thermal energy storage (ATES)
 #
 # Application of a MODFLOW 6 groundwater energy transport (GWE) model to
 # simulate a aquifer thermal energy storage (ATES) for storing (or
@@ -711,9 +711,11 @@ def build_model(sim_name, verts, cell2d, top, botm):
     flopy.mf6.ModflowGweest(
         gwe,
         porosity=prsity,
+        heat_capacity_water=cpw,
+        density_water=rhow,
+        latent_heat_vaporization=lhv,
         cps=cps,
         rhos=rhos,
-        packagedata=[cpw, rhow, lhv],
         pname="EST",
         filename="{}.est".format(gwename),
     )

--- a/scripts/ex-gwe-danckwerts.py
+++ b/scripts/ex-gwe-danckwerts.py
@@ -416,9 +416,11 @@ def build_model(sim_name):
         gwe,
         save_flows=True,
         porosity=prsity,
+        heat_capacity_water=cpw,
+        density_water=rhow,
+        latent_heat_vaporization=lhv,
         cps=cps,
         rhos=rhos,
-        packagedata=[cpw, rhow, lhv],
         pname="EST",
         filename=f"{gwename}.est",
     )

--- a/scripts/ex-gwe-geotherm.py
+++ b/scripts/ex-gwe-geotherm.py
@@ -662,9 +662,11 @@ def build_mf6_heat_model(sim_name, dirichlet=0.0, neumann=0.0, silent=False):
     flopy.mf6.ModflowGweest(
         gwe,
         porosity=prsity,
+        heat_capacity_water=cpw,
+        density_water=rhow,
+        latent_heat_vaporization=lhv,
         cps=cps,
         rhos=rhos,
-        packagedata=[cpw, rhow, lhv],
         pname="EST",
         filename="{}.est".format(gwename),
     )

--- a/scripts/ex-gwe-prt.py
+++ b/scripts/ex-gwe-prt.py
@@ -306,9 +306,11 @@ def build_gwe_sim(name):
     flopy.mf6.ModflowGweest(
         gwe,
         porosity=porosity,
+        heat_capacity_water=cpw,
+        density_water=rhow,
+        latent_heat_vaporization=lhv,
         cps=cps,
         rhos=rhos,
-        packagedata=[cpw, rhow, lhv],
         pname="EST-e",
         filename="{}.est".format(gwe_name),
     )

--- a/scripts/ex-gwe-radial.py
+++ b/scripts/ex-gwe-radial.py
@@ -761,9 +761,11 @@ def build_mf6_heat_model(
     flopy.mf6.ModflowGweest(
         gwe,
         porosity=prsity,
+        heat_capacity_water=cpw,
+        density_water=rhow,
+        latent_heat_vaporization=lhv,
         cps=cps,
         rhos=rhos,
-        packagedata=[cpw, rhow, lhv],
         pname="EST",
         filename="{}.est".format(gwename),
     )

--- a/scripts/ex-gwe-vsc.py
+++ b/scripts/ex-gwe-vsc.py
@@ -481,9 +481,11 @@ def add_gwe_model(sim, gwename, temp_upper=4.0, temp_lower=4.0):
         gwe,
         save_flows=True,
         porosity=prsity,
+        heat_capacity_water=cpw,
+        density_water=rhow,
+        latent_heat_vaporization=lhv,
         cps=cps,
         rhos=rhos,
-        packagedata=[cpw, rhow, lhv],
         pname="EST",
         filename="{}.est".format(gwename),
     )


### PR DESCRIPTION
These changes are a result of [#1882](https://github.com/MODFLOW-USGS/modflow6/pull/1882) over on the [MODFLOW 6](https://github.com/MODFLOW-USGS/modflow6) repo.  The changes implemented therein do not accommodate backward compatibility.