### PR TITLE
fix(barends): Example name on RTD not rendering correctly

### DIFF
--- a/scripts/ex-gwe-barends.py
+++ b/scripts/ex-gwe-barends.py
@@ -37,7 +37,7 @@
 # NOTE: In the current example, ncol is specified as 250.  If users prefer,
 #       this value may be increased to 500, 1,000, or more for a more refined
 #       solution.  Currently, ncol is kept low for faster run times.
-# -
+
 
 # +
 import os


### PR DESCRIPTION
#247 didn't seem to quite fix the issue on RTD.  Perhaps it is because there is a stray "-" character at the end of the header text?