### PR TITLE
ci(release): fix flopy module regeneration

### DIFF
--- a/.github/workflows/ex-rtd.yml
+++ b/.github/workflows/ex-rtd.yml
@@ -118,6 +118,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.1
         with:
           pixi-version: v0.41.4
+          manifest-path: modflow6-examples/pixi.toml
 
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@v4

--- a/.github/workflows/ex-rtd.yml
+++ b/.github/workflows/ex-rtd.yml
@@ -124,9 +124,11 @@ jobs:
         uses: pyvista/setup-headless-display-action@v4
 
       - name: Create Jupyter kernel
+        working-directory: modflow6-examples
         run: pixi run python -m ipykernel install --name python_kernel --user
 
       - name: Update FloPy classes
+        working-directory: modflow6-examples
         run: |
           cmd="pixi run python -m flopy.mf6.utils.generate_classes --ref ${{ needs.set_options.outputs.mf6_ref }}"
           if [[ "${{ needs.set_options.outputs.mf6_ref }}" == "refs/heads/master" ]]; then
@@ -140,9 +142,9 @@ jobs:
       - name: Build MODFLOW 6
         working-directory: modflow6
         run: |
-          pixi run meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
-          pixi run meson install -C builddir
-          pixi run meson test --verbose --no-rebuild -C builddir
+          pixi run --manifest-path ../modflow6-examples/pixi.toml meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
+          pixi run --manifest-path ../modflow6-examples/pixi.toml meson install -C builddir
+          pixi run --manifest-path ../modflow6-examples/pixi.toml meson test --verbose --no-rebuild -C builddir
           cp bin/* ~/.local/bin/modflow/
       
       - name: Run notebooks, make plots

--- a/.github/workflows/ex-rtd.yml
+++ b/.github/workflows/ex-rtd.yml
@@ -114,23 +114,20 @@ jobs:
           sudo tar xvzf pandoc-2.11.2-linux-amd64.tar.gz --strip-components=1 -C /usr/local
           pandoc --version
 
-      - name: Setup Micromamba
-        uses: mamba-org/setup-micromamba@v2
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.1
         with:
-          environment-file: modflow6-examples/environment.yml
-          cache-downloads: true
-          cache-environment: true
-          init-shell: bash
+          pixi-version: v0.41.4
 
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@v4
 
       - name: Create Jupyter kernel
-        run: python -m ipykernel install --name python_kernel --user
+        run: pixi run python -m ipykernel install --name python_kernel --user
 
       - name: Update FloPy classes
         run: |
-          cmd="python -m flopy.mf6.utils.generate_classes --ref ${{ needs.set_options.outputs.mf6_ref }}"
+          cmd="pixi run python -m flopy.mf6.utils.generate_classes --ref ${{ needs.set_options.outputs.mf6_ref }}"
           if [[ "${{ needs.set_options.outputs.mf6_ref }}" == "refs/heads/master" ]]; then
             cmd="$cmd --releasemode"
           fi
@@ -142,22 +139,22 @@ jobs:
       - name: Build MODFLOW 6
         working-directory: modflow6
         run: |
-          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
-          meson install -C builddir
-          meson test --verbose --no-rebuild -C builddir
+          pixi run meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
+          pixi run meson install -C builddir
+          pixi run meson test --verbose --no-rebuild -C builddir
           cp bin/* ~/.local/bin/modflow/
       
       - name: Run notebooks, make plots
         working-directory: modflow6-examples/autotest
-        run: pytest -v -n=auto --durations=0 test_notebooks.py --plot
+        run: pixi run pytest -v -n=auto --durations=0 test_notebooks.py --plot
 
       - name: Run postprocessing
         working-directory: modflow6-examples/scripts
-        run: python create-doc-tables.py
+        run: pixi run python create-doc-tables.py
 
       - name: Create Markdown tables
         working-directory: modflow6-examples/etc
-        run: python ci_create_examples_rst.py
+        run: pixi run python ci_create_examples_rst.py
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ex-rtd.yml
+++ b/.github/workflows/ex-rtd.yml
@@ -129,7 +129,12 @@ jobs:
         run: python -m ipykernel install --name python_kernel --user
 
       - name: Update FloPy classes
-        run: python -m flopy.mf6.utils.generate_classes --ref ${{ needs.set_options.outputs.mf6_ref }} --no-backup
+        run: |
+          cmd="python -m flopy.mf6.utils.generate_classes --ref ${{ needs.set_options.outputs.mf6_ref }}"
+          if [[ "${{ needs.set_options.outputs.mf6_ref }}" == "refs/heads/master" ]]; then
+            cmd="$cmd --releasemode"
+          fi
+          eval "$cmd"
 
       - name: Install MODFLOW executables
         uses: modflowpy/install-modflow-action@v1

--- a/.github/workflows/ex-workflow.yml
+++ b/.github/workflows/ex-workflow.yml
@@ -78,7 +78,7 @@ jobs:
         run: python -m ipykernel install --name python_kernel --user
 
       - name: Update FloPy classes
-        run: python -m flopy.mf6.utils.generate_classes --ref develop --no-backup
+        run: python -m flopy.mf6.utils.generate_classes --releasemode
 
       - name: Install MODFLOW executables
         uses: modflowpy/install-modflow-action@v1
@@ -163,7 +163,7 @@ jobs:
         run: python -m ipykernel install --name python_kernel --user
 
       - name: Update FloPy classes
-        run: python -m flopy.mf6.utils.generate_classes --ref develop --releasemode
+        run: python -m flopy.mf6.utils.generate_classes --releasemode
 
       - name: Install MODFLOW executables
         uses: modflowpy/install-modflow-action@v1

--- a/.github/workflows/ex-workflow.yml
+++ b/.github/workflows/ex-workflow.yml
@@ -29,23 +29,16 @@ jobs:
       - name: Checkout MODFLOW 6 examples
         uses: actions/checkout@v5
 
-      - name: Setup Micromamba
-        uses: mamba-org/setup-micromamba@v2
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.1
         with:
-          environment-file: environment.yml
-          cache-downloads: true
-          cache-environment: true
-          init-shell: bash
+          pixi-version: v0.41.4
 
-      - name: Lint
-        run: ruff check .
-
-      - name: Format
-        run: ruff format . --check
+      - name: Check format
+        run: pixi run check-format
 
       - name: Check spelling
-        run: codespell
-        # add false-positives to etc/codespell.ignore
+        run: pixi run check-spelling
 
   dist:
     name: Build example models
@@ -66,19 +59,16 @@ jobs:
           repository: MODFLOW-ORG/modflow6
           path: modflow6
 
-      - name: Setup Micromamba
-        uses: mamba-org/setup-micromamba@v2
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.1
         with:
-          environment-file: modflow6-examples/environment.yml
-          cache-downloads: true
-          cache-environment: true
-          init-shell: bash
+          pixi-version: v0.41.4
 
       - name: Create Jupyter kernel
-        run: python -m ipykernel install --name python_kernel --user
+        run: pixi run python -m ipykernel install --name python_kernel --user
 
       - name: Update FloPy classes
-        run: python -m flopy.mf6.utils.generate_classes --releasemode
+        run: pixi run update-flopy --releasemode
 
       - name: Install MODFLOW executables
         uses: modflowpy/install-modflow-action@v1
@@ -86,9 +76,9 @@ jobs:
       - name: Build MODFLOW 6
         working-directory: modflow6
         run: |
-          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
-          meson install -C builddir
-          meson test --verbose --no-rebuild -C builddir
+          pixi run meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
+          pixi run meson install -C builddir
+          pixi run meson test --verbose --no-rebuild -C builddir
 
       - name: Install MODFLOW 6
         working-directory: modflow6
@@ -97,7 +87,7 @@ jobs:
       - name: Create example models
         working-directory: modflow6-examples/autotest
         # run the scripts via pytest without running the models, just build input files
-        run: pytest -v -n=auto --durations=0 test_scripts.py --init
+        run: pixi run pytest -v -n=auto --durations=0 test_scripts.py --init
 
       - name: Make zipfile
         working-directory: modflow6-examples
@@ -139,6 +129,11 @@ jobs:
           repository: MODFLOW-ORG/usgslatex
           path: usgslatex
 
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.1
+        with:
+          pixi-version: v0.41.4
+
       - name: Install LaTeX and extra fonts
         run: |
           sudo apt-get update
@@ -148,22 +143,15 @@ jobs:
         working-directory: usgslatex/usgsLaTeX
         run: sudo ./install.sh --all-users
 
-      - name: Setup Micromamba
-        uses: mamba-org/setup-micromamba@v2
-        with:
-          environment-file: modflow6-examples/environment.yml
-          cache-downloads: true
-          cache-environment: true
-          init-shell: bash
-
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@v4
 
       - name: Create Jupyter kernel
-        run: python -m ipykernel install --name python_kernel --user
+        run: pixi run python -m ipykernel install --name python_kernel --user
 
       - name: Update FloPy classes
-        run: python -m flopy.mf6.utils.generate_classes --releasemode
+        working-directory: modflow6
+        run: pixi run update-flopy --releasemode
 
       - name: Install MODFLOW executables
         uses: modflowpy/install-modflow-action@v1
@@ -171,9 +159,9 @@ jobs:
       - name: Build MODFLOW 6
         working-directory: modflow6
         run: |
-          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
-          meson install -C builddir
-          meson test --verbose --no-rebuild -C builddir
+          pixi run meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
+          pixi run meson install -C builddir
+          pixi run meson test --verbose --no-rebuild -C builddir
 
       - name: Install MODFLOW 6
         working-directory: modflow6
@@ -181,11 +169,11 @@ jobs:
 
       - name: Run examples, make plots
         working-directory: modflow6-examples/autotest
-        run: pytest -v -n=auto --durations=0 test_scripts.py --plot
+        run: pixi run pytest -v -n=auto --durations=0 test_scripts.py --plot
 
       - name: Run postprocessing
         working-directory: modflow6-examples/scripts
-        run: python create-doc-tables.py
+        run: pixi run python create-doc-tables.py
 
       - name: Build PDF document
         working-directory: modflow6-examples/doc

--- a/.github/workflows/ex-workflow.yml
+++ b/.github/workflows/ex-workflow.yml
@@ -63,6 +63,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.1
         with:
           pixi-version: v0.41.4
+          manifest-path: modflow6-examples/pixi.toml
 
       - name: Create Jupyter kernel
         run: pixi run python -m ipykernel install --name python_kernel --user
@@ -133,6 +134,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.1
         with:
           pixi-version: v0.41.4
+          manifest-path: modflow6-examples/pixi.toml
 
       - name: Install LaTeX and extra fonts
         run: |

--- a/.github/workflows/ex-workflow.yml
+++ b/.github/workflows/ex-workflow.yml
@@ -66,9 +66,11 @@ jobs:
           manifest-path: modflow6-examples/pixi.toml
 
       - name: Create Jupyter kernel
+        working-directory: modflow6-examples
         run: pixi run python -m ipykernel install --name python_kernel --user
 
       - name: Update FloPy classes
+        working-directory: modflow6-examples
         run: pixi run update-flopy --releasemode
 
       - name: Install MODFLOW executables
@@ -77,9 +79,9 @@ jobs:
       - name: Build MODFLOW 6
         working-directory: modflow6
         run: |
-          pixi run meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
-          pixi run meson install -C builddir
-          pixi run meson test --verbose --no-rebuild -C builddir
+          pixi run --manifest-path ../modflow6-examples/pixi.toml meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
+          pixi run --manifest-path ../modflow6-examples/pixi.toml meson install -C builddir
+          pixi run --manifest-path ../modflow6-examples/pixi.toml meson test --verbose --no-rebuild -C builddir
 
       - name: Install MODFLOW 6
         working-directory: modflow6
@@ -149,10 +151,11 @@ jobs:
         uses: pyvista/setup-headless-display-action@v4
 
       - name: Create Jupyter kernel
+        working-directory: modflow6-examples
         run: pixi run python -m ipykernel install --name python_kernel --user
 
       - name: Update FloPy classes
-        working-directory: modflow6
+        working-directory: modflow6-examples
         run: pixi run update-flopy --releasemode
 
       - name: Install MODFLOW executables
@@ -161,9 +164,9 @@ jobs:
       - name: Build MODFLOW 6
         working-directory: modflow6
         run: |
-          pixi run meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
-          pixi run meson install -C builddir
-          pixi run meson test --verbose --no-rebuild -C builddir
+          pixi run --manifest-path ../modflow6-examples/pixi.toml meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
+          pixi run --manifest-path ../modflow6-examples/pixi.toml meson install -C builddir
+          pixi run --manifest-path ../modflow6-examples/pixi.toml meson test --verbose --no-rebuild -C builddir
 
       - name: Install MODFLOW 6
         working-directory: modflow6

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -319,12 +319,14 @@ To add a new example:
 
 ## Releasing the examples
 
-Steps to create a release include:
+GitHub Actions automatically creates a new release whenever code is merged into the `master` branch of this repository. To trigger a release, merge (don't squash) a PR from `develop` into `master`.
 
-1. Generate model input files, disabling model runs and plots &mdash; e.g. from the `autotest/` directory, run `pytest -v -n auto test_scripts.py`. **Note**: if model runs are enabled, the size of the `examples/` directory will balloon from double-digit MB to several GB. We only distribute input files, not output files.
-2. Build the PDF documentation as described above.
-5. Release the documentation PDF and a zip archive of model input files.
+GitHub Actions will run the following steps:
 
-These should not be necessary to perform manually, as GitHub Actions automatically creates a new release whenever code is merged into the `master` branch of this repository.
+1. Build MF6 from the target branch.
+2. Regenerate flopy modules suitable for this version of MF6.
+3. Generate example model input files. (We only distribute input files, not output files.)
+4. Build the PDF documentation as described above.
+5. Create a draft release and upload the documentation PDF and a zip archive of model input files as assets.
 
-It is necessary to manually trigger a rebuild of the ReadTheDocs site. This can be done by starting the `rtd` workflow from the GitHub Actions web UI, specifying `refs/heads/master` for both the examples and MF6 repos in the dialog. (The workflow should be used from the `develop` branch.)
+Inspect and publish the release. After publishing, it is necessary to manually trigger a rebuild of the ReadTheDocs site. This can be done by starting the `rtd` workflow from the GitHub Actions web UI, specifying `refs/heads/master` for both the examples and MF6 repos in the dialog. (The workflow should be used from the `develop` branch.)

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -66,7 +66,7 @@ See the [FloPy documentation](https://flopy.readthedocs.io/en/stable/md/get_modf
 FloPy and MODFLOW 6 versions must be kept in sync for FloPy to properly generate and consume MF6 input/output files. To update FloPy from some branch of the [MODFLOW 6 repository](https://github.com/MODFLOW-ORG/modflow6), for instance the `develop` branch:
 
 ```shell
-python -m flopy.mf6.utils.generate_classes --ref develop --no-backup
+python -m flopy.mf6.utils.generate_classes --ref develop
 ```
 
 The `--owner` and `--repo` arguments can be used to select an alternative repository (e.g. your fork). See [the FloPy documentation](https://flopy.readthedocs.io/en/stable/md/generate_classes.html) for more info.

--- a/pixi.lock
+++ b/pixi.lock
@@ -304,7 +304,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/8f/c4d9bafc34ad7ad5d8dc16dd1347ee0e507a52c3adb6bfa8887e1c6a26ba/executing-2.2.0-py2.py3-none-any.whl
-      - pypi: git+https://github.com/modflowpy/flopy.git#90601467a98ff620b3282957f721bf4277e02af0
+      - pypi: git+https://github.com/modflowpy/flopy.git#224aaa5d7d2757c67de05987e1fee3a46210fc08
       - pypi: https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fc/c7/b445faca8deb954fe536abebff4ece5b097b923de482b26e78448c89d1dd/ipykernel-6.30.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/63/f8/0031ee2b906a15a33d6bfc12dd09c3dfa966b3cb5b284ecfb7549e6ac3c4/ipython-9.4.0-py3-none-any.whl
@@ -334,7 +334,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/bf/62567830b700d9f6930e9ab6831d6ba256f7b0b730acb37278b0ccdffacf/pydotplus-2.0.2.tar.gz
-      - pypi: git+https://github.com/modflowpy/pymake.git#784451b869e3237f09c1e3b1ff126f96c5619013
+      - pypi: git+https://github.com/modflowpy/pymake.git#79ea907bc55c472778b59053d779018beba64e40
       - pypi: https://files.pythonhosted.org/packages/7e/0a/2356305c423a975000867de56888b79e44ec2192c690ff93c3109fd78081/pyzmq-27.0.1-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/40/54/b9aaf8e4867e95ac8ea27cd3249946c62c58058779e998040442d6d07625/rtds_action-1.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/ac/8f96ba9b4cfe3e4ea201f23f4f97165862395e9331a424ed325ae37024a8/setuptools_scm-8.3.1-py3-none-any.whl
@@ -651,7 +651,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/8f/c4d9bafc34ad7ad5d8dc16dd1347ee0e507a52c3adb6bfa8887e1c6a26ba/executing-2.2.0-py2.py3-none-any.whl
-      - pypi: git+https://github.com/modflowpy/flopy.git#90601467a98ff620b3282957f721bf4277e02af0
+      - pypi: git+https://github.com/modflowpy/flopy.git#224aaa5d7d2757c67de05987e1fee3a46210fc08
       - pypi: https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fc/c7/b445faca8deb954fe536abebff4ece5b097b923de482b26e78448c89d1dd/ipykernel-6.30.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/63/f8/0031ee2b906a15a33d6bfc12dd09c3dfa966b3cb5b284ecfb7549e6ac3c4/ipython-9.4.0-py3-none-any.whl
@@ -681,7 +681,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/bf/62567830b700d9f6930e9ab6831d6ba256f7b0b730acb37278b0ccdffacf/pydotplus-2.0.2.tar.gz
-      - pypi: git+https://github.com/modflowpy/pymake.git#784451b869e3237f09c1e3b1ff126f96c5619013
+      - pypi: git+https://github.com/modflowpy/pymake.git#79ea907bc55c472778b59053d779018beba64e40
       - pypi: https://files.pythonhosted.org/packages/20/50/fc384631d8282809fb1029a4460d2fe90fa0370a0e866a8318ed75c8d3bb/pyzmq-27.0.1-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/40/54/b9aaf8e4867e95ac8ea27cd3249946c62c58058779e998040442d6d07625/rtds_action-1.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/ac/8f96ba9b4cfe3e4ea201f23f4f97165862395e9331a424ed325ae37024a8/setuptools_scm-8.3.1-py3-none-any.whl
@@ -956,7 +956,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/8f/c4d9bafc34ad7ad5d8dc16dd1347ee0e507a52c3adb6bfa8887e1c6a26ba/executing-2.2.0-py2.py3-none-any.whl
-      - pypi: git+https://github.com/modflowpy/flopy.git#90601467a98ff620b3282957f721bf4277e02af0
+      - pypi: git+https://github.com/modflowpy/flopy.git#224aaa5d7d2757c67de05987e1fee3a46210fc08
       - pypi: https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fc/c7/b445faca8deb954fe536abebff4ece5b097b923de482b26e78448c89d1dd/ipykernel-6.30.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/63/f8/0031ee2b906a15a33d6bfc12dd09c3dfa966b3cb5b284ecfb7549e6ac3c4/ipython-9.4.0-py3-none-any.whl
@@ -986,7 +986,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/bf/62567830b700d9f6930e9ab6831d6ba256f7b0b730acb37278b0ccdffacf/pydotplus-2.0.2.tar.gz
-      - pypi: git+https://github.com/modflowpy/pymake.git#784451b869e3237f09c1e3b1ff126f96c5619013
+      - pypi: git+https://github.com/modflowpy/pymake.git#79ea907bc55c472778b59053d779018beba64e40
       - pypi: https://files.pythonhosted.org/packages/0e/9b/c0957041067c7724b310f22c398be46399297c12ed834c3bc42200a2756f/pyzmq-27.0.1-cp312-abi3-macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/40/54/b9aaf8e4867e95ac8ea27cd3249946c62c58058779e998040442d6d07625/rtds_action-1.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/ac/8f96ba9b4cfe3e4ea201f23f4f97165862395e9331a424ed325ae37024a8/setuptools_scm-8.3.1-py3-none-any.whl
@@ -1261,7 +1261,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/8f/c4d9bafc34ad7ad5d8dc16dd1347ee0e507a52c3adb6bfa8887e1c6a26ba/executing-2.2.0-py2.py3-none-any.whl
-      - pypi: git+https://github.com/modflowpy/flopy.git#90601467a98ff620b3282957f721bf4277e02af0
+      - pypi: git+https://github.com/modflowpy/flopy.git#224aaa5d7d2757c67de05987e1fee3a46210fc08
       - pypi: https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fc/c7/b445faca8deb954fe536abebff4ece5b097b923de482b26e78448c89d1dd/ipykernel-6.30.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/63/f8/0031ee2b906a15a33d6bfc12dd09c3dfa966b3cb5b284ecfb7549e6ac3c4/ipython-9.4.0-py3-none-any.whl
@@ -1291,7 +1291,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/bf/62567830b700d9f6930e9ab6831d6ba256f7b0b730acb37278b0ccdffacf/pydotplus-2.0.2.tar.gz
-      - pypi: git+https://github.com/modflowpy/pymake.git#784451b869e3237f09c1e3b1ff126f96c5619013
+      - pypi: git+https://github.com/modflowpy/pymake.git#79ea907bc55c472778b59053d779018beba64e40
       - pypi: https://files.pythonhosted.org/packages/0e/9b/c0957041067c7724b310f22c398be46399297c12ed834c3bc42200a2756f/pyzmq-27.0.1-cp312-abi3-macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/40/54/b9aaf8e4867e95ac8ea27cd3249946c62c58058779e998040442d6d07625/rtds_action-1.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/ac/8f96ba9b4cfe3e4ea201f23f4f97165862395e9331a424ed325ae37024a8/setuptools_scm-8.3.1-py3-none-any.whl
@@ -1579,7 +1579,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/8f/c4d9bafc34ad7ad5d8dc16dd1347ee0e507a52c3adb6bfa8887e1c6a26ba/executing-2.2.0-py2.py3-none-any.whl
-      - pypi: git+https://github.com/modflowpy/flopy.git#90601467a98ff620b3282957f721bf4277e02af0
+      - pypi: git+https://github.com/modflowpy/flopy.git#224aaa5d7d2757c67de05987e1fee3a46210fc08
       - pypi: https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fc/c7/b445faca8deb954fe536abebff4ece5b097b923de482b26e78448c89d1dd/ipykernel-6.30.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/63/f8/0031ee2b906a15a33d6bfc12dd09c3dfa966b3cb5b284ecfb7549e6ac3c4/ipython-9.4.0-py3-none-any.whl
@@ -1607,7 +1607,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/50/1b/6921afe68c74868b4c9fa424dad3be35b095e16687989ebbb50ce4fceb7c/psutil-7.0.0-cp37-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/bf/62567830b700d9f6930e9ab6831d6ba256f7b0b730acb37278b0ccdffacf/pydotplus-2.0.2.tar.gz
-      - pypi: git+https://github.com/modflowpy/pymake.git#784451b869e3237f09c1e3b1ff126f96c5619013
+      - pypi: git+https://github.com/modflowpy/pymake.git#79ea907bc55c472778b59053d779018beba64e40
       - pypi: https://files.pythonhosted.org/packages/40/96/5c50a7d2d2b05b19994bf7336b97db254299353dd9b49b565bb71b485f03/pyzmq-27.0.1-cp312-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/40/54/b9aaf8e4867e95ac8ea27cd3249946c62c58058779e998040442d6d07625/rtds_action-1.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/ac/8f96ba9b4cfe3e4ea201f23f4f97165862395e9331a424ed325ae37024a8/setuptools_scm-8.3.1-py3-none-any.whl
@@ -3274,9 +3274,9 @@ packages:
   - pkg:pypi/flaky?source=hash-mapping
   size: 22239
   timestamp: 1736040820816
-- pypi: git+https://github.com/modflowpy/flopy.git#90601467a98ff620b3282957f721bf4277e02af0
+- pypi: git+https://github.com/modflowpy/flopy.git#224aaa5d7d2757c67de05987e1fee3a46210fc08
   name: flopy
-  version: 3.10.0.dev3
+  version: 3.10.0.dev5
   requires_dist:
   - matplotlib>=1.4.0
   - numpy>=1.20.3
@@ -3326,11 +3326,12 @@ packages:
   - rasterstats ; extra == 'dev'
   - rtds-action ; extra == 'dev'
   - ruff ; extra == 'dev'
+  - scikit-learn ; extra == 'dev'
   - scipy ; extra == 'dev'
   - shapely>=2.0 ; extra == 'dev'
   - sphinx-rtd-theme>=1 ; extra == 'dev'
   - sphinx==7.1.2 ; extra == 'dev'
-  - syrupy ; extra == 'dev'
+  - syrupy<5.0.0 ; extra == 'dev'
   - tach ; extra == 'dev'
   - tomli ; extra == 'dev'
   - tomli-w ; extra == 'dev'
@@ -3360,6 +3361,7 @@ packages:
   - rasterio ; extra == 'doc'
   - rasterstats ; extra == 'doc'
   - rtds-action ; extra == 'doc'
+  - scikit-learn ; extra == 'doc'
   - scipy ; extra == 'doc'
   - shapely>=2.0 ; extra == 'doc'
   - sphinx-rtd-theme>=1 ; extra == 'doc'
@@ -3385,6 +3387,7 @@ packages:
   - pyvista ; extra == 'optional'
   - rasterio ; extra == 'optional'
   - rasterstats ; extra == 'optional'
+  - scikit-learn ; extra == 'optional'
   - scipy ; extra == 'optional'
   - shapely>=2.0 ; extra == 'optional'
   - vtk>=9.4.0 ; extra == 'optional'
@@ -3406,7 +3409,7 @@ packages:
   - pytest-xdist ; extra == 'test'
   - pyzmq>=25.1.2 ; extra == 'test'
   - ruff ; extra == 'test'
-  - syrupy ; extra == 'test'
+  - syrupy<5.0.0 ; extra == 'test'
   - tomli ; extra == 'test'
   - tomli-w ; extra == 'test'
   - virtualenv ; extra == 'test'
@@ -9612,11 +9615,11 @@ packages:
   - pkg:pypi/meson?source=hash-mapping
   size: 726539
   timestamp: 1745942023589
-- pypi: git+https://github.com/modflowpy/pymake.git#784451b869e3237f09c1e3b1ff126f96c5619013
+- pypi: git+https://github.com/modflowpy/pymake.git#79ea907bc55c472778b59053d779018beba64e40
   name: mfpymake
   version: 1.6.0.dev0
   requires_dist:
-  - meson>=1.8.0
+  - meson>=1.3.1
   - networkx
   - ninja
   - numpy

--- a/pixi.toml
+++ b/pixi.toml
@@ -17,7 +17,7 @@ jupyter = { cmd = "jupyter notebook", cwd = "notebooks"}
 build-input = { cmd = "pytest -v -n auto test_scripts.py --init", cwd = "autotest" }
 
 update-environment-yml = "pixi workspace export conda-environment environment.yml"
-update-flopy = "python -m flopy.mf6.utils.generate_classes --ref develop"
+update-flopy = "python -m flopy.mf6.utils.generate_classes"
 install = "pixi update flopy mfpymake modflowapi"
 
 # Check format


### PR DESCRIPTION
* regenerate flopy modules in release mode if workflows are running on master
* update the dev docs to clarify the release procedure
* remove ref arg from pixi task to update flopy