### PR TITLE
fix(GridIntersect): update GridIntersect after deprecation method kwarg

### DIFF
--- a/scripts/ex-gwf-advtidal.py
+++ b/scripts/ex-gwf-advtidal.py
@@ -276,7 +276,7 @@ def build_models():
         "9ca294d3260c9d3c3487f8db498a0aa6",
     ]
     for ipak, p in enumerate([recharge_zone_1, recharge_zone_2, recharge_zone_3]):
-        ix = GridIntersect(gwf.modelgrid, method="vertex", rtree=True)
+        ix = GridIntersect(gwf.modelgrid)
         result = ix.intersect(p)
         rch_spd = []
         for i in range(result.shape[0]):

--- a/scripts/ex-gwf-disvmesh.py
+++ b/scripts/ex-gwf-disvmesh.py
@@ -185,7 +185,7 @@ def build_models(sim_name):
     y = radius * np.sin(theta)
     hole = [(x, y) for x, y in zip(x, y)]
     p = Polygon(outer, holes=[hole])
-    ix = GridIntersect(gwf.modelgrid, method="vertex", rtree=True)
+    ix = GridIntersect(gwf.modelgrid)
     result = ix.intersect(p)
     ghb_cellids = np.array(result["cellids"], dtype=int)
 

--- a/scripts/ex-gwt-rotate.py
+++ b/scripts/ex-gwt-rotate.py
@@ -181,7 +181,7 @@ def get_cstrt(nlay, ncol, length, x1, x2, a1, a2, b, c1, c2, c3):
     delc = b / nlay * np.ones(nlay)
     delr = length / ncol * np.ones(ncol)
     sgr = flopy.discretization.StructuredGrid(delc, delr)
-    ix = GridIntersect(sgr, method="structured")
+    ix = GridIntersect(sgr)
     for ival, p in [(c2, p2), (c3, p3)]:
         result = ix.intersect(p)
         for i, j in list(result["cellids"]):

--- a/scripts/ex-gwt-synthetic-valley.py
+++ b/scripts/ex-gwt-synthetic-valley.py
@@ -344,7 +344,7 @@ lake_vg_grid = flopy.discretization.VertexGrid(
 
 # +
 # intersect stream features with the grid
-ixs = flopy.utils.GridIntersect(voronoi_grid, method="vertex")
+ixs = flopy.utils.GridIntersect(voronoi_grid)
 sg_result = ixs.intersect(LineString(sg_densify), sort_by_cellid=False)
 
 # build sfr package datasets

--- a/scripts/ex-prt-mp7-p02.py
+++ b/scripts/ex-prt-mp7-p02.py
@@ -313,7 +313,7 @@ def build_gwf_sim():
     )
 
     # GridIntersect object for setting up boundary conditions
-    ix = GridIntersect(gwf.modelgrid, method="vertex", rtree=True)
+    ix = GridIntersect(gwf.modelgrid)
 
     # Instantiate the MODFLOW 6 gwf initial conditions package
     flopy.mf6.ModflowGwfic(gwf, pname="ic", strt=riv_h)


### PR DESCRIPTION
method kwarg is deprecated, and rtree=True is unnecessary since it is default.