### PR TITLE
fix: apply ruff check fixes for Python docstrings (D409)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,16 +1,13 @@
+line-length = 88
 target-version = "py39"
-include = [
-    "autotest/**/*.py",
-    "scripts/**/*.py",
-    "etc/**/*.py",
-    ".doc/**/*.py",
-]
-extend-include = [
-    ".doc/**/*.ipynb"
-]
 
 [lint]
-select = ["F", "E", "I001"]
+select = [
+    "D409", # pydocstyle - section-underline-matches-section-length
+    "E",    # pycodestyle error
+    "F",    # Pyflakes
+    "I001", # isort - unsorted-imports
+]
 ignore = [
     "E501", # line too long TODO FIXME
     "E722", # do not use bare `except`

--- a/scripts/ex-gwf-curvilinear-90.py
+++ b/scripts/ex-gwf-curvilinear-90.py
@@ -978,7 +978,7 @@ class DisvStructuredGridBuilder(DisvPropertyContainer):
         """Generator that iterates through each rows' columns.
 
         Yields
-        -------
+        ------
         (int, int)
             Row index, column index
         """
@@ -995,7 +995,7 @@ class DisvStructuredGridBuilder(DisvPropertyContainer):
             Row index.
 
         Yields
-        -------
+        ------
         int
             cellid index
         """
@@ -1012,7 +1012,7 @@ class DisvStructuredGridBuilder(DisvPropertyContainer):
             Column index.
 
         Yields
-        -------
+        ------
         int
             cellid index
         """
@@ -1141,7 +1141,7 @@ class DisvGridMerger:
         name, and value is the merged grid's cellid.
 
     Notes
-    -------
+    -----
     The following is always true:
 
     ``cell2name[cell] ==  name2vert[cell2name[cell]]``
@@ -2066,7 +2066,7 @@ class DisvCurvilinearBuilder(DisvPropertyContainer):
         """Generator that iterates through the radial band columns, then bands.
 
         Yields
-        -------
+        ------
         (int, int)
             radial band index, column index
         """
@@ -2082,7 +2082,7 @@ class DisvCurvilinearBuilder(DisvPropertyContainer):
             Radial index.
 
         Yields
-        -------
+        ------
         int
             cellid index
         """
@@ -2102,7 +2102,7 @@ class DisvCurvilinearBuilder(DisvPropertyContainer):
             Column index.
 
         Yields
-        -------
+        ------
         int
             cellid index
         """
@@ -2120,7 +2120,7 @@ class DisvCurvilinearBuilder(DisvPropertyContainer):
             Radial index.
 
         Yields
-        -------
+        ------
         int
             column index
         """

--- a/scripts/ex-gwf-curvilinear.py
+++ b/scripts/ex-gwf-curvilinear.py
@@ -978,7 +978,7 @@ class DisvStructuredGridBuilder(DisvPropertyContainer):
         """Generator that iterates through each rows' columns.
 
         Yields
-        -------
+        ------
         (int, int)
             Row index, column index
         """
@@ -995,7 +995,7 @@ class DisvStructuredGridBuilder(DisvPropertyContainer):
             Row index.
 
         Yields
-        -------
+        ------
         int
             cellid index
         """
@@ -1012,7 +1012,7 @@ class DisvStructuredGridBuilder(DisvPropertyContainer):
             Column index.
 
         Yields
-        -------
+        ------
         int
             cellid index
         """
@@ -1141,7 +1141,7 @@ class DisvGridMerger:
         name, and value is the merged grid's cellid.
 
     Notes
-    -------
+    -----
     The following is always true:
 
     ``cell2name[cell] ==  name2vert[cell2name[cell]]``
@@ -2066,7 +2066,7 @@ class DisvCurvilinearBuilder(DisvPropertyContainer):
         """Generator that iterates through the radial band columns, then bands.
 
         Yields
-        -------
+        ------
         (int, int)
             radial band index, column index
         """
@@ -2082,7 +2082,7 @@ class DisvCurvilinearBuilder(DisvPropertyContainer):
             Radial index.
 
         Yields
-        -------
+        ------
         int
             cellid index
         """
@@ -2102,7 +2102,7 @@ class DisvCurvilinearBuilder(DisvPropertyContainer):
             Column index.
 
         Yields
-        -------
+        ------
         int
             cellid index
         """
@@ -2120,7 +2120,7 @@ class DisvCurvilinearBuilder(DisvPropertyContainer):
             Radial index.
 
         Yields
-        -------
+        ------
         int
             column index
         """


### PR DESCRIPTION
This PR applies ruff check [section-underline-matches-section-length (D409)](https://docs.astral.sh/ruff/rules/section-underline-matches-section-length/#section-underline-matches-section-length-d409), which impacts two Python source files.

It also re-configures ruff's configuration to remove "include" to apply the checks globally. It also removes the `extend-include` since the [default value for include](https://docs.astral.sh/ruff/settings/#include) already has "*.ipynb". A default `line-length = 88` is also re-iterated at the top of the configuration.