### PR TITLE
perf(ex-gwt-mt3dsupp82): reduce percent discrepancy to 0.0

### DIFF
--- a/scripts/ex-gwt-mt3dsupp82.py
+++ b/scripts/ex-gwt-mt3dsupp82.py
@@ -84,7 +84,7 @@ def build_mf6gwf(sim_folder):
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     tdis_ds = ((total_time, 1, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
-    flopy.mf6.ModflowIms(sim)
+    flopy.mf6.ModflowIms(sim, inner_dvclose=1.00e-4)
     gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)
     flopy.mf6.ModflowGwfdis(
         gwf,


### PR DESCRIPTION
Per @rbwinst-usgs's comment [here](https://github.com/MODFLOW-USGS/modflow6/issues/1912) (MODFLOW6 main repo #1912), specifying the head closure to be 0.0001 reduces to the percent discrepancy from 0.31 to 0.0.