### PR TITLE
fix(gridintersect): update examples

### DIFF
--- a/scripts/ex-gwe-prt.py
+++ b/scripts/ex-gwe-prt.py
@@ -143,17 +143,17 @@ def build_gwf_sim(name):
 
     # identify cells on left edge
     line = LineString([(xmin, ymin), (xmin, ymax)])
-    cells_left = gi.intersect(line)["cellids"]
+    cells_left = gi.intersect(line, geo_dataframe=False)["cellids"]
     cells_left = np.array(list(cells_left))
 
     # identify cells on right edge
     line = LineString([(xmax, ymin), (xmax, ymax)])
-    cells_right = gi.intersect(line)["cellids"]
+    cells_right = gi.intersect(line, geo_dataframe=False)["cellids"]
     cells_right = np.array(list(cells_right))
 
     # identify cells on bottom edge
     line = LineString([(xmin, ymin), (xmax, ymin)])
-    cells_bottom = gi.intersect(line)["cellids"]
+    cells_bottom = gi.intersect(line, geo_dataframe=False)["cellids"]
     cells_bottom = np.array(list(cells_bottom))
 
     # identify well cell

--- a/scripts/ex-gwf-advtidal.py
+++ b/scripts/ex-gwf-advtidal.py
@@ -277,7 +277,7 @@ def build_models():
     ]
     for ipak, p in enumerate([recharge_zone_1, recharge_zone_2, recharge_zone_3]):
         ix = GridIntersect(gwf.modelgrid)
-        result = ix.intersect(p)
+        result = ix.intersect(p, geo_dataframe=False)
         rch_spd = []
         for i in range(result.shape[0]):
             rch_spd.append(

--- a/scripts/ex-gwf-disvmesh.py
+++ b/scripts/ex-gwf-disvmesh.py
@@ -186,7 +186,7 @@ def build_models(sim_name):
     hole = [(x, y) for x, y in zip(x, y)]
     p = Polygon(outer, holes=[hole])
     ix = GridIntersect(gwf.modelgrid)
-    result = ix.intersect(p)
+    result = ix.intersect(p, geo_dataframe=False)
     ghb_cellids = np.array(result["cellids"], dtype=int)
 
     ghb_spd = []

--- a/scripts/ex-gwt-rotate.py
+++ b/scripts/ex-gwt-rotate.py
@@ -183,7 +183,7 @@ def get_cstrt(nlay, ncol, length, x1, x2, a1, a2, b, c1, c2, c3):
     sgr = flopy.discretization.StructuredGrid(delc, delr)
     ix = GridIntersect(sgr)
     for ival, p in [(c2, p2), (c3, p3)]:
-        result = ix.intersect(p)
+        result = ix.intersect(p, geo_dataframe=False)
         for i, j in list(result["cellids"]):
             cstrt[i, j] = ival
     return cstrt

--- a/scripts/ex-gwt-synthetic-valley.py
+++ b/scripts/ex-gwt-synthetic-valley.py
@@ -345,7 +345,9 @@ lake_vg_grid = flopy.discretization.VertexGrid(
 # +
 # intersect stream features with the grid
 ixs = flopy.utils.GridIntersect(voronoi_grid)
-sg_result = ixs.intersect(LineString(sg_densify), sort_by_cellid=False)
+sg_result = ixs.intersect(
+    LineString(sg_densify), sort_by_cellid=False, geo_dataframe=False
+)
 
 # build sfr package datasets
 sfr_plt_array = np.zeros(voronoi_grid.ncpl, dtype=int)

--- a/scripts/ex-prt-mp7-p02.py
+++ b/scripts/ex-prt-mp7-p02.py
@@ -1,3 +1,4 @@
+# %%
 # ## Backward Particle Tracking, Quad-Refined Grid, Steady-State Flow
 #
 # Application of a MODFLOW 6 particle-tracking (PRT) model
@@ -338,15 +339,15 @@ def build_gwf_sim():
     )
 
     # Instantiate the MODFLOW 6 gwf well package
-    welcells = ix.intersects(MultiPoint(wel_coords))
-    welcells = [icpl for (icpl,) in welcells]
+    welcells = ix.intersects(MultiPoint(wel_coords), dataframe=False)
+    welcells = welcells["cellids"]
     welspd = [[(2, icpl), wel_q[idx]] for idx, icpl in enumerate(welcells)]
     flopy.mf6.ModflowGwfwel(gwf, print_input=True, stress_period_data=welspd)
 
     # Instantiate the MODFLOW 6 gwf river package
     riverline = [(Lx - 1.0, Ly), (Lx - 1.0, 0.0)]
-    rivcells = ix.intersects(LineString(riverline))
-    rivcells = [icpl for (icpl,) in rivcells]
+    rivcells = ix.intersects(LineString(riverline), dataframe=False)
+    rivcells = rivcells["cellids"]
     rivspd = [
         [(0, icpl), riv_h, riv_c, riv_z, riv_iface, riv_iflowface] for icpl in rivcells
     ]

--- a/scripts/ex-prt-mp7-p02.py
+++ b/scripts/ex-prt-mp7-p02.py
@@ -340,14 +340,14 @@ def build_gwf_sim():
 
     # Instantiate the MODFLOW 6 gwf well package
     welcells = ix.intersects(MultiPoint(wel_coords), dataframe=False)
-    welcells = welcells["cellids"]
+    welcells = welcells["cellids"].astype(int)
     welspd = [[(2, icpl), wel_q[idx]] for idx, icpl in enumerate(welcells)]
     flopy.mf6.ModflowGwfwel(gwf, print_input=True, stress_period_data=welspd)
 
     # Instantiate the MODFLOW 6 gwf river package
     riverline = [(Lx - 1.0, Ly), (Lx - 1.0, 0.0)]
     rivcells = ix.intersects(LineString(riverline), dataframe=False)
-    rivcells = rivcells["cellids"]
+    rivcells = rivcells["cellids"].astype(int)
     rivspd = [
         [(0, icpl), riv_h, riv_c, riv_z, riv_iface, riv_iflowface] for icpl in rivcells
     ]


### PR DESCRIPTION
- suppress warnings from gridintersect by explicitly setting (geo_)dataframe=False
- modify parsing of intersected cellids in ex-prt-mp7-p02