### PR TITLE
refactor: enable extended tracking in prt examples

### DIFF
--- a/scripts/ex-gwe-prt.py
+++ b/scripts/ex-gwe-prt.py
@@ -384,6 +384,7 @@ def build_prt_sim(name):
         boundnames=True,
         stop_at_weak_sink=True,  # currently required for this problem
         exit_solve_tolerance=1e-10,
+        extend_tracking=True,
     )
     prt_track_file = f"{prt_name}.trk"
     prt_track_csv_file = f"{prt_name}.trk.csv"

--- a/scripts/ex-prt-mp7-p01.py
+++ b/scripts/ex-prt-mp7-p01.py
@@ -334,6 +334,7 @@ def build_models(example_name):
             0: ["FIRST"],
         },
         exit_solve_tolerance=1e-5,
+        extend_tracking=True,
     )
 
     # Instantiate the MODFLOW 6 prt particle release point (prp) package for example 1B,

--- a/scripts/ex-prt-mp7-p03.py
+++ b/scripts/ex-prt-mp7-p03.py
@@ -412,6 +412,7 @@ def build_prt_model():
         # coord from cell top if saturated or water table if not
         local_z=True,
         exit_solve_tolerance=1e-5,
+        extend_tracking=True,
     )
 
     # Instantiate the MODFLOW 6 prt output control package


### PR DESCRIPTION
This is necessary as of https://github.com/MODFLOW-USGS/modflow6/pull/1888.