### PR TITLE
fix: fix model configuration to avoid warnings

### DIFF
--- a/scripts/ex-gwf-maw-p03.py
+++ b/scripts/ex-gwf-maw-p03.py
@@ -85,7 +85,7 @@ H1 = 0.0  # Regional downgradient constant head ($ft$)
 maw_loc = (15, 13)  # Row, column location of well
 maw_lay = (1, 12)  # Layers with well screen
 maw_radius = 0.1333  # Well radius ($ft$)
-maw_bot = -65.0  # Bottom of the well ($ft$)
+maw_bot = -70.0  # Bottom of the well ($ft$)
 maw_highK = 1e9  # Hydraulic conductivity for well ($ft/d$)
 
 # set delr and delc for the local model

--- a/scripts/ex-gwf-sagehen.py
+++ b/scripts/ex-gwf-sagehen.py
@@ -1823,7 +1823,7 @@ fpath = pooch.retrieve(
     path=data_path,
     known_hash="md5:969ed0391d64804ec8395a578eb08ed1",
 )
-uz_ts = pd.read_csv(fpath, delim_whitespace=True, header=0)
+uz_ts = pd.read_csv(fpath, sep=r"\s+", header=0)
 
 # Need to set iuzbnd inactive where there are constant head cells, or where the
 # model grid is inactive

--- a/scripts/ex-gwt-mt3dsupp632.py
+++ b/scripts/ex-gwt-mt3dsupp632.py
@@ -216,7 +216,7 @@ def build_mf6gwt(sim_folder, distribution_coefficient, decay, decay_sorbed):
             decay=decay,
             decay_sorbed=decay_sorbed,
             bulk_density=bd,
-            distcoef=distribution_coefficient,
+            distcoef=kd,
         )
     flopy.mf6.ModflowGwtadv(gwt)
     flopy.mf6.ModflowGwtdsp(


### PR DESCRIPTION
Suppress warnings found in release candidate review

* MAW bottom elevation reset
* distcoef with sorption disabled

And replace a deprecated use of `delim_whitespace` in `pd.read_csv`