### PR TITLE
fix(gwe-ates): unit conversion should be applied to the fluid phase and not just the solid phase

### DIFF
--- a/scripts/ex-gwe-ates.py
+++ b/scripts/ex-gwe-ates.py
@@ -724,7 +724,7 @@ def build_model(sim_name, verts, cell2d, top, botm):
         xt3d_off=True,
         alh=al,
         ath1=ath1,
-        ktw=ktw,
+        ktw=ktw * unitconv,
         kts=kts,
         pname="CND",
         filename=f"{gwename}.cnd",


### PR DESCRIPTION
This fix addresses issue [#2595](https://github.com/MODFLOW-ORG/modflow6/issues/2595) reported on the main [MODFLOW 6 repo](https://github.com/MODFLOW-ORG/modflow6).  It was also reported by @WijbrandS in a [comment](https://github.com/MODFLOW-ORG/modflow6-examples/commit/011e16bcb0f916410014d4dea11acff149fdfeda#commitcomment-167962205). 