### PR TITLE
fix(ex-gwe-*): update est package input after updating variable names in GRIDDATA block

### DIFF
--- a/scripts/ex-gwe-ates.py
+++ b/scripts/ex-gwe-ates.py
@@ -714,8 +714,8 @@ def build_model(sim_name, verts, cell2d, top, botm):
         heat_capacity_water=cpw,
         density_water=rhow,
         latent_heat_vaporization=lhv,
-        cps=cps,
-        rhos=rhos,
+        heat_capacity_solid=cps,
+        density_solid=rhos,
         pname="EST",
         filename="{}.est".format(gwename),
     )

--- a/scripts/ex-gwe-danckwerts.py
+++ b/scripts/ex-gwe-danckwerts.py
@@ -419,8 +419,8 @@ def build_model(sim_name):
         heat_capacity_water=cpw,
         density_water=rhow,
         latent_heat_vaporization=lhv,
-        cps=cps,
-        rhos=rhos,
+        heat_capacity_solid=cps,
+        density_solid=rhos,
         pname="EST",
         filename=f"{gwename}.est",
     )

--- a/scripts/ex-gwe-geotherm.py
+++ b/scripts/ex-gwe-geotherm.py
@@ -665,8 +665,8 @@ def build_mf6_heat_model(sim_name, dirichlet=0.0, neumann=0.0, silent=False):
         heat_capacity_water=cpw,
         density_water=rhow,
         latent_heat_vaporization=lhv,
-        cps=cps,
-        rhos=rhos,
+        heat_capacity_solid=cps,
+        density_solid=rhos,
         pname="EST",
         filename="{}.est".format(gwename),
     )

--- a/scripts/ex-gwe-prt.py
+++ b/scripts/ex-gwe-prt.py
@@ -309,8 +309,8 @@ def build_gwe_sim(name):
         heat_capacity_water=cpw,
         density_water=rhow,
         latent_heat_vaporization=lhv,
-        cps=cps,
-        rhos=rhos,
+        heat_capacity_solid=cps,
+        density_solid=rhos,
         pname="EST-e",
         filename="{}.est".format(gwe_name),
     )

--- a/scripts/ex-gwe-radial.py
+++ b/scripts/ex-gwe-radial.py
@@ -762,8 +762,8 @@ def build_mf6_heat_model(
         heat_capacity_water=cpw,
         density_water=rhow,
         latent_heat_vaporization=lhv,
-        cps=cps,
-        rhos=rhos,
+        heat_capacity_solid=cps,
+        density_solid=rhos,
         pname="EST",
         filename="{}.est".format(gwename),
     )

--- a/scripts/ex-gwe-vsc.py
+++ b/scripts/ex-gwe-vsc.py
@@ -484,8 +484,8 @@ def add_gwe_model(sim, gwename, temp_upper=4.0, temp_lower=4.0):
         heat_capacity_water=cpw,
         density_water=rhow,
         latent_heat_vaporization=lhv,
-        cps=cps,
-        rhos=rhos,
+        heat_capacity_solid=cps,
+        density_solid=rhos,
         pname="EST",
         filename="{}.est".format(gwename),
     )


### PR DESCRIPTION
Related to #212.  Updating argument names passed to `flopy.mf6.ModflowGweest()` as required by [#2001](https://github.com/MODFLOW-USGS/modflow6/pull/2001) over on the main MODFLOW 6 repo.