### PR TITLE
chore: install rtd deps from pypi

### DIFF
--- a/.github/workflows/ex-workflow.yml
+++ b/.github/workflows/ex-workflow.yml
@@ -119,6 +119,8 @@ jobs:
     defaults:
       run:
         shell: bash -el {0}
+    env:
+      MPLBACKEND: agg
     steps:
       - name: Checkout MODFLOW 6 examples
         uses: actions/checkout@v4

--- a/environment.yml
+++ b/environment.yml
@@ -32,6 +32,13 @@ dependencies:
       - sphinx_markdown_tables
       - nbsphinx_link
       - rtds_action
+      - nbconvert==7.16.3
+      - nbsphinx
+      - ipython
+      - ipykernel
+      - sphinx-rtd-theme
+      - pygments>=2.4.1
+      - myst-parser
   - pooch
   - pyshp
   - pytest!=8.1.0
@@ -49,11 +56,3 @@ dependencies:
   - syrupy
   - tomli>=2.2.1,<3
   - tomli-w>=1.2.0,<2
-  # docs dependencies
-  - nbconvert==7.16.3
-  - nbsphinx
-  - ipython
-  - ipykernel
-  - sphinx-rtd-theme
-  - pygments>=2.4.1
-  - myst-parser


### PR DESCRIPTION
Switching to the conda environment [broke the description pages](https://modflow6-examples.readthedocs.io/en/latest/_examples/ex-gwe-geotherm.html) in the RTD site. Try installing RTD deps from PyPI instead