### PR TITLE
test: add shapshot framework, check pathlines on keating

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -1,9 +1,8 @@
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Dict, List, Tuple, Any
 
-import pytest
-import numpy as np
 import pandas as pd
+import pytest
 from numpy.typing import NDArray
 
 pytest_plugins = ["modflow_devtools.fixtures", "modflow_devtools.snapshots"]
@@ -19,7 +18,10 @@ NOTEBOOKS_PATH = PROJ_ROOT / ".doc" / "_notebooks"
 SNAPSHOT_CONFIG: dict[str, dict[str, Callable[[Path], NDArray]]] = {
     # TODO: support multiple snapshot files. this is a dictionary to leave the door open for that.
     "ex-gwt-keating": {
-        "mf6prt/track.trk.csv": lambda p: pd.read_csv(p).drop("name", axis=1).round(2).to_records(index=False),
+        "mf6prt/track.trk.csv": lambda p: pd.read_csv(p)
+        .drop("name", axis=1)
+        .round(2)
+        .to_records(index=False),
     },
 }
 
@@ -57,11 +59,13 @@ def gif(request, plot) -> bool:
 
 
 @pytest.fixture
-def snapshot_config(example_script, array_snapshot) -> dict[str, Callable[[Path], NDArray]] | None:
+def snapshot_config(
+    example_script, array_snapshot
+) -> dict[str, Callable[[Path], NDArray]] | None:
     example_name = Path(example_script).stem
     config = SNAPSHOT_CONFIG.get(example_name, {})
     if config:
-        print(f"Snapshot file for {example_name}: {list(config.keys())[0]}")
+        print(f"Snapshot file for {example_name}: {list(config.keys())[0]}")  # noqa: RUF015
     return (config, array_snapshot) if any(config) else None
 
 

--- a/autotest/test_scripts.py
+++ b/autotest/test_scripts.py
@@ -2,11 +2,12 @@
 
 import sys
 from os import environ
+from pathlib import Path
 
 from modflow_devtools.misc import run_cmd, set_env
 
 
-def test_scripts(example_script, write, run, plot, plot_show, plot_save, gif):
+def test_scripts(example_script, write, run, plot, plot_show, plot_save, gif, snapshot_config):
     with set_env(
         WRITE=str(write),
         RUN=str(run),
@@ -18,3 +19,13 @@ def test_scripts(example_script, write, run, plot, plot_show, plot_save, gif):
         args = [sys.executable, example_script]
         stdout, stderr, retcode = run_cmd(*args, verbose=True, env=environ)
         assert not retcode, stdout + stderr
+
+    if run and snapshot_config:
+        example_name = Path(example_script).stem
+        example_workspace = Path(example_script).parent.parent / "examples" / example_name
+        config, snapshot = snapshot_config
+        for path, load in config.items():
+            if (output_file := example_workspace / path).exists():
+                print(f"Comparing snapshot for {output_file}")
+                data = load(output_file)
+                assert snapshot == data

--- a/autotest/test_scripts.py
+++ b/autotest/test_scripts.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from modflow_devtools.misc import run_cmd, set_env
 
 
-def test_scripts(example_script, write, run, plot, plot_show, plot_save, gif, snapshot_config):
+def test_scripts(
+    example_script, write, run, plot, plot_show, plot_save, gif, snapshot_config
+):
     with set_env(
         WRITE=str(write),
         RUN=str(run),
@@ -22,7 +24,9 @@ def test_scripts(example_script, write, run, plot, plot_show, plot_save, gif, sn
 
     if run and snapshot_config:
         example_name = Path(example_script).stem
-        example_workspace = Path(example_script).parent.parent / "examples" / example_name
+        example_workspace = (
+            Path(example_script).parent.parent / "examples" / example_name
+        )
         config, snapshot = snapshot_config
         for path, load in config.items():
             if (output_file := example_workspace / path).exists():


### PR DESCRIPTION
Introduce a snapshot test framework. In future this should support multiple snapshots per test, but the [snapshot fixtures](https://modflow-devtools.readthedocs.io/en/latest/md/snapshots.html) need work first, so right now you can only register one per example.

Add a snapshot comparison for PRT pathlines on the Keating example to cover https://github.com/MODFLOW-ORG/modflow6/pull/2478