### PR TITLE
fix(legends): Many legends included descriptions but not the symbology

### DIFF
--- a/scripts/ex-gwt-moc3d-p02.py
+++ b/scripts/ex-gwt-moc3d-p02.py
@@ -19,6 +19,7 @@ import git
 import matplotlib.pyplot as plt
 import numpy as np
 from flopy.plot.styles import styles
+from matplotlib.lines import Line2D
 from modflow_devtools.misc import get_env, timed
 from scipy.special import erfc
 
@@ -300,7 +301,7 @@ def plot_results(sims):
         axs.set_xlabel("x position (m)")
         axs.set_ylabel("y position (m)")
         axs.set_aspect(4.0)
-        
+
         handles = [
             Line2D([0], [0], color="black", linestyle="-", label="Analytical"),
             Line2D([0], [0], color="blue", linestyle="--", label="MODFLOW 6"),

--- a/scripts/ex-gwt-moc3d-p02.py
+++ b/scripts/ex-gwt-moc3d-p02.py
@@ -300,10 +300,12 @@ def plot_results(sims):
         axs.set_xlabel("x position (m)")
         axs.set_ylabel("y position (m)")
         axs.set_aspect(4.0)
-
-        labels = ["Analytical", "MODFLOW 6"]
-        lines = [cs1.collections[0], cs2.collections[0]]
-        axs.legend(lines, labels, loc="upper left")
+        
+        handles = [
+            Line2D([0], [0], color="black", linestyle="-", label="Analytical"),
+            Line2D([0], [0], color="blue", linestyle="--", label="MODFLOW 6"),
+        ]
+        axs.legend(handles=handles, loc="upper left")
 
         if plot_show:
             plt.show()

--- a/scripts/ex-gwt-moc3d-p02tg.py
+++ b/scripts/ex-gwt-moc3d-p02tg.py
@@ -410,18 +410,20 @@ def plot_results(sims):
 
         gwt = sim_mf6gwt.trans
         pmv = flopy.plot.PlotMapView(model=gwt, ax=axs)
-        # pmv.plot_array(conc, alpha=0.5)
-        # pmv.plot_grid()
+        
         levels = [1, 3, 10, 30, 100, 300]
         cs1 = plot_analytical(axs, levels)
         cs2 = pmv.contour_array(conc, colors="blue", linestyles="--", levels=levels)
+        
         axs.set_xlabel("x position (m)")
         axs.set_ylabel("y position (m)")
         axs.set_aspect(4.0)
 
-        labels = ["Analytical", "MODFLOW 6"]
-        lines = [cs1.collections[0], cs2.collections[0]]
-        axs.legend(lines, labels, loc="upper left")
+        handles = [
+            Line2D([0], [0], color="black", linestyle="-", label="Analytical"),
+            Line2D([0], [0], color="blue", linestyle="--", label="MODFLOW 6"),
+        ]
+        axs.legend(handles=handles, loc="upper left")
 
         if plot_show:
             plt.show()

--- a/scripts/ex-gwt-moc3d-p02tg.py
+++ b/scripts/ex-gwt-moc3d-p02tg.py
@@ -23,6 +23,7 @@ import git
 import matplotlib.pyplot as plt
 import numpy as np
 from flopy.plot.styles import styles
+from matplotlib.lines import Line2D
 from modflow_devtools.misc import get_env, timed
 from scipy.special import erfc
 
@@ -410,11 +411,11 @@ def plot_results(sims):
 
         gwt = sim_mf6gwt.trans
         pmv = flopy.plot.PlotMapView(model=gwt, ax=axs)
-        
+
         levels = [1, 3, 10, 30, 100, 300]
         cs1 = plot_analytical(axs, levels)
         cs2 = pmv.contour_array(conc, colors="blue", linestyles="--", levels=levels)
-        
+
         axs.set_xlabel("x position (m)")
         axs.set_ylabel("y position (m)")
         axs.set_aspect(4.0)

--- a/scripts/ex-gwt-mt3dms-p03.py
+++ b/scripts/ex-gwt-mt3dms-p03.py
@@ -503,32 +503,24 @@ def plot_results(mt3d, mf6, idx, ax=None):
             fig = plt.figure(figsize=figure_size, dpi=300, tight_layout=True)
             ax = fig.add_subplot(1, 1, 1, aspect="equal")
 
-        mm = flopy.plot.PlotMapView(model=mt3d)
+        mm = flopy.plot.PlotMapView(model=mt3d, ax=ax)
         mm.plot_grid(color=".5", alpha=0.2)
         cs1 = mm.contour_array(conc_mt3d[1], levels=[0.1, 1.0, 10.0, 50.0], colors="k")
-        plt.clabel(cs1, inline=1, fontsize=10)
+        ax.clabel(cs1, inline=1, fontsize=10)
         cs2 = mm.contour_array(
             conc_mf6[1], levels=[0.1, 1.0, 10.0, 50.0], colors="r", linestyles="--"
         )
-        plt.clabel(cs2, inline=1, fontsize=10)
-        labels = ["MT3DMS", "MODFLOW 6"]
-        lines = [cs1.collections[0], cs2.collections[0]]
-
-        plt.xlabel("DISTANCE ALONG X-AXIS, IN METERS")
-        plt.ylabel("DISTANCE ALONG Y-AXIS, IN METERS")
+        ax.clabel(cs2, inline=1, fontsize=10)
+        
+        handles = [
+            Line2D([0], [0], color="k", linestyle="-", label="MT3DMS"),
+            Line2D([0], [0], color="r", linestyle="--", label="MODFLOW 6"),
+        ]
+        ax.set_xlabel("DISTANCE ALONG X-AXIS, IN METERS")
+        ax.set_ylabel("DISTANCE ALONG Y-AXIS, IN METERS")
         title = f"Plume at Time = 365 {time_units}"
+        ax.legend(handles=handles, loc="upper left")
 
-        ax.legend(lines, labels, loc="upper left")
-
-        # ax.plot(np.linspace(0, l, ncol), conc_mt3d[0,0,0,:], color='k', label='MT3DMS')
-        # ax.plot(np.linspace(0, l, ncol), conc_mf6[0,0,0,:], '^', color='b', label='MF6')
-        # ax.set_ylim(0, 1.2)
-        # ax.set_xlim(0, 1000)
-        # ax.set_xlabel('Distance, in m')
-        # ax.set_ylabel('Concentration')
-        # title = 'Concentration Profile at Time = 1,000 ' + '{}'.format(
-        #                                                        time_units)
-        # ax.legend()
         letter = chr(ord("@") + idx + 1)
         styles.heading(letter=letter, heading=title)
 

--- a/scripts/ex-gwt-mt3dms-p03.py
+++ b/scripts/ex-gwt-mt3dms-p03.py
@@ -31,6 +31,7 @@ import git
 import matplotlib.pyplot as plt
 import numpy as np
 from flopy.plot.styles import styles
+from matplotlib.lines import Line2D
 from modflow_devtools.misc import get_env, timed
 
 # Example name and workspace paths. If this example is running
@@ -511,7 +512,7 @@ def plot_results(mt3d, mf6, idx, ax=None):
             conc_mf6[1], levels=[0.1, 1.0, 10.0, 50.0], colors="r", linestyles="--"
         )
         ax.clabel(cs2, inline=1, fontsize=10)
-        
+
         handles = [
             Line2D([0], [0], color="k", linestyle="-", label="MT3DMS"),
             Line2D([0], [0], color="r", linestyle="--", label="MODFLOW 6"),

--- a/scripts/ex-gwt-mt3dms-p04.py
+++ b/scripts/ex-gwt-mt3dms-p04.py
@@ -526,20 +526,19 @@ def plot_results(mt3d, mf6, idx, leglab1, leglab2, ax=None):
         y = mt3d.modelgrid.ycellcenters
 
         levels = [0.15, 1.0, 2.0, 5.0]
-        mm = flopy.plot.PlotMapView(model=mt3d)
+        mm = flopy.plot.PlotMapView(model=mt3d, ax=ax)
 
         cf = plt.contourf(x, y, conc_mt3d[0, 0, :, :], levels=levels, alpha=0.5)
-        cbar = plt.colorbar(cf, shrink=0.25)
+        cbar = plt.colorbar(cf, ax=ax, shrink=0.25)
         cbar.ax.set_title(leglab1)
 
         cs2 = mm.contour_array(
             conc_mf6[0, 0, :, :], levels=levels, colors="r", linestyles="--"
         )
-        plt.clabel(cs2)
-        labels = [leglab2]
-        for i in range(len(labels)):
-            cs2.collections[i].set_label(labels[i])
-        plt.legend(loc="upper left")
+        ax.clabel(cs2)
+        
+        handles = [Line2D([0], [0], color="r", linestyle="--", label=leglab2)]
+        ax.legend(handles=handles, loc="upper left")
 
         plt.xlabel("Distance Along X-Axis, in meters")
         plt.ylabel("Distance Along Y-Axis, in meters")

--- a/scripts/ex-gwt-mt3dms-p04.py
+++ b/scripts/ex-gwt-mt3dms-p04.py
@@ -31,6 +31,7 @@ import git
 import matplotlib.pyplot as plt
 import numpy as np
 from flopy.plot.styles import styles
+from matplotlib.lines import Line2D
 from modflow_devtools.misc import get_env, timed
 
 # Example name and workspace paths. If this example is running
@@ -536,7 +537,7 @@ def plot_results(mt3d, mf6, idx, leglab1, leglab2, ax=None):
             conc_mf6[0, 0, :, :], levels=levels, colors="r", linestyles="--"
         )
         ax.clabel(cs2)
-        
+
         handles = [Line2D([0], [0], color="r", linestyle="--", label=leglab2)]
         ax.legend(handles=handles, loc="upper left")
 

--- a/scripts/ex-gwt-mt3dms-p05.py
+++ b/scripts/ex-gwt-mt3dms-p05.py
@@ -535,23 +535,25 @@ def plot_results(mt3d, mf6, idx, ax=None, ax2=None):
 
         levels = np.arange(0.2, 1, 0.2)
 
-        mm = flopy.plot.PlotMapView(model=mt3d)
+        mm = flopy.plot.PlotMapView(model=mt3d, ax=ax2)
         mm.plot_grid(color=".5", alpha=0.2)
         mm.plot_ibound()
         cs1 = mm.contour_array(conc_mt3d[0], levels=levels, colors="r")
-        plt.clabel(cs1, inline=1, fontsize=10)
+        ax2.clabel(cs1, inline=1, fontsize=10)
         cs2 = mm.contour_array(conc_mf6[0], levels=levels, colors="k", linestyles=":")
-        plt.clabel(cs2, inline=1, fontsize=10)
-        labels = ["MT3DMS", "MODFLOW 6"]
-        lines = [cs1.collections[0], cs2.collections[0]]
-
-        plt.xlabel("Distance Along X-Axis, in meters")
-        plt.ylabel("Distance Along Y-Axis, in meters")
+        ax2.clabel(cs2, inline=1, fontsize=10)
+        
+        handles = [
+            Line2D([0], [0], color="r", linestyle="-", label="MT3DMS"),
+            Line2D([0], [0], color="k", linestyle=":", label="MODFLOW 6"),
+        ]
+        ax2.set_xlabel("Distance Along X-Axis, in meters")
+        ax2.set_ylabel("Distance Along Y-Axis, in meters")
         title = "Comparison of MT3DMS and MF6 isoconcentration lines"
-        ax2.legend(lines, labels, loc="upper left")
+        ax2.legend(handles=handles, loc="upper left")
 
         # draw line representing location of cross-section shown in previous figure
-        plt.plot([155, 300], [155, 155], "k-", lw=2)
+        ax2.plot([155, 300], [155, 155], "k-", lw=2)
 
         # Add labels to the plot
         # style = dict(size=10, color='black')

--- a/scripts/ex-gwt-mt3dms-p05.py
+++ b/scripts/ex-gwt-mt3dms-p05.py
@@ -31,6 +31,7 @@ import git
 import matplotlib.pyplot as plt
 import numpy as np
 from flopy.plot.styles import styles
+from matplotlib.lines import Line2D
 from modflow_devtools.misc import get_env, timed
 
 # Example name and workspace paths. If this example is running
@@ -542,7 +543,7 @@ def plot_results(mt3d, mf6, idx, ax=None, ax2=None):
         ax2.clabel(cs1, inline=1, fontsize=10)
         cs2 = mm.contour_array(conc_mf6[0], levels=levels, colors="k", linestyles=":")
         ax2.clabel(cs2, inline=1, fontsize=10)
-        
+
         handles = [
             Line2D([0], [0], color="r", linestyle="-", label="MT3DMS"),
             Line2D([0], [0], color="k", linestyle=":", label="MODFLOW 6"),

--- a/scripts/ex-gwt-mt3dms-p07.py
+++ b/scripts/ex-gwt-mt3dms-p07.py
@@ -31,6 +31,7 @@ import git
 import matplotlib.pyplot as plt
 import numpy as np
 from flopy.plot.styles import styles
+from matplotlib.lines import Line2D
 from modflow_devtools.misc import get_env, timed
 
 # Example name and workspace paths. If this example is running

--- a/scripts/ex-gwt-mt3dms-p07.py
+++ b/scripts/ex-gwt-mt3dms-p07.py
@@ -522,9 +522,11 @@ def plot_results(mf2k5, mt3d, mf6, idx, ax=None):
         letter = chr(ord("@") + idx + 1)
         styles.heading(letter=letter, heading=title)
 
-        labels = ["MT3DMS", "MODFLOW 6"]
-        lines = [cs1.collections[0], cs2.collections[0]]
-        ax.legend(lines, labels, loc="upper center")
+        handles = [
+            Line2D([0], [0], color="k", linestyle="-", label="MT3DMS"),
+            Line2D([0], [0], color="r", linestyle=":", label="MODFLOW 6"),
+        ]
+        ax.legend(handles=handles, loc="upper center")
 
         if axWasNone:
             ax = fig.add_subplot(3, 1, 2, aspect="equal")

--- a/scripts/ex-gwt-mt3dms-p10.py
+++ b/scripts/ex-gwt-mt3dms-p10.py
@@ -656,10 +656,10 @@ def plot_results(mf2k5, mt3d, mf6, idx, ax=None):
         mm = flopy.plot.PlotMapView(model=mf2k5, ax=ax)
         mm.plot_grid(color=".5", alpha=0.2)
         cs = mm.contour_array(cinit, levels=np.arange(20, 200, 20))
-        ax.xlim(5100, 5100 + 28 * 50)
-        ax.ylim(9100, 9100 + 45 * 50)
-        ax.xlabel("Distance Along X-Axis, in meters")
-        ax.ylabel("Distance Along Y-Axis, in meters")
+        ax.set_xlim(5100, 5100 + 28 * 50)
+        ax.set_ylim(9100, 9100 + 45 * 50)
+        ax.set_xlabel("Distance Along X-Axis, in meters")
+        ax.set_ylabel("Distance Along Y-Axis, in meters")
         ax.clabel(cs, fmt=r"%3d")
         for k, i, j, q in mf2k5.wel.stress_period_data[0]:
             ax.plot(xc[j], yc[i], "ks")
@@ -688,10 +688,10 @@ def plot_results(mf2k5, mt3d, mf6, idx, ax=None):
         ]
         ax.legend(handles=handles, loc="upper left")
 
-        ax.xlim(5100, 5100 + 28 * 50)
-        ax.ylim(9100, 9100 + 45 * 50)
-        ax.xlabel("Distance Along X-Axis, in meters")
-        ax.ylabel("Distance Along Y-Axis, in meters")
+        ax.set_xlim(5100, 5100 + 28 * 50)
+        ax.set_ylim(9100, 9100 + 45 * 50)
+        ax.set_xlabel("Distance Along X-Axis, in meters")
+        ax.set_ylabel("Distance Along Y-Axis, in meters")
 
         for k, i, j, q in mf2k5.wel.stress_period_data[0]:
             ax.plot(xc[j], yc[i], "ks")
@@ -712,10 +712,10 @@ def plot_results(mf2k5, mt3d, mf6, idx, ax=None):
         cs2 = mm.contour_array(
             c_mf6, levels=np.arange(10, 200, 10), colors="red", linestyles="--"
         )
-        ax.xlim(5100, 5100 + 28 * 50)
-        ax.ylim(9100, 9100 + 45 * 50)
-        ax.xlabel("Distance Along X-Axis, in meters")
-        ax.ylabel("Distance Along Y-Axis, in meters")
+        ax.set_xlim(5100, 5100 + 28 * 50)
+        ax.set_ylim(9100, 9100 + 45 * 50)
+        ax.set_xlabel("Distance Along X-Axis, in meters")
+        ax.set_ylabel("Distance Along Y-Axis, in meters")
         for k, i, j, q in mf2k5.wel.stress_period_data[0]:
             ax.plot(xc[j], yc[i], "ks")
 
@@ -735,10 +735,10 @@ def plot_results(mf2k5, mt3d, mf6, idx, ax=None):
         cs2 = mm.contour_array(
             c_mf6, levels=np.arange(10, 200, 10), colors="red", linestyles="--"
         )
-        ax.xlim(5100, 5100 + 28 * 50)
-        ax.ylim(9100, 9100 + 45 * 50)
-        ax.xlabel("Distance Along X-Axis, in meters")
-        ax.ylabel("Distance Along Y-Axis, in meters")
+        ax.set_xlim(5100, 5100 + 28 * 50)
+        ax.set_ylim(9100, 9100 + 45 * 50)
+        ax.set_xlabel("Distance Along X-Axis, in meters")
+        ax.set_ylabel("Distance Along Y-Axis, in meters")
         for k, i, j, q in mf2k5.wel.stress_period_data[0]:
             ax.plot(xc[j], yc[i], "ks")
 

--- a/scripts/ex-gwt-mt3dms-p10.py
+++ b/scripts/ex-gwt-mt3dms-p10.py
@@ -33,6 +33,7 @@ import numpy as np
 import pooch
 from flopy.plot.styles import styles
 from flopy.utils.util_array import read1d
+from matplotlib.lines import Line2D
 from modflow_devtools.misc import get_env, timed
 
 # Example name and workspace paths. If this example is running
@@ -652,16 +653,16 @@ def plot_results(mf2k5, mt3d, mf6, idx, ax=None):
             ax = fig.add_subplot(2, 2, 1, aspect="equal")
             axWasNone = True
 
-        mm = flopy.plot.PlotMapView(model=mf2k5)
+        mm = flopy.plot.PlotMapView(model=mf2k5, ax=ax)
         mm.plot_grid(color=".5", alpha=0.2)
         cs = mm.contour_array(cinit, levels=np.arange(20, 200, 20))
-        plt.xlim(5100, 5100 + 28 * 50)
-        plt.ylim(9100, 9100 + 45 * 50)
-        plt.xlabel("Distance Along X-Axis, in meters")
-        plt.ylabel("Distance Along Y-Axis, in meters")
-        plt.clabel(cs, fmt=r"%3d")
+        ax.xlim(5100, 5100 + 28 * 50)
+        ax.ylim(9100, 9100 + 45 * 50)
+        ax.xlabel("Distance Along X-Axis, in meters")
+        ax.ylabel("Distance Along Y-Axis, in meters")
+        ax.clabel(cs, fmt=r"%3d")
         for k, i, j, q in mf2k5.wel.stress_period_data[0]:
-            plt.plot(xc[j], yc[i], "ks")
+            ax.plot(xc[j], yc[i], "ks")
 
         title = "Layer 3 Initial Concentration"
         letter = chr(ord("@") + idx + 1)
@@ -672,25 +673,28 @@ def plot_results(mf2k5, mt3d, mf6, idx, ax=None):
             ax = fig.add_subplot(2, 2, 2, aspect="equal")
 
         c = conc_mt3d[1, 2]  # Layer 3 @ 500 days (2nd specified output time)
-        mm = flopy.plot.PlotMapView(model=mf2k5)
+        mm = flopy.plot.PlotMapView(model=mf2k5, ax=ax)
         mm.plot_grid(color=".5", alpha=0.2)
         cs1 = mm.contour_array(c, levels=np.arange(10, 200, 10), colors="black")
-        plt.clabel(cs1, fmt=r"%3d")
+        ax.clabel(cs1, fmt=r"%3d")
         c_mf6 = conc_mf6[1, 2]  # Layer 3 @ 500 days
         cs2 = mm.contour_array(
             c_mf6, levels=np.arange(10, 200, 10), colors="red", linestyles="--"
         )
-        labels = ["MT3DMS", "MODFLOW 6"]
-        lines = [cs1.collections[0], cs2.collections[0]]
-        ax.legend(lines, labels, loc="upper left")
 
-        plt.xlim(5100, 5100 + 28 * 50)
-        plt.ylim(9100, 9100 + 45 * 50)
-        plt.xlabel("Distance Along X-Axis, in meters")
-        plt.ylabel("Distance Along Y-Axis, in meters")
+        handles = [
+            Line2D([0], [0], color="black", linestyle="-", label="MT3DMS"),
+            Line2D([0], [0], color="red", linestyle="--", label="MODFLOW 6"),
+        ]
+        ax.legend(handles=handles, loc="upper left")
+
+        ax.xlim(5100, 5100 + 28 * 50)
+        ax.ylim(9100, 9100 + 45 * 50)
+        ax.xlabel("Distance Along X-Axis, in meters")
+        ax.ylabel("Distance Along Y-Axis, in meters")
 
         for k, i, j, q in mf2k5.wel.stress_period_data[0]:
-            plt.plot(xc[j], yc[i], "ks")
+            ax.plot(xc[j], yc[i], "ks")
 
         title = "MT3D Layer 3 Time = 500 days"
         letter = chr(ord("@") + idx + 2)
@@ -700,20 +704,20 @@ def plot_results(mf2k5, mt3d, mf6, idx, ax=None):
         if axWasNone:
             ax = fig.add_subplot(2, 2, 3, aspect="equal")
         c = conc_mt3d[2, 2]
-        mm = flopy.plot.PlotMapView(model=mf2k5)
+        mm = flopy.plot.PlotMapView(model=mf2k5, ax=ax)
         mm.plot_grid(color=".5", alpha=0.2)
         cs1 = mm.contour_array(c, levels=np.arange(10, 200, 10), colors="black")
-        plt.clabel(cs1, fmt=r"%3d")
+        ax.clabel(cs1, fmt=r"%3d")
         c_mf6 = conc_mf6[2, 2]
         cs2 = mm.contour_array(
             c_mf6, levels=np.arange(10, 200, 10), colors="red", linestyles="--"
         )
-        plt.xlim(5100, 5100 + 28 * 50)
-        plt.ylim(9100, 9100 + 45 * 50)
-        plt.xlabel("Distance Along X-Axis, in meters")
-        plt.ylabel("Distance Along Y-Axis, in meters")
+        ax.xlim(5100, 5100 + 28 * 50)
+        ax.ylim(9100, 9100 + 45 * 50)
+        ax.xlabel("Distance Along X-Axis, in meters")
+        ax.ylabel("Distance Along Y-Axis, in meters")
         for k, i, j, q in mf2k5.wel.stress_period_data[0]:
-            plt.plot(xc[j], yc[i], "ks")
+            ax.plot(xc[j], yc[i], "ks")
 
         title = "MT3D Layer 3 Time = 750 days"
         letter = chr(ord("@") + idx + 3)
@@ -726,17 +730,17 @@ def plot_results(mf2k5, mt3d, mf6, idx, ax=None):
         mm = flopy.plot.PlotMapView(model=mf2k5)
         mm.plot_grid(color=".5", alpha=0.2)
         cs1 = mm.contour_array(c, levels=np.arange(10, 200, 10), colors="black")
-        plt.clabel(cs1, fmt=r"%3d")
+        ax.clabel(cs1, fmt=r"%3d")
         c_mf6 = conc_mf6[3, 2]
         cs2 = mm.contour_array(
             c_mf6, levels=np.arange(10, 200, 10), colors="red", linestyles="--"
         )
-        plt.xlim(5100, 5100 + 28 * 50)
-        plt.ylim(9100, 9100 + 45 * 50)
-        plt.xlabel("Distance Along X-Axis, in meters")
-        plt.ylabel("Distance Along Y-Axis, in meters")
+        ax.xlim(5100, 5100 + 28 * 50)
+        ax.ylim(9100, 9100 + 45 * 50)
+        ax.xlabel("Distance Along X-Axis, in meters")
+        ax.ylabel("Distance Along Y-Axis, in meters")
         for k, i, j, q in mf2k5.wel.stress_period_data[0]:
-            plt.plot(xc[j], yc[i], "ks")
+            ax.plot(xc[j], yc[i], "ks")
 
         title = "MT3D Layer 3 Time = 1,000 days"
         letter = chr(ord("@") + idx + 4)

--- a/scripts/ex-gwt-mt3dsupp82.py
+++ b/scripts/ex-gwt-mt3dsupp82.py
@@ -397,13 +397,14 @@ def plot_results(sims, idx):
 
         levels = [0.01, 0.1, 1, 10, 100]
         cs1 = pmv.contour_array(concmt, levels=levels, colors="r")
-
         cs2 = pmv.contour_array(conc, levels=levels, colors="b", linestyles="--")
         ax.clabel(cs2, cs2.levels[::1], fmt="%3.2f", colors="b")
 
-        labels = ["MT3DMS", "MODFLOW 6"]
-        lines = [cs1.collections[0], cs2.collections[0]]
-        ax.legend(lines, labels, loc="lower right")
+        handles = [
+            Line2D([0], [0], color="r", linestyle="-", label="MT3DMS"),
+            Line2D([0], [0], color="b", linestyle="--", label="MODFLOW 6"),
+        ]
+        ax.legend(handles=handles, loc="lower right")
 
         ax.set_xlabel("x position (m)")
         ax.set_ylabel("y position (m)")

--- a/scripts/ex-gwt-mt3dsupp82.py
+++ b/scripts/ex-gwt-mt3dsupp82.py
@@ -23,6 +23,7 @@ import git
 import matplotlib.pyplot as plt
 import numpy as np
 from flopy.plot.styles import styles
+from matplotlib.lines import Line2D
 from modflow_devtools.misc import get_env, timed
 
 # Example name and workspace paths. If this example is running

--- a/scripts/ex-gwt-uzt-2d.py
+++ b/scripts/ex-gwt-uzt-2d.py
@@ -16,6 +16,7 @@ import git
 import matplotlib.pyplot as plt
 import numpy as np
 from flopy.plot.styles import styles
+from matplotlib.lines import Line2D
 from modflow_devtools.misc import get_env, timed
 
 # Example name and workspace paths. If this example is running
@@ -860,18 +861,21 @@ def plot_results(mf2k5, mt3d, mf6, idx, ax=None):
             levels=contourLevels[0:4],
             masked_values=[1.0e30],
         )
-        plt.clabel(cs1, fmt=r"%4.2f")
-        plt.fill(poly_pts[:, 0], poly_pts[:, 1], alpha=0.2)
+        ax.clabel(cs1, fmt=r"%4.2f")
+        ax.fill(poly_pts[:, 0], poly_pts[:, 1], alpha=0.2)
         cs2 = mx.contour_array(
             combined_conc_3d[0],
             levels=contourLevels[0:4],
             colors="red",
             linestyles="--",
         )
-        plt.clabel(cs2, fmt=r"%4.2f")
+        ax.clabel(cs2, fmt=r"%4.2f")
 
-        labels = ["MF-NWT/MT3D-USGS", "MODFLOW 6"]
-        lines = [cs1.collections[0], cs2.collections[0]]
+        handles = [
+            Line2D([0], [0], color="k", linestyle="-", label="MF-NWT/MT3D-USGS"),
+            Line2D([0], [0], color="red", linestyle="--", label="MODFLOW 6"),
+        ]
+
         for x in np.linspace(0.25, 9.75, 11):
             ax.arrow(
                 x,
@@ -914,11 +918,11 @@ def plot_results(mf2k5, mt3d, mf6, idx, ax=None):
             xycoords="axes fraction",
             clip_on=False,
         )
-        ax.legend(lines, labels, loc="upper left")
 
+        ax.legend(handles=handles, loc="upper left")
         title = "Unsaturated/saturated zone concentration X-section, time = 60 days"
         letter = chr(ord("@") + idx + 1)
-        # styles.heading(letter=letter, heading=title)
+
         plt.tight_layout()
 
         if plot_show:


### PR DESCRIPTION
Many of the worked examples included this line: `lines = [cs1.collections[0], cs2.collections[0]]`

However, `QuadContourSet.collections` was deprecated in Matplotlib 3.8 and removed in 3.10.  Contour sets are now single artist objects, not a list of LineCollections per level.  Calling `.collections[0]` either raises an AttributeError, or (on older versions) gives you just one level's line rather than a representative handle for the whole set, which is why the legends were incomplete.