### PR TITLE
refactor(pathlib): more consistent use of pathlib in examples

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -94,12 +94,12 @@ A snippet like the following, which determines whether the example is running in
 ```python
 sim_name = "ex-gwf-advtidal"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 ```
 
 **Note:** The build automation expects the simulation name `sim_name` and workspace directory name to match the example name as listed in `doc/body.tex`.

--- a/scripts/ex-gwe-ates.py
+++ b/scripts/ex-gwe-ates.py
@@ -21,7 +21,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -40,13 +40,13 @@ gwfname = "gwf-" + sim_name.split("-")[-1]
 gwename = "gwe-" + sim_name.split("-")[-1]
 
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
 
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 sim_ws = workspace / sim_name
 
 # Settings from environment variables
@@ -234,7 +234,7 @@ fpath = pooch.retrieve(
     path=data_path,
     known_hash="md5:d107d2a5e01646a861e73bb3465f0747",
 )
-# fpath = os.path.join(data_path, fname)
+# fpath = data_path / fname
 
 
 # Model timing

--- a/scripts/ex-gwe-barends.py
+++ b/scripts/ex-gwe-barends.py
@@ -40,8 +40,7 @@
 
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -52,12 +51,12 @@ from modflow_devtools.misc import get_env, timed
 # Example name and base workspace
 sim_name = "ex-gwe-barends"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
 
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -235,7 +234,7 @@ ctp_spd = {0: ctp_left}
 @timed
 def build_mf6_flow_model():
     gwf_name = sim_name
-    sim_ws = os.path.join(workspace, sim_name, "mf6gwf")
+    sim_ws = workspace / sim_name / "mf6gwf"
 
     # Instantiate a MODFLOW 6 simulation
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
@@ -347,7 +346,7 @@ def build_mf6_flow_model():
 def build_mf6_heat_model():
     print(f"Building mf6gwe model...{sim_name}")
     gwename = sim_name
-    sim_ws = os.path.join(workspace, sim_name, "mf6gwe")
+    sim_ws = workspace / sim_name / "mf6gwe"
 
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
 
@@ -517,7 +516,7 @@ def plot_thermal_bleeding(sim_gwe):
     if plot_show:
         plt.show()
     if plot_save:
-        fpth = os.path.join(figs_path / f"{sim_name}-gridView.png")
+        fpth = figs_path / f"{sim_name}-gridView.png"
         fig.savefig(fpth, dpi=600)
 
     # Next, plot model output
@@ -591,7 +590,7 @@ def plot_thermal_bleeding(sim_gwe):
     if plot_show:
         plt.show()
     if plot_save:
-        fpth = os.path.join(figs_path / f"{sim_name}-200yrs.png")
+        fpth = figs_path / f"{sim_name}-200yrs.png"
         fig2.savefig(fpth, dpi=600)
 
     return

--- a/scripts/ex-gwe-danckwerts.py
+++ b/scripts/ex-gwe-danckwerts.py
@@ -11,8 +11,7 @@
 
 # +
 import math
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -36,13 +35,13 @@ gwfname = "gwf-" + sim_name.replace("ex-gwe-", "")
 gwename = "gwe-" + sim_name.replace("ex-gwe-", "")
 
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
 
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 sim_ws = workspace / sim_name
 
 # Settings from environment variables
@@ -515,29 +514,24 @@ def run_model(sim, silent=True):
 def plot_sim_vs_analytical_sln(sim):
     print("comparing simulated results to analytical solution...")
 
-    ws = sim.sim_path  # exdirs[sim.idxsim]
+    ws = Path(sim.sim_path)  # exdirs[sim.idxsim]
 
     # check some output...
-    wc_fl = gwfname + ".uzfwc.bin"
-    wcobj = flopy.utils.HeadFile(os.path.join(ws, wc_fl), text="water-content")
+    wcobj = flopy.utils.HeadFile(ws / f"{gwfname}.uzfwc.bin", text="water-content")
     wc = wcobj.get_alldata()
 
     # temperature output
-    fl2 = gwename + ".uze.bin"
-    uzeobj = flopy.utils.HeadFile(os.path.join(ws, fl2), text="TEMPERATURE")
+    uzeobj = flopy.utils.HeadFile(ws / f"{gwename}.uze.bin", text="TEMPERATURE")
     temps = uzeobj.get_alldata()
 
     # Cell flows output
-    qfile = gwename + ".cbc"
-    gweflowsobj = flopy.utils.CellBudgetFile(os.path.join(ws, qfile))
+    gweflowsobj = flopy.utils.CellBudgetFile(ws / f"{gwename}.cbc")
 
     # Binary grid file needed for post-processing
-    fgrb = gwfname + ".dis.grb"
-    grb_file = os.path.join(ws, fgrb)
+    grb_file = ws / f"{gwfname}.dis.grb"
 
     # UZE flows
-    fuzebud = gwename + ".uze.bud"
-    uzeflowsobj = flopy.utils.CellBudgetFile(os.path.join(ws, fuzebud))
+    uzeflowsobj = flopy.utils.CellBudgetFile(ws / f"{gwename}.uze.bud")
     flowsadv = uzeflowsobj.get_data(text="FLOW-JA-FACE")
 
     t = np.linspace(0.0, 100.0, 101)

--- a/scripts/ex-gwe-geotherm.py
+++ b/scripts/ex-gwe-geotherm.py
@@ -9,14 +9,9 @@
 
 # +
 # Imports
-import os
-import pathlib as pl
-import sys
-from pprint import pformat
-
-sys.path.append(os.path.join("..", "common"))
-
 import math
+from pathlib import Path
+from pprint import pformat
 
 import flopy
 import git
@@ -32,13 +27,13 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwe-geotherm"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
 
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 
 # Settings from environment variables
@@ -429,7 +424,7 @@ def build_mf6_flow_model(sim_name, silent=True):
     global top, botm
 
     gwfname = "gwf-" + sim_name.split("-")[2]
-    sim_ws = os.path.join(workspace, sim_name, "mf6gwf")
+    sim_ws = workspace / sim_name / "mf6gwf"
 
     # Instantiate a new MF6 simulation
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
@@ -566,7 +561,7 @@ def build_mf6_flow_model(sim_name, silent=True):
 def build_mf6_heat_model(sim_name, dirichlet=0.0, neumann=0.0, silent=False):
     print(f"Building mf6gwt model...{sim_name}")
     gwename = "gwe-" + sim_name.split("-")[2]
-    sim_ws = os.path.join(workspace, sim_name, "mf6gwe")
+    sim_ws = workspace / sim_name / "mf6gwe"
 
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
 
@@ -793,7 +788,7 @@ def plot_grid(sim):
         if plot_show:
             plt.show()
         if plot_save:
-            fpth = os.path.join(figs_path / f"{simname}-grid.png")
+            fpth = figs_path / f"{simname}-grid.png"
             fig.savefig(fpth, dpi=300)
 
 
@@ -824,7 +819,7 @@ def plot_grid_inset(sim):
         if plot_show:
             plt.show()
         if plot_save:
-            fpth = os.path.join(figs_path / f"{simname}-grid-inset.png")
+            fpth = figs_path / f"{simname}-grid-inset.png"
             fig.savefig(fpth, dpi=300)
 
 
@@ -853,7 +848,7 @@ def plot_head(sim):
         if plot_show:
             plt.show()
         if plot_save:
-            fpth = os.path.join(figs_path / f"{simname}-head.png")
+            fpth = figs_path / f"{simname}-head.png"
             fig.savefig(fpth, dpi=300)
 
 
@@ -947,7 +942,7 @@ def plot_temperature(sim, scen, time_):
         if plot_show:
             plt.show()
         if plot_save:
-            fpth = os.path.join(figs_path / f"{simname}-temp50days.png")
+            fpth = figs_path / f"{simname}-temp50days.png"
             fig.savefig(fpth, dpi=300)
 
 

--- a/scripts/ex-gwe-prt.py
+++ b/scripts/ex-gwe-prt.py
@@ -7,7 +7,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -37,12 +37,12 @@ gwf_name = sim_name + "-gwf"
 gwe_name = sim_name + "-gwe"
 prt_name = sim_name + "-prt"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 sim_ws = workspace / sim_name
 gwf_ws = sim_ws / "gwf"
 gwe_ws = sim_ws / "gwe"
@@ -328,8 +328,8 @@ def build_gwe_sim(name):
     )
 
     pd = [
-        ("GWFHEAD", pl.Path(f"../{gwf_ws.name}/{gwf_name}.hds"), None),
-        ("GWFBUDGET", pl.Path(f"../{gwf_ws.name}/{gwf_name}.cbc"), None),
+        ("GWFHEAD", Path(f"../{gwf_ws.name}/{gwf_name}.hds"), None),
+        ("GWFBUDGET", Path(f"../{gwf_ws.name}/{gwf_name}.cbc"), None),
     ]
     flopy.mf6.ModflowGwefmi(gwe, packagedata=pd)
 
@@ -382,8 +382,8 @@ def build_prt_sim(name):
     )
 
     pd = [
-        ("GWFHEAD", pl.Path(f"../{gwf_ws.name}/{gwf_name}.hds"), None),
-        ("GWFBUDGET", pl.Path(f"../{gwf_ws.name}/{gwf_name}.cbc"), None),
+        ("GWFHEAD", Path(f"../{gwf_ws.name}/{gwf_name}.hds"), None),
+        ("GWFBUDGET", Path(f"../{gwf_ws.name}/{gwf_name}.cbc"), None),
     ]
 
     flopy.mf6.ModflowPrtfmi(prt, packagedata=pd)

--- a/scripts/ex-gwe-radial.py
+++ b/scripts/ex-gwe-radial.py
@@ -9,8 +9,7 @@
 import math
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -30,12 +29,12 @@ from scipy.spatial.distance import cdist
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwe-radial"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -522,7 +521,7 @@ def create_divs_objs(fl, silent=True):
 
 def build_mf6_flow_model(sim_name, left_chd_spd=None, right_chd_spd=None, silent=True):
     gwfname = "gwf-" + sim_name.split("-")[2]
-    sim_ws = os.path.join(workspace, sim_name, "mf6gwf")
+    sim_ws = workspace / sim_name / "mf6gwf"
 
     # Instantiate a new MF6 simulation
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
@@ -658,7 +657,7 @@ def build_mf6_heat_model(
 ):
     print(f"Building mf6gwt model...{sim_name}")
     gwename = "gwe-" + sim_name.split("-")[2]
-    sim_ws = os.path.join(workspace, sim_name[:-2], "mf6gwe" + scen_ext)
+    sim_ws = workspace / sim_name[:-2] / f"mf6gwe{scen_ext}"
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
 
     # Instantiating MODFLOW 6 groundwater transport model

--- a/scripts/ex-gwe-vsc.py
+++ b/scripts/ex-gwe-vsc.py
@@ -16,7 +16,7 @@
 # settings from environment variables.
 
 # +
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -35,12 +35,12 @@ from modflow_devtools.misc import get_env, timed
 sim_name = "ex-gwe-vsc"
 
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
 
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 sim_ws = workspace / sim_name
 
 # Settings from environment variables

--- a/scripts/ex-gwf-advtidal.py
+++ b/scripts/ex-gwf-advtidal.py
@@ -12,8 +12,7 @@
 # Import dependencies, read settings from environment variables, and define model parameters.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -30,12 +29,12 @@ from shapely.geometry import Polygon
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-advtidal"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -124,7 +123,7 @@ def get_timeseries(fname, names, interpolation, filename=None):
 
 
 def build_models():
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(
         sim_name=sim_name,
         sim_ws=sim_ws,

--- a/scripts/ex-gwf-bcf2ss.py
+++ b/scripts/ex-gwf-bcf2ss.py
@@ -14,8 +14,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -31,12 +30,12 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-bcf2ss"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -137,7 +136,7 @@ relax = 0.97
 
 # +
 def build_models(name, rewet, wetfct, iwetit, ihdwet, linear_acceleration, newton):
-    sim_ws = os.path.join(workspace, name)
+    sim_ws = workspace / name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -347,7 +346,7 @@ def plot_results(silent=True):
 
     with styles.USGSMap():
         name = next(iter(parameters.keys()))
-        sim_ws = os.path.join(workspace, name)
+        sim_ws = workspace / name
         sim = flopy.mf6.MFSimulation.load(
             sim_name=sim_name, sim_ws=sim_ws, verbosity_level=verbosity_level
         )
@@ -447,7 +446,7 @@ def plot_results(silent=True):
 
         # plot simulated newton results
         name = list(parameters.keys())[1]
-        sim_ws = os.path.join(workspace, name)
+        sim_ws = workspace / name
         sim = flopy.mf6.MFSimulation.load(
             sim_name=sim_name, sim_ws=sim_ws, verbosity_level=verbosity_level
         )

--- a/scripts/ex-gwf-bump.py
+++ b/scripts/ex-gwf-bump.py
@@ -7,8 +7,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -24,12 +23,12 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-bump"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -129,7 +128,7 @@ def build_models(
     ihdwet=None,
     wetdry=None,
 ):
-    sim_ws = os.path.join(workspace, name)
+    sim_ws = workspace / name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     if newton:

--- a/scripts/ex-gwf-capture.py
+++ b/scripts/ex-gwf-capture.py
@@ -15,10 +15,9 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
 import shutil
 import sys
+from pathlib import Path
 
 import flopy
 import git
@@ -35,12 +34,12 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-capture"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -156,7 +155,7 @@ for _k, i, j, _h in chd_spd[0]:
 
 # +
 def build_models():
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(
         sim_name=sim_name,
         sim_ws=sim_ws,
@@ -262,8 +261,8 @@ def run_models():
         soext = ".dll"
     if sys.platform.lower() == "darwin":
         soext = ".dylib"
-    libmf6_path = pl.Path(shutil.which("mf6")).parent / f"libmf6{soext}"
-    sim_ws = os.path.join(workspace, sim_name)
+    libmf6_path = Path(shutil.which("mf6")).parent / f"libmf6{soext}"
+    sim_ws = workspace / sim_name
     mf6 = modflowapi.ModflowApi(libmf6_path, working_directory=sim_ws)
     qbase = capture_fraction_iteration(mf6, cf_q)
 
@@ -288,7 +287,7 @@ def run_models():
             capture[irow, jcol] = (qriv - qbase) / abs(cf_q)
 
     # save the capture fraction array
-    fpth = os.path.join(sim_ws, "capture.npz")
+    fpth = sim_ws / "capture.npz"
     np.savez_compressed(fpth, capture=capture)
 
 
@@ -313,7 +312,7 @@ def plot_results(silent=True):
         verbosity_level = 1
 
     with styles.USGSMap():
-        sim_ws = os.path.join(workspace, sim_name)
+        sim_ws = workspace / sim_name
         sim = flopy.mf6.MFSimulation.load(
             sim_name=sim_name, sim_ws=sim_ws, verbosity_level=verbosity_level
         )
@@ -321,7 +320,7 @@ def plot_results(silent=True):
         wel = gwf.get_package("WEL-1")
 
         # load the capture fraction data
-        fpth = os.path.join(sim_ws, "capture.npz")
+        fpth = sim_ws / "capture.npz"
         capture = np.load(fpth)["capture"]
 
         # plot grid

--- a/scripts/ex-gwf-csub-p01.py
+++ b/scripts/ex-gwf-csub-p01.py
@@ -11,8 +11,7 @@
 
 # +
 import datetime
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -28,12 +27,12 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-csub-p01"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -136,7 +135,7 @@ relax = 1.0
 
 # +
 def build_models():
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-csub-p03.py
+++ b/scripts/ex-gwf-csub-p03.py
@@ -11,8 +11,7 @@
 
 # +
 import datetime
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -30,13 +29,13 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-csub-p03"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-tbls_path = root / "tables" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+tbls_path = root / "tables" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -405,9 +404,9 @@ def build_models(
     ssv=1e-1,
     sse=1e-3,
 ):
-    sim_ws = os.path.join(workspace, name)
+    sim_ws = workspace / name
     if subdir_name is not None:
-        sim_ws = os.path.join(sim_ws, subdir_name)
+        sim_ws = sim_ws / subdir_name
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -1035,7 +1034,7 @@ def plot_boundary_heads(silent=True):
             return v
 
         name = next(iter(parameters.keys()))
-        pth = os.path.join(workspace, name, f"{name}.gwf.obs.csv")
+        pth = workspace / name / f"{name}.gwf.obs.csv"
         hdata = process_dtw_obs(pth)
 
         pheads = ("HD01", "HD12", "HD14")
@@ -1079,11 +1078,11 @@ def plot_boundary_heads(silent=True):
 def plot_head_es_comparison(silent=True):
     with styles.USGSPlot() as fs:
         name = next(iter(parameters.keys()))
-        pth = os.path.join(workspace, name, f"{name}.csub.obs.csv")
+        pth = workspace / name / f"{name}.csub.obs.csv"
         hb = process_csub_obs(pth)
 
         name = list(parameters.keys())[1]
-        pth = os.path.join(workspace, name, f"{name}.csub.obs.csv")
+        pth = workspace / name / f"{name}.csub.obs.csv"
         es = process_csub_obs(pth)
 
         ymin = (2.0, 1, 1, 1, 0.1, 0.1)
@@ -1153,7 +1152,7 @@ def plot_head_es_comparison(silent=True):
 def plot_calibration(silent=True):
     with styles.USGSPlot():
         name = list(parameters.keys())[1]
-        fpath = os.path.join(workspace, name, f"{name}.csub.obs.csv")
+        fpath = workspace / name / f"{name}.csub.obs.csv"
         df_sim = get_sim_dataframe(fpath)
         for key in pcomp:
             df_sim[key] = df_sim[list(df_sim.filter(regex=key))].sum(axis=1)
@@ -1429,7 +1428,7 @@ def plot_calibration(silent=True):
 def plot_vertical_head(silent=True):
     with styles.USGSPlot() as fs:
         name = list(parameters.keys())[1]
-        pth = os.path.join(workspace, name, f"{name}.gwf.obs.csv")
+        pth = workspace / name / f"{name}.gwf.obs.csv"
         df_heads, col_list = process_sim_csv(
             pth, origin_str="1908-05-09 00:00:00.000000"
         )

--- a/scripts/ex-gwf-csub-p04.py
+++ b/scripts/ex-gwf-csub-p04.py
@@ -10,8 +10,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -27,12 +26,12 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-csub-p04"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -183,7 +182,7 @@ relax = 0.97
 
 # +
 def build_models():
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-curvilinear-90.py
+++ b/scripts/ex-gwf-curvilinear-90.py
@@ -20,10 +20,9 @@
 
 # +
 import copy
-import os
-import pathlib as pl
 from itertools import cycle
 from math import sqrt
+from pathlib import Path
 
 import flopy
 import git
@@ -37,11 +36,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-curve-90"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -2266,7 +2265,7 @@ rclose = 1e-4
 
 # +
 def build_models(name):
-    sim_ws = os.path.join(workspace, name)
+    sim_ws = workspace / name
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -2468,7 +2467,7 @@ def plot_results(silent=True):
     else:
         verbosity_level = 1
 
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation.load(
         sim_name=sim_name, sim_ws=sim_ws, verbosity_level=verbosity_level
     )
@@ -2480,7 +2479,7 @@ def plot_results(silent=True):
 
 
 def calculate_model_error():
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation.load(
         sim_name=sim_name, sim_ws=sim_ws, verbosity_level=0
     )

--- a/scripts/ex-gwf-curvilinear.py
+++ b/scripts/ex-gwf-curvilinear.py
@@ -20,10 +20,9 @@
 
 # +
 import copy
-import os
-import pathlib as pl
 from itertools import cycle
 from math import sqrt
+from pathlib import Path
 
 import flopy
 import git
@@ -37,11 +36,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-curvilin"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -2335,7 +2334,7 @@ rclose = 1e-4
 
 # +
 def build_models(name):
-    sim_ws = os.path.join(workspace, name)
+    sim_ws = workspace / name
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -2603,7 +2602,7 @@ def plot_results(silent=True):
     else:
         verbosity_level = 1
 
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation.load(
         sim_name=sim_name, sim_ws=sim_ws, verbosity_level=verbosity_level
     )

--- a/scripts/ex-gwf-disvmesh.py
+++ b/scripts/ex-gwf-disvmesh.py
@@ -11,8 +11,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import flopy.utils.cvfdutil
@@ -31,12 +30,12 @@ from shapely.geometry import Polygon
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-disvmesh"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -145,7 +144,7 @@ rclose = 1e-6
 
 # +
 def build_models(sim_name):
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -241,7 +240,7 @@ figure_size = (5, 5)
 
 def plot_grid(idx, sim):
     with styles.USGSMap():
-        sim_ws = os.path.join(workspace, sim_name)
+        sim_ws = workspace / sim_name
         gwf = sim.get_model(sim_name)
 
         fig = plt.figure(figsize=figure_size)
@@ -263,7 +262,7 @@ def plot_grid(idx, sim):
 
 def plot_head(idx, sim):
     with styles.USGSMap():
-        sim_ws = os.path.join(workspace, sim_name)
+        sim_ws = workspace / sim_name
         gwf = sim.get_model(sim_name)
 
         fig = plt.figure(figsize=(7.5, 5))

--- a/scripts/ex-gwf-drn-p01.py
+++ b/scripts/ex-gwf-drn-p01.py
@@ -12,8 +12,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -29,13 +28,13 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-drn-p01"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-tbls_path = root / "tables" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+tbls_path = root / "tables" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -99,7 +98,7 @@ shape3d = (nlay, nrow, ncol)
 
 # Load the idomain, top, bottom, and uzf/mvr arrays
 sfr_sim_name = "ex-gwf-sfr-p01"  # some data files come from another example
-sfr_data_path = data_path.parent / sfr_sim_name if root else pl.Path.cwd()
+sfr_data_path = data_path.parent / sfr_sim_name if root else Path.cwd()
 
 fname = "idomain.txt"
 fpath = pooch.retrieve(
@@ -419,7 +418,7 @@ rclose = 1e-6
 
 # +
 def build_models(name, uzf_gwseep=None):
-    sim_ws = os.path.join(workspace, name)
+    sim_ws = workspace / name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -590,10 +589,10 @@ def plot_gwseep_results(silent=True):
     with styles.USGSPlot() as fs:
         # load the observations
         name = next(iter(parameters.keys()))
-        fpth = os.path.join(workspace, name, f"{sim_name}.surfrate.obs.csv")
+        fpth = workspace / name / f"{sim_name}.surfrate.obs.csv"
         drn = flopy.utils.Mf6Obs(fpth).data
         name = list(parameters.keys())[1]
-        fpth = os.path.join(workspace, name, f"{sim_name}.surfrate.obs.csv")
+        fpth = workspace / name / f"{sim_name}.surfrate.obs.csv"
         uzf = flopy.utils.Mf6Obs(fpth).data
 
         time = drn["totim"] / 86400.0

--- a/scripts/ex-gwf-fhb.py
+++ b/scripts/ex-gwf-fhb.py
@@ -11,8 +11,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -25,11 +24,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-fhb"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -90,7 +89,7 @@ rclose = 1e-6
 
 # +
 def build_models():
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-hani.py
+++ b/scripts/ex-gwf-hani.py
@@ -10,8 +10,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import flopy.utils.cvfdutil
@@ -25,11 +24,11 @@ from modflow_devtools.misc import get_env, timed
 # in the git repository, use the folder structure described in
 # the README. Otherwise just use the current working directory.
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -91,7 +90,7 @@ rclose = 1e-6
 
 # +
 def build_models(sim_name, angle1, xt3d):
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -174,7 +173,7 @@ figure_size = (3.5, 3.5)
 def plot_grid(idx, sim):
     with styles.USGSMap():
         sim_name = list(parameters.keys())[idx]
-        sim_ws = os.path.join(workspace, sim_name)
+        sim_ws = workspace / sim_name
         gwf = sim.get_model(sim_name)
 
         fig = plt.figure(figsize=figure_size)
@@ -198,7 +197,7 @@ def plot_grid(idx, sim):
 def plot_head(idx, sim):
     with styles.USGSMap():
         sim_name = list(parameters.keys())[idx]
-        sim_ws = os.path.join(workspace, sim_name)
+        sim_ws = workspace / sim_name
         gwf = sim.get_model(sim_name)
 
         fig = plt.figure(figsize=figure_size)

--- a/scripts/ex-gwf-lak-p01.py
+++ b/scripts/ex-gwf-lak-p01.py
@@ -8,8 +8,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -23,11 +22,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-lak-p01"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -167,7 +166,7 @@ rclose = 1e-6
 
 # +
 def build_models():
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-lak-p02.py
+++ b/scripts/ex-gwf-lak-p02.py
@@ -8,8 +8,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -29,12 +28,12 @@ masked_values = (0, 1e30, -1e30)
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-lak-p02"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -269,7 +268,7 @@ rclose = 1e-6
 
 # +
 def build_models():
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -412,7 +411,7 @@ masked_values = (0, 1e30, -1e30)
 
 
 def plot_grid(gwf, silent=True):
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
 
     # create lake array
     ilake = gwf.dis.idomain.array
@@ -448,7 +447,7 @@ def plot_grid(gwf, silent=True):
         [xedges[16], ycenters[22]],
     ]
     parts = [poly0, poly1, poly2]
-    shape_pth = os.path.join(workspace, sim_name, "sfr.shp")
+    shape_pth = workspace / sim_name / "sfr.shp"
     w = shp.Writer(target=shape_pth, shapeType=shp.POLYLINE)
     w.field("no", "C")
     w.line([poly0])

--- a/scripts/ex-gwf-lgr.py
+++ b/scripts/ex-gwf-lgr.py
@@ -7,8 +7,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import flopy.utils.binaryfile as bf
@@ -24,11 +23,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 example_name = "ex-gwf-lgr"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -530,7 +529,7 @@ def build_models(sim_name, silent=False):
     # Instantiate the MODFLOW 6 simulation
     name = "lgr"
     gwfname = "gwf-" + name
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(
         sim_name=sim_name,
         version="mf6",
@@ -860,11 +859,11 @@ def plot_results(mf6, idx):
     sim_name = mf6.name
     with styles.USGSPlot():
         # Start by retrieving some output
-        mf6_out_pth = mf6.simulation_data.mfpath.get_sim_path()
+        mf6_out_pth = Path(mf6.simulation_data.mfpath.get_sim_path())
         sfr_parent_bud_file = next(iter(mf6.model_names)) + ".sfr.bud"
         sfr_child_bud_file = list(mf6.model_names)[1] + ".sfr.bud"
-        sfr_parent_out = os.path.join(mf6_out_pth, sfr_parent_bud_file)
-        sfr_child_out = os.path.join(mf6_out_pth, sfr_child_bud_file)
+        sfr_parent_out = mf6_out_pth / sfr_parent_bud_file
+        sfr_child_out = mf6_out_pth / sfr_child_bud_file
         modobjp = bf.CellBudgetFile(sfr_parent_out, precision="double")
         modobjc = bf.CellBudgetFile(sfr_child_out, precision="double")
 

--- a/scripts/ex-gwf-lgrv.py
+++ b/scripts/ex-gwf-lgrv.py
@@ -8,8 +8,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import flopy.utils.lgrutil
@@ -25,12 +24,12 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-lgrv"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -253,7 +252,7 @@ def riv_resample(icoarsen, nrow, ncol, rivdat, idomain, rowcolspan):
 
 
 def build_lgr_model(name):
-    sim_ws = os.path.join(workspace, name)
+    sim_ws = workspace / name
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -374,7 +373,7 @@ def build_models(
     yorigin=None,
 ):
     if sim is None:
-        sim_ws = os.path.join(workspace, name)
+        sim_ws = workspace / name
         sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
         flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
         flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-maw-p01.py
+++ b/scripts/ex-gwf-maw-p01.py
@@ -8,8 +8,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -24,11 +23,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-maw-p01"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -120,7 +119,7 @@ rclose = 1e-4
 
 # +
 def build_models(name, rate=0.0):
-    sim_ws = os.path.join(workspace, name)
+    sim_ws = workspace / name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -211,10 +210,10 @@ def plot_maw_results(silent=True):
     with styles.USGSPlot():
         # load the observations
         name = next(iter(parameters.keys()))
-        fpth = os.path.join(workspace, name, f"{sim_name}.maw.obs.csv")
+        fpth = workspace / name / f"{sim_name}.maw.obs.csv"
         maw0 = flopy.utils.Mf6Obs(fpth).data
         name = list(parameters.keys())[1]
-        fpth = os.path.join(workspace, name, f"{sim_name}.maw.obs.csv")
+        fpth = workspace / name / f"{sim_name}.maw.obs.csv"
         maw1 = flopy.utils.Mf6Obs(fpth).data
 
         time = maw0["totim"] * 86400.0
@@ -288,7 +287,7 @@ def plot_grid(silent=True):
     else:
         verbosity = 1
     name = next(iter(parameters.keys()))
-    sim_ws = os.path.join(workspace, name)
+    sim_ws = workspace / name
     sim = flopy.mf6.MFSimulation.load(
         sim_name=sim_name, sim_ws=sim_ws, verbosity_level=verbosity
     )

--- a/scripts/ex-gwf-maw-p02.py
+++ b/scripts/ex-gwf-maw-p02.py
@@ -8,8 +8,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -24,11 +23,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-maw-p02"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -112,7 +111,7 @@ rclose = 1e-4
 
 # +
 def build_models():
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -202,7 +201,7 @@ masked_values = (0, 1e30, -1e30)
 def plot_maw_results(silent=True):
     with styles.USGSPlot():
         # load the observations
-        fpth = os.path.join(workspace, sim_name, f"{sim_name}.maw.obs.csv")
+        fpth = workspace / sim_name / f"{sim_name}.maw.obs.csv"
         maw = flopy.utils.Mf6Obs(fpth).data
 
         time = maw["totim"] * 86400.0

--- a/scripts/ex-gwf-maw-p03.py
+++ b/scripts/ex-gwf-maw-p03.py
@@ -7,8 +7,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -22,11 +21,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-maw-p03"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -232,7 +231,7 @@ def build_models(name, simulation="regional"):
 
 
 def build_regional(name):
-    sim_ws = os.path.join(workspace, name)
+    sim_ws = workspace / name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -282,7 +281,7 @@ def build_regional(name):
 def build_local(name, simulation):
     # get regional heads for constant head boundaries
     pth = next(iter(parameters.keys()))
-    fpth = os.path.join(workspace, pth, f"{sim_name}.hds")
+    fpth = workspace / pth / f"{sim_name}.hds"
     try:
         h = flopy.utils.HeadFile(fpth).get_data()
     except:
@@ -308,7 +307,7 @@ def build_local(name, simulation):
                 chd_spd.append([k, il, 0, hi1])
                 chd_spd.append([k, il, ncol - 1, hi2])
 
-    sim_ws = os.path.join(workspace, name)
+    sim_ws = workspace / name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -424,10 +423,10 @@ def plot_maw_results(silent=True):
     with styles.USGSPlot():
         # load the observations
         name = list(parameters.keys())[1]
-        fpth = os.path.join(workspace, name, f"{sim_name}.maw.obs.csv")
+        fpth = workspace / name / f"{sim_name}.maw.obs.csv"
         maw = flopy.utils.Mf6Obs(fpth).data
         name = list(parameters.keys())[2]
-        fpth = os.path.join(workspace, name, f"{sim_name}.gwf.obs.csv")
+        fpth = workspace / name / f"{sim_name}.gwf.obs.csv"
         gwf = flopy.utils.Mf6Obs(fpth).data
 
         # process heads
@@ -530,7 +529,7 @@ def plot_regional_grid(silent=True):
     else:
         verbosity = 1
     name = next(iter(parameters.keys()))
-    sim_ws = os.path.join(workspace, name)
+    sim_ws = workspace / name
     sim = flopy.mf6.MFSimulation.load(
         sim_name=sim_name, sim_ws=sim_ws, verbosity_level=verbosity
     )
@@ -642,7 +641,7 @@ def plot_local_grid(silent=True):
     else:
         verbosity = 1
     name = list(parameters.keys())[1]
-    sim_ws = os.path.join(workspace, name)
+    sim_ws = workspace / name
     sim = flopy.mf6.MFSimulation.load(
         sim_name=sim_name, sim_ws=sim_ws, verbosity_level=verbosity
     )

--- a/scripts/ex-gwf-nwt-p02.py
+++ b/scripts/ex-gwf-nwt-p02.py
@@ -10,8 +10,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -25,11 +24,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-nwt-p02"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -131,7 +130,7 @@ def build_models(
     ihdwet=None,
     wetdry=None,
 ):
-    sim_ws = os.path.join(workspace, name)
+    sim_ws = workspace / name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     if newton:
@@ -244,7 +243,7 @@ def plot_results(silent=True):
     with styles.USGSMap():
         # load the newton model
         name = next(iter(parameters.keys()))
-        sim_ws = os.path.join(workspace, name)
+        sim_ws = workspace / name
         sim = flopy.mf6.MFSimulation.load(
             sim_name=sim_name, sim_ws=sim_ws, verbosity_level=verbosity_level
         )
@@ -260,7 +259,7 @@ def plot_results(silent=True):
 
         # load rewet model
         name = list(parameters.keys())[1]
-        sim_ws = os.path.join(workspace, name)
+        sim_ws = workspace / name
         sim1 = flopy.mf6.MFSimulation.load(
             sim_name=sim_name, sim_ws=sim_ws, verbosity_level=verbosity_level
         )

--- a/scripts/ex-gwf-nwt-p03.py
+++ b/scripts/ex-gwf-nwt-p03.py
@@ -11,8 +11,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -28,12 +27,12 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-nwt-p03"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -136,7 +135,7 @@ rclose = 1e-6
 
 # +
 def build_models(name, recharge="high"):
-    sim_ws = os.path.join(workspace, name)
+    sim_ws = workspace / name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-radial.py
+++ b/scripts/ex-gwf-radial.py
@@ -18,9 +18,8 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
 from math import sqrt
+from pathlib import Path
 
 import flopy
 import git
@@ -44,11 +43,11 @@ from scipy.special import j0, jn_zeros
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-rad-disu"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -1163,7 +1162,7 @@ rclose = 1e-4
 
 # +
 def build_models(name):
-    sim_ws = os.path.join(workspace, name)
+    sim_ws = workspace / name
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -1955,7 +1954,7 @@ def plot_results(silent=True):
     else:
         verbosity_level = 1
 
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation.load(
         sim_name=sim_name, sim_ws=sim_ws, verbosity_level=verbosity_level
     )

--- a/scripts/ex-gwf-sagehen.py
+++ b/scripts/ex-gwf-sagehen.py
@@ -8,8 +8,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -25,12 +24,12 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-sagehen"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -1948,7 +1947,7 @@ maxmvr = 10000  # Something arbitrarily high
 # +
 def build_models(silent=False):
     # Instantiate the MODFLOW 6 simulation
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(
         sim_name=sim_name,
         version="mf6",

--- a/scripts/ex-gwf-sfr-p01.py
+++ b/scripts/ex-gwf-sfr-p01.py
@@ -9,8 +9,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -26,12 +25,12 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-sfr-p01"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -267,7 +266,7 @@ rclose = 1e-6
 
 # +
 def build_models():
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-sfr-p01b.py
+++ b/scripts/ex-gwf-sfr-p01b.py
@@ -10,8 +10,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -28,12 +27,12 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-sfr-p01b"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -3748,7 +3747,7 @@ rclose = 1e-6
 
 # +
 def build_models():
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -4434,8 +4433,8 @@ def plot_mvr_results(idx, gwf, silent=True):
 
 def plot_uzfcolumn_results(idx, gwf, silent=True):
     with styles.USGSPlot():
-        sim_ws = os.path.join(workspace, sim_name)
-        fname = os.path.join(sim_ws, "obs_uzf_column.csv")
+        sim_ws = workspace / sim_name
+        fname = sim_ws / "obs_uzf_column.csv"
         uzf_dat = pd.read_csv(fname, header=0)
         uzf_dat["time_days"] = uzf_dat["time"] / 86400
         x = uzf_dat["time_days"]

--- a/scripts/ex-gwf-sfr-pindersauer.py
+++ b/scripts/ex-gwf-sfr-pindersauer.py
@@ -10,8 +10,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -25,12 +24,12 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-sfr-pindersauer"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -181,7 +180,7 @@ def analytical_solution(lambdas, x, t):
 
 # +
 def build_models(sim_name, lambda_val, leakance, stage):
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     name = sim_name.replace("pindersauer", "ps")
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
@@ -363,7 +362,7 @@ def plot_observations(sim_list, silent=True):
 def plot_results(silent=True):
     sim_list = []
     for key in parameters.keys():
-        sim_ws = os.path.join(workspace, key)
+        sim_ws = workspace / key
         sim_name = key.replace("pindersauer", "ps")
         sim_list.append(flopy.mf6.MFSimulation.load(sim_ws=sim_ws))
     plot_observations(sim_list, silent=silent)

--- a/scripts/ex-gwf-spbc.py
+++ b/scripts/ex-gwf-spbc.py
@@ -9,8 +9,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -24,11 +23,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-spbc"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -86,7 +85,7 @@ rclose = 1e-6
 
 # +
 def build_models():
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-toth.py
+++ b/scripts/ex-gwf-toth.py
@@ -16,8 +16,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -32,12 +31,12 @@ from modflow_devtools.misc import get_env, timed
 sim_name = "ex-gwf-toth"
 gwf_name = "toth"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -104,7 +103,7 @@ ninner = 100
 
 # +
 def build_models():
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
 
     tdis = flopy.mf6.ModflowTdis(sim)
@@ -155,7 +154,6 @@ def plot_results(sim):
 
 def plot_head_results(sim):
     print("Plotting head model results...")
-    sim_ws = sim.simulation_data.mfpath.get_sim_path()
     gwf = sim.gwf[0]
 
     # load gwf output

--- a/scripts/ex-gwf-twri.py
+++ b/scripts/ex-gwf-twri.py
@@ -9,8 +9,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -24,11 +23,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-twri01"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -152,7 +151,7 @@ rclose = 1e-6
 
 # +
 def build_models():
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -201,7 +200,7 @@ def build_models():
 
 
 def build_mf5model():
-    sim_ws = os.path.join(workspace, sim_name, "mf2005")
+    sim_ws = workspace / sim_name / "mf2005"
     mf = flopy.modflow.Modflow(
         modelname=sim_name, model_ws=sim_ws, exe_name="mf2005dbl"
     )
@@ -272,7 +271,7 @@ figure_size = (6, 6)
 
 def plot_results(sim, mf, silent=True):
     with styles.USGSMap():
-        sim_ws = os.path.join(workspace, sim_name)
+        sim_ws = workspace / sim_name
         gwf = sim.get_model(sim_name)
 
         # create MODFLOW 6 head object
@@ -280,7 +279,7 @@ def plot_results(sim, mf, silent=True):
 
         # create MODFLOW-2005 head object
         file_name = gwf.oc.head_filerecord.get_data()[0][0]
-        fpth = os.path.join(sim_ws, "mf2005", file_name)
+        fpth = sim_ws / "mf2005" / file_name
         hobj0 = flopy.utils.HeadFile(fpth)
 
         # create MODFLOW 6 cell-by-cell budget object
@@ -288,7 +287,7 @@ def plot_results(sim, mf, silent=True):
 
         # create MODFLOW-2005 cell-by-cell budget object
         file_name = gwf.oc.budget_filerecord.get_data()[0][0]
-        fpth = os.path.join(sim_ws, "mf2005", file_name)
+        fpth = sim_ws / "mf2005" / file_name
         cobj0 = flopy.utils.CellBudgetFile(fpth, precision="double")
 
         # extract heads

--- a/scripts/ex-gwf-u1disv.py
+++ b/scripts/ex-gwf-u1disv.py
@@ -11,8 +11,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import flopy.utils.cvfdutil
@@ -26,11 +25,11 @@ from modflow_devtools.misc import get_env, timed
 # in the git repository, use the folder structure described in
 # the README. Otherwise just use the current working directory.
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -125,7 +124,7 @@ rclose = 1e-6
 
 # +
 def build_models(sim_name, xt3d):
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(
@@ -209,7 +208,7 @@ figure_size = (6, 6)
 def plot_grid(idx, sim):
     with styles.USGSMap():
         sim_name = list(parameters.keys())[idx]
-        sim_ws = os.path.join(workspace, sim_name)
+        sim_ws = workspace / sim_name
         gwf = sim.get_model(sim_name)
 
         fig = plt.figure(figsize=figure_size)
@@ -257,7 +256,7 @@ def plot_grid(idx, sim):
 def plot_head(idx, sim):
     with styles.USGSMap():
         sim_name = list(parameters.keys())[idx]
-        sim_ws = os.path.join(workspace, sim_name)
+        sim_ws = workspace / sim_name
         gwf = sim.get_model(sim_name)
 
         fig = plt.figure(figsize=(7.5, 5))

--- a/scripts/ex-gwf-u1gwfgwf.py
+++ b/scripts/ex-gwf-u1gwfgwf.py
@@ -18,8 +18,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -34,11 +33,11 @@ from modflow_devtools.misc import get_env, timed
 # in the git repository, use the folder structure described in
 # the README. Otherwise just use the current working directory.
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -131,7 +130,7 @@ rclose = 1e-6
 
 # +
 def build_models(sim_name, XT3D_in_models, XT3D_at_exchange):
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-whirl.py
+++ b/scripts/ex-gwf-whirl.py
@@ -10,8 +10,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -25,11 +24,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-whirl"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -90,7 +89,7 @@ rclose = 1e-6
 
 # +
 def build_models():
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(

--- a/scripts/ex-gwf-zaidel.py
+++ b/scripts/ex-gwf-zaidel.py
@@ -8,8 +8,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -23,11 +22,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwf-zaidel"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -100,7 +99,7 @@ def build_models(H2=1.0):
         [0, 0, ncol - 1, H2],
     ]
 
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     flopy.mf6.ModflowIms(

--- a/scripts/ex-gwt-gwtgwt-p10.py
+++ b/scripts/ex-gwt-gwtgwt-p10.py
@@ -11,8 +11,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -28,12 +27,12 @@ from modflow_devtools.misc import get_env
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwt-gwtgwt-p10"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -98,7 +97,7 @@ laytyp = icelltype = 0
 
 # Starting heads from file:
 gwt_mt3dms_sim_name = "ex-gwt-mt3dms-p10"
-gwt_mt3dms_data_path = data_path.parent / gwt_mt3dms_sim_name if root else pl.Path.cwd()
+gwt_mt3dms_data_path = data_path.parent / gwt_mt3dms_sim_name if root else Path.cwd()
 fname = "p10shead.dat"
 fpath = pooch.retrieve(
     url=f"https://github.com/MODFLOW-USGS/modflow6-examples/raw/master/data/{gwt_mt3dms_sim_name}/{fname}",
@@ -230,7 +229,7 @@ scheme = "Undefined"
 
 # +
 def build_models():
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
 
     # Instantiating time discretization

--- a/scripts/ex-gwt-hecht-mendez.py
+++ b/scripts/ex-gwt-hecht-mendez.py
@@ -25,8 +25,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -41,12 +40,12 @@ from scipy.special import erf, erfc
 # the README. Otherwise just use the current working directory.
 name = "hecht-mendez"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -378,7 +377,7 @@ def build_mf2k5_flow_model(
     silent=False,
 ):
     print(f"Building mf2005 model...{sim_name}")
-    mt3d_ws = os.path.join(workspace, sim_name, "mt3d")
+    mt3d_ws = workspace / sim_name / "mt3d"
     modelname_mf = "hecht-mendez"
 
     # Instantiate the MODFLOW model
@@ -446,8 +445,8 @@ def build_mf6_flow_model(
     silent=False,
 ):
     print(f"Building mf6gwf model...{sim_name}")
-    gwfname = "gwf-" + name
-    sim_ws = os.path.join(workspace, sim_name, "mf6gwf")
+    gwfname = f"gwf-{name}"
+    sim_ws = workspace / sim_name / "mf6gwf"
     sim = flopy.mf6.MFSimulation(sim_name=gwfname, sim_ws=sim_ws, exe_name="mf6")
 
     # Instantiating MODFLOW 6 time discretization
@@ -571,7 +570,7 @@ def build_mt3d_transport_model(
     print(f"Building mt3dms model...{sim_name}")
 
     modelname_mt = "hecht-mendez_mt"
-    mt3d_ws = os.path.join(workspace, sim_name, "mt3d")
+    mt3d_ws = workspace / sim_name / "mt3d"
     mt = flopy.mt3d.Mt3dms(
         modelname=modelname_mt,
         model_ws=mt3d_ws,
@@ -636,7 +635,7 @@ def build_mf6_transport_model(
     # Instantiating MODFLOW 6 groundwater transport package
     print(f"Building mf6gwt model...{sim_name}")
     gwtname = "gwt-" + name
-    sim_ws = os.path.join(workspace, sim_name, "mf6gwt")
+    sim_ws = workspace / sim_name / "mf6gwt"
     sim = flopy.mf6.MFSimulation(sim_name=gwtname, sim_ws=sim_ws, exe_name="mf6")
 
     # MF6 time discretization is a bit different than corresponding flow simulation
@@ -823,15 +822,13 @@ def plot_results(
     constantheadright=14,
 ):
     if mt3d is not None:
-        mt3d_out_path = mt3d.model_ws
+        mt3d_out_path = Path(mt3d.model_ws)
 
         # Get the MT3DMS concentration output
-        fname_mt3d = os.path.join(mt3d_out_path, "MT3D001.UCN")
+        fname_mt3d = mt3d_out_path / "MT3D001.UCN"
         ucnobj_mt3d = flopy.utils.UcnFile(fname_mt3d)
         times_mt3d = ucnobj_mt3d.get_times()
         conc_mt3d = ucnobj_mt3d.get_alldata()
-
-    mf6_out_path = sim_mf6gwt.simulation_data.mfpath.get_sim_path()
 
     # Get the MF6 concentration output
     gwt = sim_mf6gwt.get_model("gwt-" + name)

--- a/scripts/ex-gwt-henry.py
+++ b/scripts/ex-gwt-henry.py
@@ -7,8 +7,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -20,11 +19,11 @@ from modflow_devtools.misc import get_env, timed
 # in the git repository, use the folder structure described in
 # the README. Otherwise just use the current working directory.
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -91,7 +90,7 @@ hclose, rclose, relax = 1e-10, 1e-6, 0.97
 def build_models(sim_folder, inflow):
     print(f"Building model...{sim_folder}")
     name = "flow"
-    sim_ws = os.path.join(workspace, sim_folder)
+    sim_ws = workspace / sim_folder
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     tdis_ds = ((perlen, nstp, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)

--- a/scripts/ex-gwt-keating.py
+++ b/scripts/ex-gwt-keating.py
@@ -10,8 +10,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -27,12 +26,12 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwt-keating"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = root / "data" / sim_name if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = root / "data" / sim_name if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -117,7 +116,7 @@ rchspd[1] = [[(0, 0, j), rrate, 0.0] for j in rcol]
 def build_mf6gwf():
     print(f"Building mf6gwf model...{sim_name}")
     name = "flow"
-    sim_ws = os.path.join(workspace, sim_name, "mf6gwf")
+    sim_ws = workspace / sim_name / "mf6gwf"
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     tdis_ds = ((period1, 1, 1.0), (period2, 1, 1.0))
     flopy.mf6.ModflowTdis(
@@ -204,7 +203,7 @@ def build_mf6gwf():
 def build_mf6gwt():
     print(f"Building mf6gwt model...{sim_name}")
     name = "trans"
-    sim_ws = os.path.join(workspace, sim_name, "mf6gwt")
+    sim_ws = workspace / sim_name / "mf6gwt"
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         sim_ws=sim_ws,
@@ -342,7 +341,7 @@ def plot_head_results(sims):
     botm = gwf.dis.botm.array
 
     with styles.USGSMap():
-        sim_ws = sim_mf6gwf.simulation_data.mfpath.get_sim_path()
+        sim_ws = Path(sim_mf6gwf.simulation_data.mfpath.get_sim_path())
         head = gwf.output.head().get_data()
         head = np.where(head > botm, head, np.nan)
         fig, ax = plt.subplots(1, 1, figsize=figure_size, dpi=300, tight_layout=True)
@@ -362,8 +361,7 @@ def plot_head_results(sims):
         if plot_show:
             plt.show()
         if plot_save:
-            sim_folder = os.path.split(sim_ws)[0]
-            sim_folder = os.path.basename(sim_folder)
+            sim_folder = sim_ws.parent.name
             fname = f"{sim_folder}-head.png"
             fpth = figs_path / fname
             fig.savefig(fpth)
@@ -379,7 +377,7 @@ def plot_conc_results(sims):
     with styles.USGSMap():
         head = gwf.output.head().get_data()
         head = np.where(head > botm, head, np.nan)
-        sim_ws = sim_mf6gwt.simulation_data.mfpath.get_sim_path()
+        sim_ws = Path(sim_mf6gwt.simulation_data.mfpath.get_sim_path())
         cobj = gwt.output.concentration()
         conc_times = cobj.get_times()
         conc_times = np.array(conc_times)
@@ -426,8 +424,7 @@ def plot_conc_results(sims):
         if plot_show:
             plt.show()
         if plot_save:
-            sim_folder = os.path.split(sim_ws)[0]
-            sim_folder = os.path.basename(sim_folder)
+            sim_folder = sim_ws.parent.name
             fname = f"{sim_folder}-conc.png"
             fpth = figs_path / fname
             fig.savefig(fpth)
@@ -499,7 +496,7 @@ def plot_cvt_results(sims):
     gwt = sim_mf6gwt.trans
 
     with styles.USGSMap():
-        sim_ws = sim_mf6gwt.simulation_data.mfpath.get_sim_path()
+        sim_ws = Path(sim_mf6gwt.simulation_data.mfpath.get_sim_path())
         mf6gwt_ra = gwt.obs.output.obs().data
         dt = [("totim", "f8"), ("obs", "f8")]
 
@@ -562,8 +559,7 @@ def plot_cvt_results(sims):
         if plot_show:
             plt.show()
         if plot_save:
-            sim_folder = os.path.split(sim_ws)[0]
-            sim_folder = os.path.basename(sim_folder)
+            sim_folder = sim_ws.parent.name
             fname = f"{sim_folder}-cvt.png"
             fpth = figs_path / fname
             fig.savefig(fpth)

--- a/scripts/ex-gwt-moc3d-p01.py
+++ b/scripts/ex-gwt-moc3d-p01.py
@@ -10,8 +10,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -25,11 +24,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 example_name = "ex-gwt-moc3dp1"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -293,7 +292,7 @@ def get_decay_dict(decay_rate, sorption=False):
 def build_mf6gwf(sim_folder):
     print(f"Building mf6gwf model...{sim_folder}")
     name = "flow"
-    sim_ws = os.path.join(workspace, sim_folder, "mf6gwf")
+    sim_ws = workspace / sim_folder / "mf6gwf"
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     tdis_ds = ((total_time, 1, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
@@ -344,7 +343,7 @@ def build_mf6gwf(sim_folder):
 def build_mf6gwt(sim_folder, longitudinal_dispersivity, retardation_factor, decay_rate):
     print(f"Building mf6gwt model...{sim_folder}")
     name = "trans"
-    sim_ws = os.path.join(workspace, sim_folder, "mf6gwt")
+    sim_ws = workspace / sim_folder / "mf6gwt"
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     tdis_ds = ((total_time, 240, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
@@ -442,7 +441,7 @@ def plot_results_ct(
 ):
     _, sim_mf6gwt = sims
     with styles.USGSPlot():
-        sim_ws = sim_mf6gwt.simulation_data.mfpath.get_sim_path()
+        sim_ws = Path(sim_mf6gwt.simulation_data.mfpath.get_sim_path())
         mf6gwt_ra = sim_mf6gwt.get_model("trans").obs.output.obs().data
         fig, axs = plt.subplots(1, 1, figsize=figure_size, dpi=300, tight_layout=True)
         alabel = ["ANALYTICAL", "", ""]
@@ -497,8 +496,7 @@ def plot_results_ct(
         if plot_show:
             plt.show()
         if plot_save:
-            sim_folder = os.path.split(sim_ws)[0]
-            sim_folder = os.path.basename(sim_folder)
+            sim_folder = sim_ws.parent.name
             fname = f"{sim_folder}-ct.png"
             fpth = figs_path / fname
             fig.savefig(fpth)
@@ -562,9 +560,8 @@ def plot_results_cd(
         if plot_show:
             plt.show()
         if plot_save:
-            sim_ws = sim_mf6gwt.simulation_data.mfpath.get_sim_path()
-            sim_folder = os.path.split(sim_ws)[0]
-            sim_folder = os.path.basename(sim_folder)
+            sim_ws = Path(sim_mf6gwt.simulation_data.mfpath.get_sim_path())
+            sim_folder = sim_ws.parent.name
             fname = f"{sim_folder}-cd.png"
             fpth = figs_path / fname
             fig.savefig(fpth)

--- a/scripts/ex-gwt-moc3d-p02.py
+++ b/scripts/ex-gwt-moc3d-p02.py
@@ -12,8 +12,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import git
@@ -28,11 +27,11 @@ from scipy.special import erfc
 # the README. Otherwise just use the current working directory.
 example_name = "ex-gwt-moc3d-p02"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -133,7 +132,7 @@ class Wexler3d:
 def build_mf6gwf(sim_folder):
     print(f"Building mf6gwf model...{sim_folder}")
     name = "flow"
-    sim_ws = os.path.join(workspace, sim_folder, "mf6gwf")
+    sim_ws = workspace / sim_folder / "mf6gwf"
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     tdis_ds = ((total_time, 1, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
@@ -182,7 +181,7 @@ def build_mf6gwf(sim_folder):
 def build_mf6gwt(sim_folder):
     print(f"Building mf6gwt model...{sim_folder}")
     name = "trans"
-    sim_ws = os.path.join(workspace, sim_folder, "mf6gwt")
+    sim_ws = workspace / sim_folder / "mf6gwt"
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     tdis_ds = ((total_time, 400, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
@@ -309,9 +308,8 @@ def plot_results(sims):
         if plot_show:
             plt.show()
         if plot_save:
-            sim_ws = sim_mf6gwt.simulation_data.mfpath.get_sim_path()
-            sim_folder = os.path.split(sim_ws)[0]
-            sim_folder = os.path.basename(sim_folder)
+            sim_ws = Path(sim_mf6gwt.simulation_data.mfpath.get_sim_path())
+            sim_folder = sim_ws.parent.name
             fname = f"{sim_folder}-map.png"
             fpth = figs_path / fname
             fig.savefig(fpth)

--- a/scripts/ex-gwt-moc3d-p02tg.py
+++ b/scripts/ex-gwt-moc3d-p02tg.py
@@ -15,8 +15,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 
 import flopy
 import flopy.utils.cvfdutil
@@ -32,11 +31,11 @@ from scipy.special import erfc
 # the README. Otherwise just use the current working directory.
 example_name = "ex-gwt-moc3d-p02tg"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -204,7 +203,7 @@ def make_grid():
 def build_mf6gwf(sim_folder):
     print(f"Building mf6gwf model...{sim_folder}")
     name = "flow"
-    sim_ws = os.path.join(workspace, sim_folder, "mf6gwf")
+    sim_ws = workspace / sim_folder / "mf6gwf"
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     tdis_ds = ((total_time, 1, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
@@ -263,7 +262,7 @@ def build_mf6gwf(sim_folder):
 def build_mf6gwt(sim_folder):
     print(f"Building mf6gwt model...{sim_folder}")
     name = "trans"
-    sim_ws = os.path.join(workspace, sim_folder, "mf6gwt")
+    sim_ws = workspace / sim_folder / "mf6gwt"
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     tdis_ds = ((total_time, 100, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
@@ -383,7 +382,7 @@ def plot_analytical(ax, levels):
 def plot_grid(sims):
     _, sim_mf6gwt = sims
     with styles.USGSMap():
-        sim_ws = sim_mf6gwt.simulation_data.mfpath.get_sim_path()
+        sim_ws = Path(sim_mf6gwt.simulation_data.mfpath.get_sim_path())
         fig, axs = plt.subplots(1, 1, figsize=figure_size, dpi=300, tight_layout=True)
         gwt = sim_mf6gwt.trans
         pmv = flopy.plot.PlotMapView(model=gwt, ax=axs)
@@ -395,8 +394,7 @@ def plot_grid(sims):
         if plot_show:
             plt.show()
         if plot_save:
-            sim_folder = os.path.split(sim_ws)[0]
-            sim_folder = os.path.basename(sim_folder)
+            sim_folder = sim_ws.parent.name
             fname = f"{sim_folder}-grid.png"
             fpth = figs_path / fname
             fig.savefig(fpth)
@@ -428,10 +426,8 @@ def plot_results(sims):
         if plot_show:
             plt.show()
         if plot_save:
-            sim_folder = os.path.split(
-                sim_mf6gwt.simulation_data.mfpath.get_sim_path()
-            )[0]
-            sim_folder = os.path.basename(sim_folder)
+            sim_ws = Path(sim_mf6gwt.simulation_data.mfpath.get_sim_path())
+            sim_folder = sim_ws.parent.name
             fname = f"{sim_folder}-map.png"
             fpth = figs_path / fname
             fig.savefig(fpth)

--- a/scripts/ex-gwt-mt3dms-p01.py
+++ b/scripts/ex-gwt-mt3dms-p01.py
@@ -23,8 +23,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -38,11 +37,11 @@ from modflow_devtools.misc import get_env, timed
 # in the git repository, use the folder structure described in
 # the README. Otherwise just use the current working directory.
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -170,7 +169,7 @@ def build_models(
     decay=0.0,
     silent=False,
 ):
-    mt3d_ws = os.path.join(workspace, sim_name, "mt3d")
+    mt3d_ws = workspace / sim_name / "mt3d"
     modelname_mf = "p01-mf"
 
     # Instantiate the MODFLOW model
@@ -282,7 +281,7 @@ def build_models(
     # MODFLOW 6
     name = "p01-mf6"
     gwfname = "gwf-" + name
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
 
     # Instantiating MODFLOW 6 time discretization
@@ -517,11 +516,10 @@ figure_size = (5, 3.5)
 
 
 def plot_results(mt3d, mf6, idx, ax=None):
-    mt3d_out_path = mt3d.model_ws
-    mf6.simulation_data.mfpath.get_sim_path()
+    mt3d_out_path = Path(mt3d.model_ws)
 
     # Get the MT3DMS concentration output
-    fname_mt3d = os.path.join(mt3d_out_path, "MT3D001.UCN")
+    fname_mt3d = mt3d_out_path / "MT3D001.UCN"
     ucnobj_mt3d = flopy.utils.UcnFile(fname_mt3d)
     conc_mt3d = ucnobj_mt3d.get_alldata()
 

--- a/scripts/ex-gwt-mt3dms-p03.py
+++ b/scripts/ex-gwt-mt3dms-p03.py
@@ -23,8 +23,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -39,11 +38,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 example_name = "ex-gwt-mt3dms-p03"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -143,7 +142,7 @@ tdis_rc.append((perlen, nstp, 1.0))
 
 # +
 def build_models(sim_name, mixelm=0, silent=False):
-    mt3d_ws = os.path.join(workspace, sim_name, "mt3d")
+    mt3d_ws = workspace / sim_name / "mt3d"
     modelname_mf = "p03-mf"
 
     # Instantiate the MODFLOW model
@@ -232,7 +231,7 @@ def build_models(sim_name, mixelm=0, silent=False):
     # MODFLOW 6
     name = "p03-mf6"
     gwfname = "gwf-" + name
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
 
     # Instantiating MODFLOW 6 time discretization
@@ -484,11 +483,10 @@ figure_size = (6, 4.5)
 
 
 def plot_results(mt3d, mf6, idx, ax=None):
-    mt3d_out_path = mt3d.model_ws
-    mf6.simulation_data.mfpath.get_sim_path()
+    mt3d_out_path = Path(mt3d.model_ws)
 
     # Get the MT3DMS concentration output
-    fname_mt3d = os.path.join(mt3d_out_path, "MT3D001.UCN")
+    fname_mt3d = mt3d_out_path / "MT3D001.UCN"
     ucnobj_mt3d = flopy.utils.UcnFile(fname_mt3d)
     conc_mt3d = ucnobj_mt3d.get_alldata()
 

--- a/scripts/ex-gwt-mt3dms-p04.py
+++ b/scripts/ex-gwt-mt3dms-p04.py
@@ -23,8 +23,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -39,11 +38,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 example_name = "ex-gwt-mt3dms-p04"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -167,7 +166,7 @@ tdis_rc.append((perlen, nstp, 1.0))
 
 # +
 def build_models(sim_name, mixelm=0, silent=False):
-    mt3d_ws = os.path.join(workspace, sim_name, "mt3d")
+    mt3d_ws = workspace / sim_name / "mt3d"
     modelname_mf = "p04-mf"
 
     # Instantiate the MODFLOW model
@@ -260,7 +259,7 @@ def build_models(sim_name, mixelm=0, silent=False):
     # MODFLOW 6
     name = "p04-mf6"
     gwfname = "gwf-" + name
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
 
     # Instantiating MODFLOW 6 time discretization
@@ -503,11 +502,10 @@ figure_size = (6, 4.5)
 
 
 def plot_results(mt3d, mf6, idx, leglab1, leglab2, ax=None):
-    mt3d_out_path = mt3d.model_ws
-    mf6.simulation_data.mfpath.get_sim_path()
+    mt3d_out_path = Path(mt3d.model_ws)
 
     # Get the MT3DMS concentration output
-    fname_mt3d = os.path.join(mt3d_out_path, "MT3D001.UCN")
+    fname_mt3d = mt3d_out_path / "MT3D001.UCN"
     ucnobj_mt3d = flopy.utils.UcnFile(fname_mt3d)
     conc_mt3d = ucnobj_mt3d.get_alldata()
 

--- a/scripts/ex-gwt-mt3dms-p05.py
+++ b/scripts/ex-gwt-mt3dms-p05.py
@@ -23,8 +23,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -39,11 +38,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 example_name = "ex-gwt-mt3dms-p05"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -150,7 +149,7 @@ tdis_rc.append((perlen, nstp, 1.0))
 
 # +
 def build_models(sim_name, mixelm=0, silent=False):
-    mt3d_ws = os.path.join(workspace, sim_name, "mt3d")
+    mt3d_ws = workspace / sim_name / "mt3d"
     modelname_mf = "p05-mf"
 
     # Instantiate the MODFLOW model
@@ -242,7 +241,7 @@ def build_models(sim_name, mixelm=0, silent=False):
     # MODFLOW 6
     name = "p05-mf6"
     gwfname = "gwf-" + name
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
 
     # Instantiating MODFLOW 6 time discretization
@@ -484,11 +483,10 @@ figure_size = (6, 4.5)
 
 
 def plot_results(mt3d, mf6, idx, ax=None, ax2=None):
-    mt3d_out_path = mt3d.model_ws
-    mf6.simulation_data.mfpath.get_sim_path()
+    mt3d_out_path = Path(mt3d.model_ws)
 
     # Get the MT3DMS concentration output
-    fname_mt3d = os.path.join(mt3d_out_path, "MT3D001.UCN")
+    fname_mt3d = mt3d_out_path / "MT3D001.UCN"
     ucnobj_mt3d = flopy.utils.UcnFile(fname_mt3d)
     conc_mt3d = ucnobj_mt3d.get_alldata()
 

--- a/scripts/ex-gwt-mt3dms-p06.py
+++ b/scripts/ex-gwt-mt3dms-p06.py
@@ -23,8 +23,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -39,11 +38,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 example_name = "ex-gwt-mt3dms-p06"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variable
 write = get_env("WRITE", True)
@@ -160,7 +159,7 @@ tdis_rc.append((perlen, nstp, 1.0))
 
 # +
 def build_models(sim_name, mixelm=0, silent=False):
-    mt3d_ws = os.path.join(workspace, sim_name, "mt3d")
+    mt3d_ws = workspace / sim_name / "mt3d"
     modelname_mf = "p06-mf"
 
     # Instantiate the MODFLOW model
@@ -251,7 +250,7 @@ def build_models(sim_name, mixelm=0, silent=False):
     # MODFLOW 6
     name = "p06-mf6"
     gwfname = "gwf-" + name
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
 
     # Instantiating MODFLOW 6 time discretization
@@ -487,16 +486,15 @@ figure_size = (6, 4.5)
 
 
 def plot_results(mt3d, mf6, idx, ax=None):
-    mt3d_out_path = mt3d.model_ws
-    mf6_out_path = mf6.simulation_data.mfpath.get_sim_path()
-    mf6.simulation_data.mfpath.get_sim_path()
+    mt3d_out_path = Path(mt3d.model_ws)
+    mf6_out_path = Path(mf6.simulation_data.mfpath.get_sim_path())
 
     # Get the MT3DMS observation output file
-    fname = os.path.join(mt3d_out_path, "MT3D001.OBS")
-    cvt = mt3d.load_obs(fname) if os.path.isfile(fname) else None
+    fname = mt3d_out_path / "MT3D001.OBS"
+    cvt = mt3d.load_obs(fname) if fname.is_file() else None
 
     # Get the MODFLOW 6 concentration observation output file
-    fname = os.path.join(mf6_out_path, list(mf6.model_names)[1] + ".obs.csv")
+    fname = mf6_out_path / (list(mf6.model_names)[1] + ".obs.csv")
     mf6cobs = flopy.utils.Mf6Obs(fname).data
 
     # Create figure for scenario

--- a/scripts/ex-gwt-mt3dms-p07.py
+++ b/scripts/ex-gwt-mt3dms-p07.py
@@ -23,8 +23,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -39,11 +38,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 example_name = "ex-gwt-mt3dms-p07"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -162,7 +161,7 @@ tdis_rc.append((perlen, nstp, 1.0))
 
 # +
 def build_models(sim_name, mixelm=0, silent=False):
-    mt3d_ws = os.path.join(workspace, sim_name, "mt3d")
+    mt3d_ws = workspace / sim_name / "mt3d"
     modelname_mf = "p07-mf"
 
     # Instantiate the MODFLOW model
@@ -252,7 +251,7 @@ def build_models(sim_name, mixelm=0, silent=False):
     # MODFLOW 6
     name = "p07-mf6"
     gwfname = "gwf-" + name
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
 
     # Instantiating MODFLOW 6 time discretization
@@ -484,11 +483,10 @@ figure_size = (4, 8)
 
 
 def plot_results(mf2k5, mt3d, mf6, idx, ax=None):
-    mt3d_out_path = mt3d.model_ws
-    mf6.simulation_data.mfpath.get_sim_path()
+    mt3d_out_path = Path(mt3d.model_ws)
 
     # Get the MT3DMS concentration output
-    fname_mt3d = os.path.join(mt3d_out_path, "MT3D001.UCN")
+    fname_mt3d = mt3d_out_path / "MT3D001.UCN"
     ucnobj_mt3d = flopy.utils.UcnFile(fname_mt3d)
     conc_mt3d = ucnobj_mt3d.get_alldata()
 

--- a/scripts/ex-gwt-mt3dms-p08.py
+++ b/scripts/ex-gwt-mt3dms-p08.py
@@ -23,8 +23,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -41,13 +40,13 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwt-mt3dms-p08"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = pl.Path(f"../data/{sim_name}")
-data_path = data_path if data_path.is_dir() else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = Path(f"../data/{sim_name}")
+data_path = data_path if data_path.is_dir() else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -185,7 +184,7 @@ tdis_rc.append((perlen, nstp, 1.0))
 # +
 def build_models(mixelm=0, silent=False):
     print(f"Building mf2005 model...{sim_name}")
-    mt3d_ws = os.path.join(workspace, sim_name, "mt3d")
+    mt3d_ws = workspace / sim_name / "mt3d"
     modelname_mf = "p08-mf"
 
     # Instantiate the MODFLOW model
@@ -279,7 +278,7 @@ def build_models(mixelm=0, silent=False):
     print(f"Building mf6gwt model...{sim_name}")
     name = "p08_mf6"
     gwfname = "gwf_" + name
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
 
     # Instantiating MODFLOW 6 time discretization
@@ -564,11 +563,10 @@ figure_size = (5, 7)
 
 
 def plot_results(mf2k5, mt3d, mf6, idx, ax=None):
-    mt3d_out_path = mt3d.model_ws
-    mf6.simulation_data.mfpath.get_sim_path()
+    mt3d_out_path = Path(mt3d.model_ws)
 
     # Get the MT3DMS concentration output
-    fname_mt3d = os.path.join(mt3d_out_path, "MT3D001.UCN")
+    fname_mt3d = mt3d_out_path / "MT3D001.UCN"
     ucnobj_mt3d = flopy.utils.UcnFile(fname_mt3d)
     conc_mt3d = ucnobj_mt3d.get_alldata()
 

--- a/scripts/ex-gwt-mt3dms-p09.py
+++ b/scripts/ex-gwt-mt3dms-p09.py
@@ -23,8 +23,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -39,13 +38,13 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 example_name = "ex-gwt-mt3dms-p09"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = pl.Path(f"../data/{example_name}")
-data_path = data_path if data_path.is_dir() else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = Path(f"../data/{example_name}")
+data_path = data_path if data_path.is_dir() else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -158,7 +157,7 @@ nadvfd = 1
 # +
 def build_models(sim_name, mixelm=0, silent=False):
     print(f"Building mf2005 model...{sim_name}")
-    mt3d_ws = os.path.join(workspace, sim_name, "mt3d")
+    mt3d_ws = workspace / sim_name / "mt3d"
     modelname_mf = "p09-mf"
 
     # Instantiate the MODFLOW model
@@ -257,7 +256,7 @@ def build_models(sim_name, mixelm=0, silent=False):
 
     name = "p09-mf6"
     gwfname = "gwf-" + name
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
 
     # Instantiating MODFLOW 6 time discretization
@@ -512,11 +511,10 @@ figure_size = (7, 5)
 
 
 def plot_results(mf2k5, mt3d, mf6, idx, ax=None):
-    mt3d_out_path = mt3d.model_ws
-    mf6.simulation_data.mfpath.get_sim_path()
+    mt3d_out_path = Path(mt3d.model_ws)
 
     # Get the MT3DMS concentration output
-    fname_mt3d = os.path.join(mt3d_out_path, "MT3D001.UCN")
+    fname_mt3d = mt3d_out_path / "MT3D001.UCN"
     ucnobj_mt3d = flopy.utils.UcnFile(fname_mt3d)
     conc_mt3d = ucnobj_mt3d.get_alldata()
 

--- a/scripts/ex-gwt-mt3dms-p10.py
+++ b/scripts/ex-gwt-mt3dms-p10.py
@@ -23,8 +23,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -41,13 +40,13 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwt-mt3dms-p10"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = pl.Path(f"../data/{sim_name}")
-data_path = data_path if data_path.is_dir() else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = Path(f"../data/{sim_name}")
+data_path = data_path if data_path.is_dir() else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -238,7 +237,7 @@ nadvfd = 1
 # +
 def build_models(mixelm=0, silent=False):
     print(f"Building mf2005 model...{sim_name}")
-    mt3d_ws = os.path.join(workspace, sim_name, "mt3d")
+    mt3d_ws = workspace / sim_name / "mt3d"
     modelname_mf = "p10-mf"
 
     # Instantiate the MODFLOW model
@@ -347,7 +346,7 @@ def build_models(mixelm=0, silent=False):
 
     name = "p10-mf6"
     gwfname = "gwf-" + name
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
 
     # Instantiating MODFLOW 6 time discretization
@@ -625,11 +624,10 @@ figure_size = (6, 8)
 
 
 def plot_results(mf2k5, mt3d, mf6, idx, ax=None):
-    mt3d_out_path = mt3d.model_ws
-    mf6.simulation_data.mfpath.get_sim_path()
+    mt3d_out_path = Path(mt3d.model_ws)
 
     # Get the MT3DMS concentration output
-    fname_mt3d = os.path.join(mt3d_out_path, "MT3D001.UCN")
+    fname_mt3d = mt3d_out_path / "MT3D001.UCN"
     ucnobj_mt3d = flopy.utils.UcnFile(fname_mt3d)
     conc_mt3d = ucnobj_mt3d.get_alldata()
 

--- a/scripts/ex-gwt-mt3dsupp631.py
+++ b/scripts/ex-gwt-mt3dsupp631.py
@@ -13,8 +13,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -28,11 +27,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 example_name = "ex-gwt-mt3dsupp631"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -78,7 +77,7 @@ obs_xloc = 8.0  # Observation x location ($m$)
 def build_mf6gwf(sim_folder):
     print(f"Building mf6gwf model...{sim_folder}")
     name = "flow"
-    sim_ws = os.path.join(workspace, sim_folder, "mf6gwf")
+    sim_ws = workspace / sim_folder / "mf6gwf"
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     tdis_ds = (
         (source_duration, 1, 1.0),
@@ -131,7 +130,7 @@ def build_mf6gwf(sim_folder):
 def build_mf6gwt(sim_folder):
     print(f"Building mf6gwt model...{sim_folder}")
     name = "trans"
-    sim_ws = os.path.join(workspace, sim_folder, "mf6gwt")
+    sim_ws = workspace / sim_folder / "mf6gwt"
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     pertim1 = source_duration
     pertim2 = total_time - source_duration
@@ -183,7 +182,7 @@ def build_mf6gwt(sim_folder):
 def build_mf2005(sim_folder):
     print(f"Building mf2005 model...{sim_folder}")
     name = "flow"
-    sim_ws = os.path.join(workspace, sim_folder, "mf2005")
+    sim_ws = workspace / sim_folder / "mf2005"
     mf = flopy.modflow.Modflow(modelname=name, model_ws=sim_ws, exe_name="mf2005")
     pertim1 = source_duration
     pertim2 = total_time - source_duration
@@ -216,7 +215,7 @@ def build_mf2005(sim_folder):
 def build_mt3dms(sim_folder, modflowmodel):
     print(f"Building mt3dms model...{sim_folder}")
     name = "trans"
-    sim_ws = os.path.join(workspace, sim_folder, "mt3d")
+    sim_ws = workspace / sim_folder / "mt3d"
     mt = flopy.mt3d.Mt3dms(
         modelname=name,
         model_ws=sim_ws,
@@ -298,8 +297,8 @@ def plot_results(sims, idx):
             label="MODFLOW 6 GWT",
         )
 
-        sim_ws = sim_mt3dms.model_ws
-        fname = os.path.join(sim_ws, "MT3D001.OBS")
+        sim_ws = Path(sim_mt3dms.model_ws)
+        fname = sim_ws / "MT3D001.OBS"
         mt3dms_ra = sim_mt3dms.load_obs(fname)
         colname = mt3dms_ra.dtype.names[2]
         axs.plot(
@@ -316,8 +315,7 @@ def plot_results(sims, idx):
         if plot_show:
             plt.show()
         if plot_save:
-            sim_folder = os.path.split(sim_ws)[0]
-            sim_folder = os.path.basename(sim_folder)
+            sim_folder = sim_ws.parent.name
             fname = f"{sim_folder}.png"
             fpth = figs_path / fname
             fig.savefig(fpth)

--- a/scripts/ex-gwt-mt3dsupp632.py
+++ b/scripts/ex-gwt-mt3dsupp632.py
@@ -13,8 +13,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -27,11 +26,11 @@ from modflow_devtools.misc import get_env, timed
 # in the git repository, use the folder structure described in
 # the README. Otherwise just use the current working directory.
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -114,7 +113,7 @@ dual_domain = True  # Flag indicating that dual domain is active
 def build_mf6gwf(sim_folder):
     print(f"Building mf6gwf model...{sim_folder}")
     name = "flow"
-    sim_ws = os.path.join(workspace, sim_folder, "mf6gwf")
+    sim_ws = workspace / sim_folder / "mf6gwf"
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     tdis_ds = (
         (source_duration, 1, 1.0),
@@ -162,7 +161,7 @@ def build_mf6gwf(sim_folder):
 def build_mf6gwt(sim_folder, distribution_coefficient, decay, decay_sorbed):
     print(f"Building mf6gwt model...{sim_folder}")
     name = "trans"
-    sim_ws = os.path.join(workspace, sim_folder, "mf6gwt")
+    sim_ws = workspace / sim_folder / "mf6gwt"
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     pertim1 = source_duration
     pertim2 = total_time - source_duration
@@ -253,7 +252,7 @@ def build_mf6gwt(sim_folder, distribution_coefficient, decay, decay_sorbed):
 def build_mf2005(sim_folder):
     print(f"Building mf2005 model...{sim_folder}")
     name = "flow"
-    sim_ws = os.path.join(workspace, sim_folder, "mf2005")
+    sim_ws = workspace / sim_folder / "mf2005"
     mf = flopy.modflow.Modflow(modelname=name, model_ws=sim_ws, exe_name="mf2005")
     pertim1 = source_duration
     pertim2 = total_time - source_duration
@@ -288,7 +287,7 @@ def build_mt3dms(
 ):
     print(f"Building mt3dms model...{sim_folder}")
     name = "trans"
-    sim_ws = os.path.join(workspace, sim_folder, "mt3d")
+    sim_ws = workspace / sim_folder / "mt3d"
     mt = flopy.mt3d.Mt3dms(
         modelname=name,
         model_ws=sim_ws,
@@ -394,9 +393,9 @@ def plot_results():
 
         case_colors = ["blue", "green", "red"]
         for icase, sim_name in enumerate(parameters.keys()):
-            sim_ws = os.path.join(workspace, sim_name)
+            sim_ws = workspace / sim_name
 
-            fname = os.path.join(sim_ws, "mf6gwt", "trans.obs.csv")
+            fname = sim_ws / "mf6gwt" / "trans.obs.csv"
             mf6gwt_ra = flopy.utils.Mf6Obs(fname).data
             axs.plot(
                 mf6gwt_ra["totim"],
@@ -408,7 +407,7 @@ def plot_results():
                 linestyle="None",
             )
 
-            fname = os.path.join(sim_ws, "mt3d", "MT3D001.OBS")
+            fname = sim_ws / "mt3d" / "MT3D001.OBS"
             mt3dms_ra = flopy.mt3d.Mt3dms.load_obs(fname)
             axs.plot(
                 mt3dms_ra["time"],
@@ -445,8 +444,8 @@ def plot_scenario_results(sims, idx):
             linestyle="None",
             label="MODFLOW 6 GWT",
         )
-        sim_ws = sim_mt3dms.model_ws
-        fname = os.path.join(sim_ws, "MT3D001.OBS")
+        sim_ws = Path(sim_mt3dms.model_ws)
+        fname = sim_ws / "MT3D001.OBS"
         mt3dms_ra = sim_mt3dms.load_obs(fname)
         axs.plot(
             mt3dms_ra["time"],
@@ -463,8 +462,7 @@ def plot_scenario_results(sims, idx):
         if plot_show:
             plt.show()
         if plot_save:
-            sim_folder = os.path.split(sim_ws)[0]
-            sim_folder = os.path.basename(sim_folder)
+            sim_folder = sim_ws.parent.name
             fname = f"{sim_folder}.png"
             fpth = figs_path / fname
             fig.savefig(fpth)

--- a/scripts/ex-gwt-mt3dsupp82.py
+++ b/scripts/ex-gwt-mt3dsupp82.py
@@ -15,8 +15,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -31,11 +30,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 example_name = "ex-gwt-mt3dsupp82"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -80,7 +79,7 @@ porosity = 0.3  # Porosity of mobile domain (unitless)
 def build_mf6gwf(sim_folder):
     print(f"Building mf6gwf model...{sim_folder}")
     name = "flow"
-    sim_ws = os.path.join(workspace, sim_folder, "mf6gwf")
+    sim_ws = workspace / sim_folder / "mf6gwf"
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     tdis_ds = ((total_time, 1, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
@@ -180,7 +179,7 @@ def build_mf6gwf(sim_folder):
 def build_mf6gwt(sim_folder):
     print(f"Building mf6gwt model...{sim_folder}")
     name = "trans"
-    sim_ws = os.path.join(workspace, sim_folder, "mf6gwt")
+    sim_ws = workspace / sim_folder / "mf6gwt"
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     tdis_ds = ((total_time, 20, 1.0),)
     flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
@@ -265,7 +264,7 @@ def build_mf6gwt(sim_folder):
 def build_mf2005(sim_folder):
     print(f"Building mf2005 model...{sim_folder}")
     name = "flow"
-    sim_ws = os.path.join(workspace, sim_folder, "mf2005")
+    sim_ws = workspace / sim_folder / "mf2005"
     mf = flopy.modflow.Modflow(modelname=name, model_ws=sim_ws, exe_name="mf2005")
     perlen = [total_time]
     dis = flopy.modflow.ModflowDis(
@@ -305,7 +304,7 @@ def build_mf2005(sim_folder):
 def build_mt3dms(sim_folder, modflowmodel):
     print(f"Building mt3dms model...{sim_folder}")
     name = "trans"
-    sim_ws = os.path.join(workspace, sim_folder, "mt3d")
+    sim_ws = workspace / sim_folder / "mt3d"
     mt = flopy.mt3d.Mt3dms(
         modelname=name,
         model_ws=sim_ws,
@@ -381,8 +380,8 @@ def plot_results(sims, idx):
     with styles.USGSMap() as fs:
         conc = gwt.output.concentration().get_data()
 
-        sim_ws = sim_mt3dms.model_ws
-        fname = os.path.join(sim_ws, "MT3D001.UCN")
+        sim_ws = Path(sim_mt3dms.model_ws)
+        fname = sim_ws / "MT3D001.UCN"
         cobjmt = flopy.utils.UcnFile(fname)
         concmt = cobjmt.get_data()
 
@@ -412,8 +411,7 @@ def plot_results(sims, idx):
         if plot_show:
             plt.show()
         if plot_save:
-            sim_folder = os.path.split(sim_ws)[0]
-            sim_folder = os.path.basename(sim_folder)
+            sim_folder = sim_ws.parent.name
             fname = f"{sim_folder}-map.png"
             fpth = figs_path / fname
             fig.savefig(fpth)

--- a/scripts/ex-gwt-prudic2004t2.py
+++ b/scripts/ex-gwt-prudic2004t2.py
@@ -14,8 +14,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -31,13 +30,13 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwt-prudic2004t2"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = pl.Path(f"../data/{sim_name}")
-data_path = data_path if data_path.is_dir() else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = Path(f"../data/{sim_name}")
+data_path = data_path if data_path.is_dir() else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -197,7 +196,7 @@ def build_mf6gwf(sim_folder):
     global idomain
     print(f"Building mf6gwf model...{sim_folder}")
     name = "flow"
-    sim_ws = os.path.join(workspace, sim_folder, "mf6gwf")
+    sim_ws = workspace / sim_folder / "mf6gwf"
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     tdis_data = [(total_time, 1, 1.0)]
     flopy.mf6.ModflowTdis(
@@ -345,7 +344,7 @@ def build_mf6gwf(sim_folder):
 def build_mf6gwt(sim_folder):
     print(f"Building mf6gwt model...{sim_folder}")
     name = "trans"
-    sim_ws = os.path.join(workspace, sim_folder, "mf6gwt")
+    sim_ws = workspace / sim_folder / "mf6gwt"
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name="mf6")
     tdis_data = ((total_time, 300, 1.0),)
     flopy.mf6.ModflowTdis(
@@ -556,7 +555,7 @@ def plot_gwf_results(sims):
     sim_mf6gwf, _ = sims
     gwf = sim_mf6gwf.flow
     with styles.USGSMap():
-        sim_ws = sim_mf6gwf.simulation_data.mfpath.get_sim_path()
+        sim_ws = Path(sim_mf6gwf.simulation_data.mfpath.get_sim_path())
 
         head = gwf.output.head().get_data()
         stage = gwf.lak.output.stage().get_data().flatten()
@@ -588,8 +587,7 @@ def plot_gwf_results(sims):
         if plot_show:
             plt.show()
         if plot_save:
-            sim_folder = os.path.split(sim_ws)[0]
-            sim_folder = os.path.basename(sim_folder)
+            sim_folder = sim_ws.parent.name
             fname = f"{sim_folder}-head.png"
             fpth = figs_path / fname
             fig.savefig(fpth)
@@ -602,7 +600,7 @@ def plot_gwt_results(sims):
     gwt = sim_mf6gwt.trans
 
     with styles.USGSMap() as fs:
-        sim_ws = sim_mf6gwt.simulation_data.mfpath.get_sim_path()
+        sim_ws = Path(sim_mf6gwt.simulation_data.mfpath.get_sim_path())
 
         conc = gwt.output.concentration().get_data()
         lakconc = gwt.lak.output.concentration().get_data().flatten()
@@ -649,8 +647,7 @@ def plot_gwt_results(sims):
         if plot_show:
             plt.show()
         if plot_save:
-            sim_folder = os.path.split(sim_ws)[0]
-            sim_folder = os.path.basename(sim_folder)
+            sim_folder = sim_ws.parent.name
             fname = f"{sim_folder}-conc.png"
             fpth = figs_path / fname
             fig.savefig(fpth)
@@ -708,8 +705,7 @@ def plot_gwt_results(sims):
             if plot_show:
                 plt.show()
             if plot_save:
-                sim_folder = os.path.split(sim_ws)[0]
-                sim_folder = os.path.basename(sim_folder)
+                sim_folder = sim_ws.parent.name
                 fname = f"{sim_folder}-cvt.png"
                 fpth = figs_path / fname
                 fig.savefig(fpth)

--- a/scripts/ex-gwt-rotate.py
+++ b/scripts/ex-gwt-rotate.py
@@ -7,8 +7,7 @@
 # Import dependencies, define some variables, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -23,11 +22,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwt-rotate"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -193,7 +192,7 @@ def get_cstrt(nlay, ncol, length, x1, x2, a1, a2, b, c1, c2, c3):
 def build_models(sim_folder):
     print(f"Building model...{sim_folder}")
     name = "flow"
-    sim_ws = os.path.join(workspace, sim_folder)
+    sim_ws = workspace / sim_folder
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         sim_ws=sim_ws,
@@ -317,7 +316,7 @@ figure_size = (6, 4)
 
 def plot_velocity_profile(sim, idx):
     with styles.USGSMap() as fs:
-        sim_ws = os.path.join(workspace, sim_name)
+        sim_ws = workspace / sim_name
         gwf = sim.get_model("flow")
         gwt = sim.get_model("trans")
         print("Creating velocity profile plot...")
@@ -362,7 +361,7 @@ def plot_velocity_profile(sim, idx):
 
         # plot numerical results
         file_name = gwf.oc.budget_filerecord.get_data()[0][0]
-        fpth = os.path.join(sim_ws, file_name)
+        fpth = sim_ws / file_name
         bobj = flopy.utils.CellBudgetFile(fpth, precision="double")
         kstpkper = bobj.get_kstpkper()
         spdis = bobj.get_data(text="DATA-SPDIS", kstpkper=kstpkper[0])[0]
@@ -394,7 +393,7 @@ def plot_velocity_profile(sim, idx):
 
 def plot_conc(sim, idx):
     with styles.USGSMap() as fs:
-        sim_ws = os.path.join(workspace, sim_name)
+        sim_ws = workspace / sim_name
         gwf = sim.get_model("flow")
         gwt = sim.get_model("trans")
 
@@ -454,7 +453,7 @@ def make_animated_gif(sim, idx):
 
     print("Creating animation...")
     with styles.USGSMap() as fs:
-        sim_ws = os.path.join(workspace, sim_name)
+        sim_ws = workspace / sim_name
         gwf = sim.get_model("flow")
         gwt = sim.get_model("trans")
 

--- a/scripts/ex-gwt-saltlake.py
+++ b/scripts/ex-gwt-saltlake.py
@@ -14,8 +14,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -30,11 +29,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 example_name = "ex-gwt-saltlake"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -100,7 +99,7 @@ hclose, rclose, relax = 1e-8, 1e-8, 0.97
 def build_models(sim_folder):
     print(f"Building model...{sim_folder}")
     name = "flow"
-    sim_ws = os.path.join(workspace, sim_folder)
+    sim_ws = workspace / sim_folder
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         sim_ws=sim_ws,
@@ -251,7 +250,7 @@ figure_size = (6, 8)
 def plot_conc(sim, idx):
     with styles.USGSMap():
         sim_name = example_name
-        sim_ws = os.path.join(workspace, sim_name)
+        sim_ws = workspace / sim_name
         gwf = sim.get_model("flow")
         gwt = sim.get_model("trans")
 
@@ -319,7 +318,7 @@ def make_animated_gif(sim, idx):
 
     with styles.USGSMap():
         sim_name = example_name
-        sim_ws = os.path.join(workspace, sim_name)
+        sim_ws = workspace / sim_name
         gwf = sim.get_model("flow")
         gwt = sim.get_model("trans")
 

--- a/scripts/ex-gwt-stallman.py
+++ b/scripts/ex-gwt-stallman.py
@@ -13,8 +13,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -30,11 +29,11 @@ from modflow_devtools.misc import get_env, timed
 # the README. Otherwise just use the current working directory.
 example_name = "ex-gwt-stallman"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -140,7 +139,7 @@ def Stallman(T_az, dT, tau, t, c_rho, darcy_flux, ko, c_w, rho_w, zbotm, nlay):
 def build_models(sim_folder):
     print(f"Building model...{sim_folder}")
     name = "flow"
-    sim_ws = os.path.join(workspace, sim_folder)
+    sim_ws = workspace / sim_folder
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         sim_ws=sim_ws,
@@ -273,7 +272,7 @@ figure_size = (6, 8)
 def plot_conc(sim, idx):
     with styles.USGSMap() as fs:
         sim_name = example_name
-        sim_ws = os.path.join(workspace, sim_name)
+        sim_ws = workspace / sim_name
         gwf = sim.get_model("flow")
         gwt = sim.get_model("trans")
 
@@ -333,7 +332,7 @@ def plot_conc(sim, idx):
 
 def make_animated_gif(sim, idx):
     sim_name = example_name
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     gwf = sim.get_model("flow")
     gwt = sim.get_model("trans")
 

--- a/scripts/ex-gwt-synthetic-valley.py
+++ b/scripts/ex-gwt-synthetic-valley.py
@@ -7,8 +7,7 @@
 # Import dependencies, define the example name and workspace, read settings from environment variables, and define some general utilities.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -121,13 +120,13 @@ def circle_function(center=(0, 0), radius=1.0, dtheta=10.0):
 # the README. Otherwise just use the current working directory.
 sim_name = "ex-gwt-synthetic-valley"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
-data_path = pl.Path(f"../data/{sim_name}")
-data_path = data_path if data_path.is_dir() else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
+data_path = Path(f"../data/{sim_name}")
+data_path = data_path if data_path.is_dir() else Path.cwd()
 
 # Conversion factors
 ft2m = 1.0 / 3.28081
@@ -206,7 +205,7 @@ wp = np.array(well_points)
 
 # +
 # create the voronoi grid
-temp_path = pl.Path("temp/triangle_data")
+temp_path = Path("temp/triangle_data")
 temp_path.mkdir(parents=True, exist_ok=True)
 tri = Triangle(angle=30, nodes=sg_densify, model_ws=temp_path)
 tri.add_polygon(bp_densify)
@@ -456,7 +455,7 @@ welspd = [
 def build_mf6gwf(sim_folder):
     print(f"Building mf6gwf model...{sim_folder}")
     name = "flow"
-    sim_ws = os.path.join(workspace, sim_folder, "mf6gwf")
+    sim_ws = workspace / sim_folder / "mf6gwf"
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         sim_ws=sim_ws,
@@ -555,7 +554,7 @@ def build_mf6gwf(sim_folder):
 def build_mf6gwt(sim_folder):
     print(f"Building mf6gwt model...{sim_folder}")
     name = "trans"
-    sim_ws = os.path.join(workspace, sim_folder, "mf6gwt")
+    sim_ws = workspace / sim_folder / "mf6gwt"
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         sim_ws=sim_ws,
@@ -810,7 +809,7 @@ def plot_results(sims, idx):
 def plot_river_mapping(sims, idx):
     print("Plotting river mapping...")
     sim_mf6gwf, _, _, _ = sims
-    sim_ws = sim_mf6gwf.simulation_data.mfpath.get_sim_path()
+    sim_ws = Path(sim_mf6gwf.simulation_data.mfpath.get_sim_path())
     dv = 100.0  # m
 
     with styles.USGSMap():
@@ -886,7 +885,7 @@ def plot_river_mapping(sims, idx):
         if plot_show:
             plt.show()
         if plot_save:
-            sim_folder = os.path.basename(os.path.split(sim_ws)[0])
+            sim_folder = sim_ws.parent.name
             fname = f"{sim_folder}-river-discretization.png"
             fig.savefig(figs_path / fname)
 
@@ -894,7 +893,7 @@ def plot_river_mapping(sims, idx):
 def plot_head_results(sims, idx):
     print("Plotting gwf model results...")
     sim_mf6gwf, _, _, _ = sims
-    sim_ws = sim_mf6gwf.simulation_data.mfpath.get_sim_path()
+    sim_ws = Path(sim_mf6gwf.simulation_data.mfpath.get_sim_path())
     gwf = sim_mf6gwf.flow
 
     xlims = (extent[0], extent[1])
@@ -1026,7 +1025,7 @@ def plot_head_results(sims, idx):
         if plot_show:
             plt.show()
         if plot_save:
-            sim_folder = os.path.basename(os.path.split(sim_ws)[0])
+            sim_folder = sim_ws.parent.name
             fname = f"{sim_folder}-head.png"
             fig.savefig(figs_path / fname)
 
@@ -1034,7 +1033,7 @@ def plot_head_results(sims, idx):
 def plot_conc_results(sims):
     print("Plotting gwt model results...")
     _, sim_mf6gwt, _, _ = sims
-    sim_ws = sim_mf6gwt.simulation_data.mfpath.get_sim_path()
+    sim_ws = Path(sim_mf6gwt.simulation_data.mfpath.get_sim_path())
     gwt = sim_mf6gwt.trans
     with styles.USGSMap():
         fig = plt.figure(figsize=six_panel_figsize, constrained_layout=True)
@@ -1133,8 +1132,7 @@ def plot_conc_results(sims):
         if plot_show:
             plt.show()
         if plot_save:
-            sim_folder = os.path.split(sim_ws)[0]
-            sim_folder = os.path.basename(sim_folder)
+            sim_folder = sim_ws.parent.name
             fname = f"{sim_folder}-conc.png"
             fig.savefig(figs_path / fname)
 

--- a/scripts/ex-gwt-uzt-2d.py
+++ b/scripts/ex-gwt-uzt-2d.py
@@ -8,8 +8,7 @@
 # Import dependencies, define the example name and workspace, and read settings from environment variables.
 
 # +
-import os
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -23,11 +22,11 @@ from modflow_devtools.misc import get_env, timed
 # in the git repository, use the folder structure described in
 # the README. Otherwise just use the current working directory.
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 
 # Settings from environment variables
 write = get_env("WRITE", True)
@@ -287,7 +286,7 @@ def build_models(
     silent=False,
 ):
     print(f"Building mf-nwt model...{sim_name}")
-    model_ws = os.path.join(workspace, sim_name, "mt3d")
+    model_ws = workspace / sim_name / "mt3d"
     modelname_mf = "uzt-2d-mf"
 
     # Instantiate the MODFLOW model
@@ -446,7 +445,7 @@ def build_models(
 
     name = "uzt-2d-mf6"
     gwfname = "gwf-" + name
-    sim_ws = os.path.join(workspace, sim_name)
+    sim_ws = workspace / sim_name
     sim = flopy.mf6.MFSimulation(sim_name=sim_name, sim_ws=sim_ws, exe_name="mf6")
 
     # How much output to write?
@@ -779,12 +778,10 @@ figure_size = (6, 4)
 
 def plot_results(mf2k5, mt3d, mf6, idx, ax=None):
     print("Plotting model results...")
-    mt3d_out_path = mt3d.model_ws
-    mf6_out_path = mf6.simulation_data.mfpath.get_sim_path()
-    mf6.simulation_data.mfpath.get_sim_path()
+    mt3d_out_path = Path(mt3d.model_ws)
 
     # Get the MF-NWT heads
-    fname_mfnwt = os.path.join(mt3d_out_path, "uzt-2d-mf.hds")
+    fname_mfnwt = mt3d_out_path / "uzt-2d-mf.hds"
     hds_mfnwt = flopy.utils.HeadFile(fname_mfnwt)
     hds = hds_mfnwt.get_alldata()
     # Make list of vertices for plotting the saturated zone as a polygon
@@ -804,7 +801,7 @@ def plot_results(mf2k5, mt3d, mf6, idx, ax=None):
     poly_pts = np.array(satzn)
 
     # Get the MT3DMS concentration output
-    fname_mt3d = os.path.join(mt3d_out_path, "MT3D001.UCN")
+    fname_mt3d = mt3d_out_path / "MT3D001.UCN"
     ucnobj_mt3d = flopy.utils.UcnFile(fname_mt3d)
     times_mt3d = ucnobj_mt3d.get_times()
     conc_mt3d = ucnobj_mt3d.get_alldata()

--- a/scripts/ex-prt-mp7-p01.py
+++ b/scripts/ex-prt-mp7-p01.py
@@ -25,7 +25,7 @@
 # and read settings from environment variables.
 
 # +
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -48,11 +48,11 @@ gwf_name = sim_name.replace("ex-prt-", "") + "-gwf"
 prt_name = sim_name.replace("ex-prt-", "") + "-prt"
 mp7_name = sim_name.replace("ex-prt-", "") + "-mp7"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 sim_ws = workspace / sim_name
 gwf_ws = sim_ws / "gwf"
 prt_ws = sim_ws / "prt"
@@ -367,8 +367,8 @@ def build_models(example_name):
 
     # Instantiate the MODFLOW 6 prt flow model interface
     pd = [
-        ("GWFHEAD", pl.Path(f"../{gwf_ws.name}/{headfile}")),
-        ("GWFBUDGET", pl.Path(f"../{gwf_ws.name}/{budgetfile}")),
+        ("GWFHEAD", Path(f"../{gwf_ws.name}/{headfile}")),
+        ("GWFBUDGET", Path(f"../{gwf_ws.name}/{budgetfile}")),
     ]
     flopy.mf6.ModflowPrtfmi(prt, packagedata=pd)
 

--- a/scripts/ex-prt-mp7-p02.py
+++ b/scripts/ex-prt-mp7-p02.py
@@ -27,7 +27,7 @@
 # and read settings from environment variables.
 
 # +
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -54,11 +54,11 @@ gwf_name = sim_name.replace("ex-prt-", "") + "-gwf"
 prt_name = sim_name.replace("ex-prt-", "") + "-prt"
 mp7_name = sim_name.replace("ex-prt-", "") + "-mp7"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 sim_ws = workspace / sim_name
 gwf_ws = sim_ws / "gwf"
 prt_ws = sim_ws / "prt"
@@ -464,8 +464,8 @@ def build_prt_sim():
     # Instantiate the MODFLOW 6 prt flow model interface
     # using "time-reversed" budget and head files
     pd = [
-        ("GWFHEAD", pl.Path(f"../{gwf_ws.name}/{headfile_bkwd}")),
-        ("GWFBUDGET", pl.Path(f"../{gwf_ws.name}/{budgetfile_bkwd}")),
+        ("GWFHEAD", Path(f"../{gwf_ws.name}/{headfile_bkwd}")),
+        ("GWFBUDGET", Path(f"../{gwf_ws.name}/{budgetfile_bkwd}")),
     ]
     flopy.mf6.ModflowPrtfmi(prt, packagedata=pd)
 

--- a/scripts/ex-prt-mp7-p03.py
+++ b/scripts/ex-prt-mp7-p03.py
@@ -30,7 +30,7 @@
 # and read settings from environment variables.
 
 # +
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -53,11 +53,11 @@ gwf_name = sim_name.replace("ex-prt-", "") + "-gwf"
 prt_name = sim_name.replace("ex-prt-", "") + "-prt"
 mp7_name = sim_name.replace("ex-prt-", "") + "-mp7"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 sim_ws = workspace / sim_name
 gwf_ws = sim_ws / "gwf"
 prt_ws = sim_ws / "prt"
@@ -435,8 +435,8 @@ def build_prt_model():
     flopy.mf6.ModflowPrtfmi(
         prt,
         packagedata=[
-            ("GWFHEAD", pl.Path(f"../{gwf_ws.name}/{headfile}")),
-            ("GWFBUDGET", pl.Path(f"../{gwf_ws.name}/{budgetfile}")),
+            ("GWFHEAD", Path(f"../{gwf_ws.name}/{headfile}")),
+            ("GWFBUDGET", Path(f"../{gwf_ws.name}/{budgetfile}")),
         ],
     )
 

--- a/scripts/ex-prt-mp7-p04.py
+++ b/scripts/ex-prt-mp7-p04.py
@@ -18,7 +18,7 @@
 # and read settings from environment variables.
 
 # +
-import pathlib as pl
+from pathlib import Path
 from pprint import pformat
 
 import flopy
@@ -43,11 +43,11 @@ gwf_name = sim_name.replace("ex-prt-", "") + "-gwf"
 prt_name = sim_name.replace("ex-prt-", "") + "-prt"
 mp7_name = sim_name.replace("ex-prt-", "") + "-mp7"
 try:
-    root = pl.Path(git.Repo(".", search_parent_directories=True).working_dir)
+    root = Path(git.Repo(".", search_parent_directories=True).working_dir)
 except:
     root = None
-workspace = root / "examples" if root else pl.Path.cwd()
-figs_path = root / "figures" if root else pl.Path.cwd()
+workspace = root / "examples" if root else Path.cwd()
+figs_path = root / "figures" if root else Path.cwd()
 sim_ws = workspace / sim_name
 gwf_ws = sim_ws / "gwf"
 prt_ws = sim_ws / "prt"
@@ -609,8 +609,8 @@ def build_prt():
     flopy.mf6.ModflowPrtfmi(
         prt,
         packagedata=[
-            ("GWFHEAD", pl.Path(f"../{gwf_ws.name}/{headfile_bkwd}")),
-            ("GWFBUDGET", pl.Path(f"../{gwf_ws.name}/{budgetfile_bkwd}")),
+            ("GWFHEAD", Path(f"../{gwf_ws.name}/{headfile_bkwd}")),
+            ("GWFBUDGET", Path(f"../{gwf_ws.name}/{budgetfile_bkwd}")),
         ],
     )
 


### PR DESCRIPTION
This refactor makes more consistent use of the standard pathlib module throughout all of the examples.