### PR TITLE
fix(prt): provide grid file to FMI in p03 and keating

### DIFF
--- a/scripts/ex-gwt-keating.py
+++ b/scripts/ex-gwt-keating.py
@@ -356,6 +356,7 @@ def build_mf6prt():
         saverecord=[("BUDGET", "ALL")],
     )
     pd = [
+        ("GWFGRID", Path(f"../{gwf_ws.name}/flow.dis.grb")),
         ("GWFHEAD", Path(f"../{gwf_ws.name}/flow.hds")),
         ("GWFBUDGET", Path(f"../{gwf_ws.name}/flow.bud")),
     ]

--- a/scripts/ex-prt-mp7-p03.py
+++ b/scripts/ex-prt-mp7-p03.py
@@ -67,6 +67,7 @@ prt_ws.mkdir(exist_ok=True, parents=True)
 mp7_ws.mkdir(exist_ok=True, parents=True)
 
 # Define output file names
+gridfile = f"{gwf_name}.dis.grb"
 headfile = f"{gwf_name}.hds"
 budgetfile = f"{gwf_name}.cbb"
 budgetfile_prt = f"{prt_name}.cbb"
@@ -435,6 +436,7 @@ def build_prt_model():
     flopy.mf6.ModflowPrtfmi(
         prt,
         packagedata=[
+            ("GWFGRID", Path(f"../{gwf_ws.name}/{gridfile}")),
             ("GWFHEAD", Path(f"../{gwf_ws.name}/{headfile}")),
             ("GWFBUDGET", Path(f"../{gwf_ws.name}/{budgetfile}")),
         ],


### PR DESCRIPTION
The binary grid file will be necessary with https://github.com/MODFLOW-ORG/modflow6/pull/2624 for PRT to distinguish confined from convertible cells.