### PR TITLE
chore: Update ruff to be python 3.10 compliant

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
 line-length = 88
-target-version = "py39"
+target-version = "py310"
 
 [lint]
 select = [

--- a/scripts/ex-gwe-geotherm.py
+++ b/scripts/ex-gwe-geotherm.py
@@ -9,6 +9,7 @@
 
 # +
 # Imports
+import itertools
 import math
 from pathlib import Path
 from pprint import pformat
@@ -291,7 +292,7 @@ def create_bnd_iverts(bnd_verts, vert_idx, ivert_idx, side):
 
     # Once sorted, create rectangular iverts along entire boundary
     new_pt2 = None
-    for i, (v1, v2) in enumerate(zip(bnd_verts[0:-1], bnd_verts[1:])):
+    for i, (v1, v2) in enumerate(itertools.pairwise(bnd_verts)):
         v_x_coord1 = v1[1]
         v_y_coord1 = v1[2]
 


### PR DESCRIPTION
There is an inconsistincy between the the enviroments.yml , which specified python 3.10 as the minmal version, and the ruff.toml file that enforces python 3.9 compliancies. This can give  ruff errors when using python 3.10 functionalty like the 'match' statement.

This PR updates the the ruff toml to be in line with the enviroments.yml