### PR TITLE
chore(dependencies): pin matplotlib<=3.9.4 for now

### DIFF
--- a/etc/requirements.pip.txt
+++ b/etc/requirements.pip.txt
@@ -3,7 +3,7 @@ pytest-xdist
 appdirs
 requests
 numpy
-matplotlib
+matplotlib<=3.9.4
 bmipy
 affine
 scipy


### PR DESCRIPTION
Some of the example scripts have begun to break with [matplotlib 3.10](https://github.com/matplotlib/matplotlib/releases/tag/v3.10.0). Most of the failures are due to [the removal](https://github.com/matplotlib/matplotlib/pull/28767/files) of the `collections` attribute from `ContourSet` and related API changes. We will need to rewrite some things to work around this. For reference see the [corresponding change](https://github.com/modflowpy/flopy/pull/1951) from a while ago in flopy.

Two failures however seem to be internal to matplotlib, with pillow being used incorrectly:

```
Traceback (most recent call last):
    File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/matplotlib/animation.py", line 224, in saving
      yield self
    File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/matplotlib/animation.py", line 1126, in save
      writer.grab_frame(**savefig_kwargs)
    File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/matplotlib/animation.py", line 499, in grab_frame
      self._frame.append(im)
  AttributeError: 'PillowWriter' object has no attribute '_frame'. Did you mean: '_frames'?
```

While we address the former and wait for a resolution for the latter, we can just pin mpl.