### PR TITLE
perf(ex-gwt-moc3d-p02tg): reduce percent discrepancy in flow model

### DIFF
--- a/scripts/ex-gwt-moc3d-p02tg.py
+++ b/scripts/ex-gwt-moc3d-p02tg.py
@@ -212,6 +212,7 @@ def build_mf6gwf(sim_folder):
         sim,
         print_option="summary",
         inner_maximum=300,
+        inner_dvclose=1e-4,
         linear_acceleration="bicgstab",
     )
     gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)


### PR DESCRIPTION
An easy fix per @rbwinst-usgs's [#1913](https://github.com/MODFLOW-USGS/modflow6/issues/1913) on the main [MODFLOW 6 repo](https://github.com/MODFLOW-USGS/modflow6)