### PR TITLE
chore(dependencies): pin meson and other packages

### DIFF
--- a/.doc/requirements.rtd.txt
+++ b/.doc/requirements.rtd.txt
@@ -1,3 +1,4 @@
+sphinx>=4
 nbconvert==7.16.3
 nbsphinx
 nbsphinx_link
@@ -5,6 +6,6 @@ ipython
 ipykernel
 rtds_action
 sphinx_markdown_tables
-sphinx-rtd-theme
+sphinx-rtd-theme>=1
 pygments>=2.4.1
 myst-parser

--- a/etc/requirements.pip.txt
+++ b/etc/requirements.pip.txt
@@ -24,5 +24,5 @@ GitPython
 pyvista
 codespell
 ruff
-meson
+meson==1.3.0
 ninja


### PR DESCRIPTION
Fix the build error currently afflicting CI. It's somewhere in the mf5to6 converter. We pin meson to 1.3.0 upstream in mf6. Also pin some docs dependencies to the same versions as in the mf6 pixi environment.